### PR TITLE
refactor(pm): extract DependencySpec into pm/dep_spec.cppm (PR-R1)

### DIFF
--- a/src/manifest.cppm
+++ b/src/manifest.cppm
@@ -4,8 +4,18 @@ export module mcpp.manifest;
 
 import std;
 import mcpp.libs.toml;
+import mcpp.pm.dep_spec;     // M5.x pm/ subsystem refactor: DependencySpec lives here
 
 export namespace mcpp::manifest {
+
+// PR-R1 transitional: the dependency data model has moved into
+// `mcpp.pm.dep_spec`. The aliases below keep `mcpp::manifest::DependencySpec`
+// and `mcpp::manifest::kDefaultNamespace` available as before so existing
+// callers (`cli.cppm`, `fetcher.cppm`, ...) compile unchanged. A later
+// refactor PR will migrate call sites to reference `mcpp::pm::` directly
+// and these aliases can disappear.
+using DependencySpec = mcpp::pm::DependencySpec;
+inline constexpr auto kDefaultNamespace = mcpp::pm::kDefaultNamespace;
 
 struct Package {
     std::string                 name;
@@ -35,29 +45,9 @@ struct Target {
     std::string                 main;           // for binary / test
 };
 
-// One declared dependency. Path-based deps refer to a sibling mcpp package
-// on disk; version-based deps (M2 future) come from a registry.
-struct DependencySpec {
-    // (M5.x) xpkg-style namespace. Defaults to "mcpp" for the root index.
-    // Carried alongside the existing fully-qualified name (which the
-    // dependencies map keys on) so callers that want the structured form
-    // — registry lookup, lockfile entries, error messages — can pull it
-    // out without re-splitting strings.
-    std::string                 namespace_;     // "mcpp" / "mcpplibs" / ...
-    std::string                 shortName;      // package name without namespace prefix
-    std::string                 version;        // "0.0.1" / "^1.2" / "" (req string)
-    std::string                 path;           // filesystem path, or empty
-    std::string                 git;            // "https://..." or empty
-    std::string                 gitRev;         // commit / tag / branch (any one)
-    std::string                 gitRefKind;     // "rev" / "tag" / "branch" (for clarity)
-    bool isPath()    const { return !path.empty(); }
-    bool isGit()     const { return !git.empty(); }
-    bool isVersion() const { return !isPath() && !isGit() && !version.empty(); }
-};
-
-// The default namespace for packages with no explicit namespace declaration.
-// Treated as the mcpp-index "root" — `gtest = "1.15.2"` ⇒ (mcpp, gtest).
-inline constexpr std::string_view kDefaultNamespace = "mcpp";
+// `DependencySpec` and `kDefaultNamespace` have moved to mcpp.pm.dep_spec.
+// Aliases at the top of this file keep `mcpp::manifest::DependencySpec`
+// resolvable for unchanged call sites.
 
 // `[toolchain]` section per docs/21-toolchain-and-tools.md
 //   linux   = "gcc@15.1.0"

--- a/src/pm/dep_spec.cppm
+++ b/src/pm/dep_spec.cppm
@@ -1,0 +1,44 @@
+// mcpp.pm.dep_spec — package-management subsystem: dependency data model.
+//
+// Owns `DependencySpec` and the default-namespace constant. Pure value
+// types — no IO, no parsing here. Parsing currently lives in
+// `mcpp.manifest`; a follow-up PR-R5 will move the `[dependencies]` /
+// `[dev-dependencies]` parsing here, alongside the namespaced subtable
+// + flat + legacy-dotted forms already established in PR-A.
+//
+// See `.agents/docs/2026-05-08-pm-subsystem-architecture.md` for the
+// full pm/ subsystem layout.
+
+export module mcpp.pm.dep_spec;
+
+import std;
+
+export namespace mcpp::pm {
+
+// One declared dependency. Path-based deps refer to a sibling mcpp package
+// on disk; version-based deps come from a registry; git-based deps clone
+// a remote at a fixed ref.
+struct DependencySpec {
+    // xpkg-style namespace. Defaults to `kDefaultNamespace` ("mcpp") for
+    // the root index. Carried alongside the existing fully-qualified name
+    // (which the dependencies map keys on) so callers that want the
+    // structured form — registry lookup, lockfile entries, error
+    // messages — can pull it out without re-splitting strings.
+    std::string                 namespace_;     // "mcpp" / "mcpplibs" / ...
+    std::string                 shortName;      // package name without namespace prefix
+    std::string                 version;        // "0.0.1" / "^1.2" / "" (req string)
+    std::string                 path;           // filesystem path, or empty
+    std::string                 git;            // "https://..." or empty
+    std::string                 gitRev;         // commit / tag / branch (any one)
+    std::string                 gitRefKind;     // "rev" / "tag" / "branch" (for clarity)
+
+    bool isPath()    const { return !path.empty(); }
+    bool isGit()     const { return !git.empty(); }
+    bool isVersion() const { return !isPath() && !isGit() && !version.empty(); }
+};
+
+// Default namespace for packages declared without an explicit one — the
+// mcpp-index "root". Bare `gtest = "1.15.2"` becomes `(mcpp, gtest)`.
+inline constexpr std::string_view kDefaultNamespace = "mcpp";
+
+} // namespace mcpp::pm

--- a/src/pm/index_spec.cppm
+++ b/src/pm/index_spec.cppm
@@ -1,0 +1,19 @@
+// mcpp.pm.index_spec — package-index repository configuration.
+//
+// Reserved for the upcoming `[indices]` parsing & IndexSpec data type;
+// see `.agents/docs/2026-05-08-package-index-config.md` for the full
+// design. The module placeholder is created early so the rest of the
+// pm/ subsystem can land its imports against a stable module path
+// while the implementation arrives.
+
+export module mcpp.pm.index_spec;
+
+import std;
+
+export namespace mcpp::pm {
+
+// Placeholder. The full `IndexSpec` (url / rev / tag / branch / path)
+// + `[indices]` TOML parsing lands in a dedicated PR per the
+// package-index-config design doc.
+
+} // namespace mcpp::pm


### PR DESCRIPTION
## Summary

First of seven refactor PRs described in
[`.agents/docs/2026-05-08-pm-subsystem-architecture.md`](.agents/docs/2026-05-08-pm-subsystem-architecture.md).
**Strictly zero behavior change** — the dependency data model just moves
to its new home.

* New module `mcpp.pm.dep_spec` (`src/pm/dep_spec.cppm`) owns
  `DependencySpec` and the `kDefaultNamespace` constant. Pure value
  types only — no parsing, no IO. `[dependencies]` parsing remains in
  `mcpp.manifest` for now and moves in PR-R5.
* New empty placeholder `mcpp.pm.index_spec` so later PRs can land
  imports against a stable module path while the index-config feature
  arrives.
* `mcpp.manifest` keeps `mcpp::manifest::DependencySpec` and
  `mcpp::manifest::kDefaultNamespace` resolvable via aliases, so every
  call site compiles unchanged. The aliases will be removed in a later
  PR once callers are migrated to `mcpp::pm::` directly.

## Test plan

- [x] `mcpp build` (worktree)
- [x] `mcpp test` — 9/9 unit binaries pass
- [x] e2e subset: 02 / 09 / 12 / 23 / 25 / 26 / 27 all pass
- [ ] Full CI green