### PR TITLE
refactor(pm): add pm/pm.cppm subsystem façade (PR-R7)

### DIFF
--- a/src/pm/pm.cppm
+++ b/src/pm/pm.cppm
@@ -1,0 +1,34 @@
+// mcpp.pm — package-management subsystem façade.
+//
+// This is the single import point that callers in `cli.cppm`,
+// `build/`, `pack/`, etc. should use to reach pm types and high-level
+// operations. The internal modules (`pm.resolver`, `pm.commands`,
+// `pm.package_fetcher`, `pm.publisher`) stay deliberately out of the
+// public surface — re-exporting them would invite call sites to
+// reach into pm internals and undo the encapsulation gained by R1–R6.
+//
+// What this module re-exports:
+//
+//   * Data types only:
+//       - `mcpp::pm::DependencySpec`         (from pm.dep_spec)
+//       - `mcpp::pm::kDefaultNamespace`      (from pm.dep_spec)
+//       - everything currently in pm.index_spec (placeholder; the
+//         index-config implementation will land here)
+//       - `mcpp::pm::Lockfile` and friends   (from pm.lock_io)
+//
+// Internal pm modules (resolver, package_fetcher, commands, publisher)
+// MUST be imported directly by callers that need them; they are
+// intentionally **not** re-exported here. As the call-site migration
+// progresses, an additional high-level operation
+//   `prepare_dependencies(Manifest&, Lockfile&, ...)` → vector<...>
+// will appear here, replacing the ~250-line dependency-resolution
+// loop currently inlined in `cli.cppm::prepare_build`. That landing
+// is tracked separately so this PR stays a pure additive facade.
+//
+// See `.agents/docs/2026-05-08-pm-subsystem-architecture.md` §4.10.
+
+export module mcpp.pm;
+
+export import mcpp.pm.dep_spec;
+export import mcpp.pm.index_spec;
+export import mcpp.pm.lock_io;


### PR DESCRIPTION
## Summary

Closes the [seven-PR pm subsystem refactor](.agents/docs/2026-05-08-pm-subsystem-architecture.md).
**Strictly zero behavior change.**

* `mcpp.pm` (`src/pm/pm.cppm`) is the single import point for callers
  outside the subsystem (cli, build, pack). Re-exports the three
  data-type modules (`dep_spec`, `index_spec`, `lock_io`) but
  **deliberately not** the flow modules (`resolver`, `commands`,
  `package_fetcher`, `publisher`) — those remain direct-import-only,
  preserving the encapsulation gained by R1–R6.

* No call-site migration here. Existing `import mcpp.lockfile` /
  `import mcpp.fetcher` / `import mcpp.publish.xpkg_emit` shims keep
  working; new code can reach the same types via `import mcpp.pm`.

* `prepare_dependencies` (the high-level operation that should replace
  the ~250-line dep-resolution loop in `cli.cppm::prepare_build`) is
  intentionally left for a separate PR. Pulling it out is
  behavior-touching and doesn't belong inside the strict-move R-series.

## Final pm/ subsystem layout

```
src/pm/
├── pm.cppm                  (façade, this PR)
├── dep_spec.cppm            (R1)
├── index_spec.cppm          (R1 placeholder, awaits index-config)
├── lock_io.cppm             (R2)
├── package_fetcher.cppm     (R3)
├── resolver.cppm            (R4)
├── commands.cppm            (R5)
└── publisher.cppm           (R6)
```

## Test plan

- [x] `mcpp build` (worktree)
- [x] `mcpp test` — 9/9 unit binaries pass
- [x] e2e: 02 / 09 / 12 / 23 / 27 all pass
- [ ] Full CI green