### PR TITLE
ci(release): fix actions/checkout fetch-tags conflict on push-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,15 @@ jobs:
       # so we pin to a known path.
       MCPP_HOME: /home/runner/.mcpp
     steps:
-      # fetch-tags so the resolve-tag step can detect existing tags
-      # without an extra round-trip; full history isn't needed.
+      # fetch-depth: 0 instead of fetch-tags: true — actions/checkout@v4
+      # fails on push-tag triggers when both the ref'd tag and
+      # `fetch-tags: true` are set:
+      #   "Cannot fetch both <sha> and refs/tags/vX.Y.Z to refs/tags/vX.Y.Z"
+      # Full-history fetch covers the resolve-tag step's needs without
+      # that contention.
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Resolve target tag + commit
         id: resolve


### PR DESCRIPTION
## Summary

The v0.0.2 push-tag triggered run [25579775799](https://github.com/mcpp-community/mcpp/actions/runs/25579775799) failed at the checkout step:

```
Cannot fetch both ef6dffd0a... and refs/tags/v0.0.2 to refs/tags/v0.0.2
```

Known issue with `actions/checkout@v4` when both the ref'd tag and
`fetch-tags: true` are set on the same checkout — it ends up trying to
fetch the same ref twice. Switching to `fetch-depth: 0` gives the
resolve-tag step the full history it needs without the conflict.

## Test plan

After merge:
- `gh workflow run release.yml -f tag=v0.0.2` to rebuild v0.0.2 with
  the fixed checkout step.
- Verify the release artefacts upload to the v0.0.2 GitHub Release.