### PR TITLE
fix(pm): de-inline resolver functions to satisfy musl-gcc 15.1 link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,15 @@ jobs:
       # so we pin to a known path.
       MCPP_HOME: /home/runner/.mcpp
     steps:
-      # fetch-tags so the resolve-tag step can detect existing tags
-      # without an extra round-trip; full history isn't needed.
+      # fetch-depth: 0 instead of fetch-tags: true — actions/checkout@v4
+      # fails on push-tag triggers when both the ref'd tag and
+      # `fetch-tags: true` are set:
+      #   "Cannot fetch both <sha> and refs/tags/vX.Y.Z to refs/tags/vX.Y.Z"
+      # Full-history fetch covers the resolve-tag step's needs without
+      # that contention.
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Resolve target tag + commit
         id: resolve

--- a/src/pm/resolver.cppm
+++ b/src/pm/resolver.cppm
@@ -5,6 +5,13 @@
 // `.agents/docs/2026-05-08-pm-subsystem-architecture.md`). Strictly
 // pulled out of `cli.cppm` with no behavior change; the same
 // signatures, the same error strings, the same platform key picking.
+//
+// Implementation note: `resolve_semver` is **not** declared inline on
+// purpose. Inlining it across modules makes every importer
+// (cli.cppm, ...) instantiate `std::_Vector_base<vr::Version>`'s
+// destructor locally. With musl-gcc 15.1's libstdc++ that triggers
+// `undefined reference to std::_Vector_base<...>::_Vector_impl::~_Vector_impl()`
+// at link time. Single-definition-point sidesteps the bug.
 
 export module mcpp.pm.resolver;
 
@@ -34,7 +41,22 @@ inline constexpr std::string_view kXpkgPlatform =
 // "constraint" so callers re-resolve via the index — bare `1.2.3` is
 // treated as exact for back-compat with pre-SemVer pinning workflows;
 // users opt into resolution by writing `^1.2.3` etc.
-inline bool is_version_constraint(std::string_view v) {
+bool is_version_constraint(std::string_view v);
+
+// Resolve a SemVer constraint against the index entry's available
+// versions. Returns the chosen exact version string, or an error
+// message. The fetcher is used to read the lua descriptor for the
+// requested package name.
+std::expected<std::string, std::string>
+resolve_semver(std::string_view name,
+               std::string_view constraint,
+               mcpp::pm::Fetcher& fetcher);
+
+} // namespace mcpp::pm
+
+namespace mcpp::pm {
+
+bool is_version_constraint(std::string_view v) {
     if (v.empty()) return true;
     if (v == "*") return true;
     char c = v.front();
@@ -43,11 +65,7 @@ inline bool is_version_constraint(std::string_view v) {
     return false;
 }
 
-// Resolve a SemVer constraint against the index entry's available
-// versions. Returns the chosen exact version string, or an error
-// message. The fetcher is used to read the lua descriptor for the
-// requested package name.
-inline std::expected<std::string, std::string>
+std::expected<std::string, std::string>
 resolve_semver(std::string_view name,
                std::string_view constraint,
                mcpp::pm::Fetcher& fetcher)


### PR DESCRIPTION
## Summary

The release.yml musl-static build of v0.0.2 failed at the link step:

```
obj/cli.m.o: in function `std::_Vector_base<mcpp::version_req::Version>::~_Vector_base()':
  undefined reference to `std::_Vector_base<...>::_Vector_impl::~_Vector_impl()'
```

PR-R4 declared `resolve_semver` and friends `inline` in
`pm/resolver.cppm`. Every importer (currently `cli.cppm`) ends up
locally instantiating the destructor of `std::_Vector_base<vr::Version>`.
With musl-gcc 15.1's libstdc++ that specific instantiation is missing
the matching `_Vector_impl` destructor symbol, and the linker rejects.

Moving the function bodies out of the `export` block — declarations
only there, definitions in a later non-export `mcpp::pm` block within
the same module unit — gives a single definition point, single
instantiation site. The cross-module duplicate disappears and musl-gcc
links cleanly.

ci.yml never caught this because it uses gcc@16.1.0 (glibc); the issue
is specific to musl-gcc 15.1's libstdc++.

## Verification

- [x] `mcpp build` — glibc, 9/9 unit tests pass
- [x] `mcpp build --target x86_64-linux-musl` — musl-gcc 15.1, links clean
- [ ] CI green
- [ ] Re-run release.yml with `tag=v0.0.2` after this lands