### PR TITLE
fix(release): bump hard-coded version strings to 0.0.2

### DIFF
--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -61,7 +61,7 @@ namespace mcpp::cli::detail {
 // canonical printer here so the docs/CHANGELOG examples don't drift
 // every time cmdline tweaks its formatting.
 void print_usage() {
-    std::println("mcpp v0.0.1 — modern C++23 build tool");
+    std::println("mcpp v{} — modern C++23 build tool", mcpp::toolchain::MCPP_VERSION);
     std::println("");
     std::println("Usage:");
     std::println("Project commands:");
@@ -2802,7 +2802,7 @@ int cmd_explain(std::string_view code) {
 // can share `cmd_doctor` / `cmd_env` between top-level and `mcpp self`.
 
 int cmd_self_version(const mcpplibs::cmdline::ParsedArgs& /*parsed*/) {
-    std::println("mcpp 0.0.1");
+    std::println("mcpp {}", mcpp::toolchain::MCPP_VERSION);
     return 0;
 }
 
@@ -2871,7 +2871,7 @@ int run(int argc, char** argv) {
         std::string_view a = argv[1];
         if (a == "--help" || a == "-h") { print_usage(); return 0; }
         if (a == "--version" || a == "-V") {
-            std::println("mcpp 0.0.1");
+            std::println("mcpp {}", mcpp::toolchain::MCPP_VERSION);
             return 0;
         }
     }
@@ -2944,7 +2944,7 @@ int run(int argc, char** argv) {
 
     // ─── Build the top-level App ────────────────────────────────────────
     auto app = cl::App("mcpp")
-        .version("0.0.1")
+        .version(std::string{mcpp::toolchain::MCPP_VERSION})
         .description("modern C++ build tool")
         .option(cl::Option("quiet").short_name('q')
             .help("Suppress status output").global())

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.1";
+inline constexpr std::string_view MCPP_VERSION = "0.0.2";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;


### PR DESCRIPTION
## Summary

The v0.0.2 release.yml run produced a fully-functional musl-static
binary, but the smoke-test step rejected it because `mcpp --version`
still printed `mcpp 0.0.1`. The version literal had been hand-coded in
five places that the `[package].version` bump in `mcpp.toml` didn't
reach.

Bump the canonical constant `mcpp::toolchain::MCPP_VERSION` to `0.0.2`
and route every other `mcpp 0.0.x` print site through it. Future bumps
need a one-line change.

## Test plan

- [x] Local build, `mcpp --version` → `mcpp 0.0.2`
- [x] Local build, `mcpp self version` → `mcpp 0.0.2`
- [ ] CI green
- [ ] Re-tag v0.0.2 to merge commit + push tag → release.yml passes smoke-test