### PR TITLE
release: v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 > 本文件追踪 `mcpp-community/mcpp` 公开仓的版本演进。
 > 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
-## [Unreleased] — 0.0.3
+## [0.0.3] — 2026-05-10
 
 依赖解析体系的三步演进:0.0.2 release tag 之后合入 transitive walker,
 这一版补齐 SemVer 合并(Level 2)+ 多版本 mangling 兜底(Level 1)。

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.2"
+version     = "0.0.3"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.2";
+inline constexpr std::string_view MCPP_VERSION = "0.0.3";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;


### PR DESCRIPTION
## Summary
- `mcpp.toml` + `MCPP_VERSION` constant → `0.0.3`
- CHANGELOG: lock `[Unreleased]` → `[0.0.3] — 2026-05-10`

This release packages the three-tier dependency resolution work:
- #17 — Transitive dependency walker
- #18 — SemVer merge (Level 2)
- #19 — Multi-version mangling (Level 1)

## Test plan
- [x] CI green on the merged commits already
- [ ] CI green on this PR
- [ ] After merge, push `0.0.3` tag → release workflow produces linux-x86_64 binary + install.sh