### PR TITLE
refactor: rename default index from mcpp-index to mcpplibs

### DIFF
--- a/src/bmi_cache.cppm
+++ b/src/bmi_cache.cppm
@@ -28,7 +28,7 @@ export namespace mcpp::bmi_cache {
 struct CacheKey {
     std::filesystem::path mcppHome;
     std::string fingerprint;
-    std::string indexName;       // "mcpp-index" / "xim" / ...
+    std::string indexName;       // "mcpplibs" / "xim" / ...
     std::string packageName;     // "mcpplibs.cmdline"
     std::string version;         // "0.0.1"
 

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -2019,7 +2019,7 @@ prepare_build(bool print_fingerprint,
             mcpp::lockfile::LockedPackage lp;
             lp.name    = name;
             lp.version = spec.version;
-            lp.source  = std::format("mcpp-index+{}",
+            lp.source  = std::format("mcpplibs+{}",
                                      "https://github.com/mcpp-community/mcpp-index.git");
             lp.hash    = "sha256:<from-xlings>";   // M3 will populate from install plan
             lock.packages.push_back(std::move(lp));

--- a/src/config.cppm
+++ b/src/config.cppm
@@ -5,7 +5,7 @@
 //     bin/mcpp                  mcpp binary (self-contained mode)
 //     registry/                 XLINGS_HOME for mcpp's xlings
 //       bin/xlings              vendored xlings binary (= <XLINGS_HOME>/bin/xlings)
-//       .xlings.json            seeded with index_repos = [mcpp-index]
+//       .xlings.json            seeded with index_repos = [mcpplibs]
 //     bmi/<fp>/                 BMI cache (existing)
 //     cache/                    metadata caches
 //     config.toml               this module's input
@@ -47,7 +47,7 @@ struct GlobalConfig {
     std::filesystem::path           xlingsHomeOverride;  // empty = use registryDir
 
     // From config.toml [index]
-    std::string                     defaultIndex;        // "mcpp-index"
+    std::string                     defaultIndex;        // "mcpplibs"
     std::vector<IndexRepo>          indexRepos;
 
     // From config.toml [cache]
@@ -201,9 +201,9 @@ binary = "bundled"
 home   = ""
 
 [index]
-default = "mcpp-index"
+default = "mcpplibs"
 
-[index.repos."mcpp-index"]
+[index.repos."mcpplibs"]
 url = "https://github.com/mcpp-community/mcpp-index.git"
 # xlings auto-adds xim / awesome / scode / d2x as defaults.
 
@@ -597,7 +597,7 @@ std::expected<GlobalConfig, ConfigError> load_or_init(
     cfg.xlingsBinaryMode = doc->get_string("xlings.binary").value_or("bundled");
     if (auto h = doc->get_string("xlings.home"); h && !h->empty())
         cfg.xlingsHomeOverride = *h;
-    cfg.defaultIndex   = doc->get_string("index.default").value_or("mcpp-index");
+    cfg.defaultIndex   = doc->get_string("index.default").value_or("mcpplibs");
     cfg.searchTtlSeconds = doc->get_int("cache.search_ttl_seconds").value_or(3600);
     cfg.defaultJobs    = doc->get_int("build.default_jobs").value_or(0);
     cfg.defaultBackend = doc->get_string("build.default_backend").value_or("ninja");
@@ -613,7 +613,7 @@ std::expected<GlobalConfig, ConfigError> load_or_init(
             cfg.indexRepos.push_back({ name, it->second.as_string() });
         }
     }
-    // Defaults: only mcpp-index. xlings auto-adds its own standard
+    // Defaults: only mcpplibs. xlings auto-adds its own standard
     // defaults (xim / awesome / scode / d2x) because globalIndexRepos_
     // is non-empty (per xlings/src/core/config.cppm). Explicitly listing
     // them ourselves can cause cross-index name conflicts during
@@ -623,7 +623,7 @@ std::expected<GlobalConfig, ConfigError> load_or_init(
         for (auto& r : cfg.indexRepos) if (r.name == name) return;
         cfg.indexRepos.push_back({ std::string(name), std::string(url) });
     };
-    add_default("mcpp-index", "https://github.com/mcpp-community/mcpp-index.git");
+    add_default("mcpplibs", "https://github.com/mcpp-community/mcpp-index.git");
 
     // 5. Seed registry/.xlings.json if missing
     auto xjson = cfg.xlingsHome() / ".xlings.json";

--- a/src/pm/dep_spec.cppm
+++ b/src/pm/dep_spec.cppm
@@ -40,7 +40,7 @@ struct DependencySpec {
 };
 
 // Default namespace for packages declared without an explicit one — the
-// mcpp-index "root". Bare `gtest = "1.15.2"` becomes `(mcpp, gtest)`.
+// mcpplibs "root". Bare `gtest = "1.15.2"` becomes `(mcpp, gtest)`.
 inline constexpr std::string_view kDefaultNamespace = "mcpplibs";
 
 } // namespace mcpp::pm

--- a/src/pm/lock_io.cppm
+++ b/src/pm/lock_io.cppm
@@ -18,7 +18,7 @@ export namespace mcpp::pm {
 struct LockedPackage {
     std::string name;
     std::string version;
-    std::string source;     // e.g. "mcpp-index+https://..." (M2 placeholder)
+    std::string source;     // e.g. "mcpplibs+https://..." (M2 placeholder)
     std::string hash;       // "sha256:..." or "fnv1a:..."
 };
 

--- a/src/pm/package_fetcher.cppm
+++ b/src/pm/package_fetcher.cppm
@@ -92,7 +92,7 @@ public:
     // High-level helpers (parsed payload for common ops).
 
     struct SearchHit {
-        std::string source;       // "mcpp-index"
+        std::string source;       // "mcpplibs"
         std::string name;
         std::string description;
     };
@@ -479,7 +479,7 @@ Fetcher::search(std::string_view keyword) {
                 }
                 // record
                 if (!name.empty()) {
-                    hits.push_back({"mcpp-index", std::move(name), std::move(desc)});
+                    hits.push_back({cfg_.defaultIndex, std::move(name), std::move(desc)});
                 }
                 // advance past ]
                 while (p < items.size() && items[p] != ']') ++p;
@@ -657,7 +657,7 @@ Fetcher::read_xpkg_lua(std::string_view package_name) const
 namespace {
 
 struct ParsedTarget {
-    std::string indexName;       // "xim", "mcpp-index", or "" (default)
+    std::string indexName;       // "xim", "mcpplibs", or "" (default)
     std::string packageName;
     std::string version;
 };
@@ -696,7 +696,7 @@ Fetcher::resolve_xpkg_path(std::string_view target,
                            EventHandler* handler)
 {
     // Default to xim namespace for tools/toolchain. Modular libs use
-    // mcpp-index but consumers (cli) typically pass "<idx>:<name>@<ver>"
+    // mcpplibs but consumers (cli) typically pass "<idx>:<name>@<ver>"
     // explicitly anyway.
     auto parsed = parse_target(target, "xim");
     if (parsed.packageName.empty() || parsed.version.empty()) {
@@ -735,7 +735,7 @@ Fetcher::resolve_xpkg_path(std::string_view target,
         }
         XpkgPayload payload;
         // For xim packages (gcc, cmake, ...) the version dir IS the root.
-        // For mcpp-index packages the version dir contains an extracted
+        // For mcpplibs packages the version dir contains an extracted
         // tarball subdirectory; we treat the wrapper subdir as the root
         // when its content includes bin/ or include/.
         std::error_code ec;

--- a/tests/e2e/10_env_command.sh
+++ b/tests/e2e/10_env_command.sh
@@ -19,9 +19,9 @@ out=$("$MCPP" self env 2>&1)
 [[ -f "$MCPP_HOME/registry/.xlings.json" ]]  || { echo "missing seeded .xlings.json"; exit 1; }
 [[ -x "$MCPP_HOME/registry/bin/xlings" ]] || { echo "xlings binary not acquired"; exit 1; }
 
-# Verify seeded .xlings.json contains mcpp-index and NOT awesome
-grep -q '"name": "mcpp-index"' "$MCPP_HOME/registry/.xlings.json" || {
-    echo "seeded .xlings.json missing mcpp-index"; exit 1; }
+# Verify seeded .xlings.json contains mcpplibs and NOT awesome
+grep -q '"name": "mcpplibs"' "$MCPP_HOME/registry/.xlings.json" || {
+    echo "seeded .xlings.json missing mcpplibs"; exit 1; }
 if grep -q '"name": "awesome"' "$MCPP_HOME/registry/.xlings.json"; then
     echo "seeded .xlings.json should NOT contain awesome"; exit 1
 fi
@@ -29,6 +29,6 @@ fi
 # Output should mention key paths (use grep — [[ pattern match struggles with multi-line + parens)
 echo "$out" | grep -q 'MCPP_HOME'     || { echo "no MCPP_HOME in env output"; exit 1; }
 echo "$out" | grep -q 'xlings binary' || { echo "no xlings binary in env output"; exit 1; }
-echo "$out" | grep -q 'mcpp-index'    || { echo "no mcpp-index in env output"; exit 1; }
+echo "$out" | grep -q 'mcpplibs'    || { echo "no mcpplibs in env output"; exit 1; }
 
 echo "OK"

--- a/tests/e2e/11_index_list.sh
+++ b/tests/e2e/11_index_list.sh
@@ -10,8 +10,8 @@ export MCPP_HOME="$TMP/mcpp-home"
 # init
 "$MCPP" self env > /dev/null
 
-# list should at minimum show mcpp-index (from seeded config)
+# list should at minimum show mcpplibs (from seeded config)
 out=$("$MCPP" index list 2>&1)
-[[ "$out" == *"mcpp-index"* ]] || { echo "index list missing mcpp-index: $out"; exit 1; }
+[[ "$out" == *"mcpplibs"* ]] || { echo "index list missing mcpplibs: $out"; exit 1; }
 
 echo "OK"

--- a/tests/e2e/19_bmi_cache_reuse.sh
+++ b/tests/e2e/19_bmi_cache_reuse.sh
@@ -91,7 +91,7 @@ fp_dir="$(ls "$MCPP_HOME/bmi" | head -1)"
 [[ -n "$fp_dir" ]] || { echo "no fingerprint dir under bmi/"; exit 1; }
 
 # Create a synthetic cache entry as if a previous build produced it.
-fake_pkg_dir="$MCPP_HOME/bmi/$fp_dir/deps/mcpp-index/fake.pkg@9.9.9"
+fake_pkg_dir="$MCPP_HOME/bmi/$fp_dir/deps/mcpplibs/fake.pkg@9.9.9"
 mkdir -p "$fake_pkg_dir/gcm.cache" "$fake_pkg_dir/obj"
 echo SYN > "$fake_pkg_dir/gcm.cache/fake.pkg.gcm"
 echo SYN > "$fake_pkg_dir/obj/fake.m.o"

--- a/tests/e2e/23_remove_update.sh
+++ b/tests/e2e/23_remove_update.sh
@@ -33,7 +33,7 @@ cat > mcpp.lock <<'EOF'
 version = 1
 [package.bar]
 version = "2.0.0"
-source  = "mcpp-index+https://example.com"
+source  = "mcpplibs+https://example.com"
 hash    = "sha256:placeholder"
 EOF
 

--- a/tests/e2e/32_semver_merge.sh
+++ b/tests/e2e/32_semver_merge.sh
@@ -14,10 +14,13 @@ source "$(dirname "$0")/_inherit_toolchain.sh"
 
 # Index is needed since we exercise version-source deps.
 mkdir -p "$MCPP_HOME/registry/data"
-if [[ -d "$HOME/.mcpp/registry/data/mcpp-index" ]]; then
-    ln -sf "$HOME/.mcpp/registry/data/mcpp-index" \
-        "$MCPP_HOME/registry/data/mcpp-index"
-fi
+# Link pre-cached index data (may be under old "mcpp-index" or new "mcpplibs" name)
+for idx_name in mcpplibs mcpp-index; do
+    if [[ -d "$HOME/.mcpp/registry/data/$idx_name" ]]; then
+        ln -sf "$HOME/.mcpp/registry/data/$idx_name" \
+            "$MCPP_HOME/registry/data/$idx_name"
+    fi
+done
 # Pre-cached xpkg downloads so the test doesn't re-fetch the world.
 if [[ -d "$HOME/.mcpp/registry/data/xpkgs" ]]; then
     [[ -e "$MCPP_HOME/registry/data/xpkgs" ]] \

--- a/tests/e2e/33_multi_version_mangling.sh
+++ b/tests/e2e/33_multi_version_mangling.sh
@@ -18,10 +18,13 @@ source "$(dirname "$0")/_inherit_toolchain.sh"
 
 # Index + xpkgs need to be visible since we exercise version-source deps.
 mkdir -p "$MCPP_HOME/registry/data"
-if [[ -d "$HOME/.mcpp/registry/data/mcpp-index" ]]; then
-    ln -sf "$HOME/.mcpp/registry/data/mcpp-index" \
-        "$MCPP_HOME/registry/data/mcpp-index"
-fi
+# Link pre-cached index data (may be under old "mcpp-index" or new "mcpplibs" name)
+for idx_name in mcpplibs mcpp-index; do
+    if [[ -d "$HOME/.mcpp/registry/data/$idx_name" ]]; then
+        ln -sf "$HOME/.mcpp/registry/data/$idx_name" \
+            "$MCPP_HOME/registry/data/$idx_name"
+    fi
+done
 if [[ -d "$HOME/.mcpp/registry/data/xpkgs" ]]; then
     [[ -e "$MCPP_HOME/registry/data/xpkgs" ]] \
         || ln -sf "$HOME/.mcpp/registry/data/xpkgs" \

--- a/tests/unit/test_bmi_cache.cpp
+++ b/tests/unit/test_bmi_cache.cpp
@@ -28,7 +28,7 @@ CacheKey makeKey(const std::filesystem::path& home) {
     return CacheKey{
         .mcppHome    = home,
         .fingerprint = "deadbeef0123abcd",
-        .indexName   = "mcpp-index",
+        .indexName   = "mcpplibs",
         .packageName = "mcpplibs.cmdline",
         .version     = "0.0.1",
     };
@@ -44,7 +44,7 @@ void writeFile(const std::filesystem::path& p, std::string_view body) {
 TEST(BmiCache, KeyDirLayoutMatchesDocs26) {
     auto k = makeKey("/home/u/.mcpp");
     EXPECT_EQ(k.dir().string(),
-              "/home/u/.mcpp/bmi/deadbeef0123abcd/deps/mcpp-index/mcpplibs.cmdline@0.0.1");
+              "/home/u/.mcpp/bmi/deadbeef0123abcd/deps/mcpplibs/mcpplibs.cmdline@0.0.1");
     EXPECT_EQ(k.manifestFile().filename().string(), "manifest.txt");
     EXPECT_EQ(k.gcmDir().filename().string(),       "gcm.cache");
     EXPECT_EQ(k.objDir().filename().string(),       "obj");


### PR DESCRIPTION
## Summary
- Rename default index name from `"mcpp-index"` to `"mcpplibs"` to align with `kDefaultNamespace`
- When `defaultIndex == "mcpplibs"`, the canonical path `<ns>-x-<ns>.<short>` and fallback path `<indexName>-x-<fqname>` naturally unify — no more `mcpp-index-x-mcpplibs.cmdline` vs `mcpplibs-x-mcpplibs.cmdline` mismatch
- Fix hardcoded `"mcpp-index"` in `Fetcher::search()` → now uses `cfg_.defaultIndex`

## Changes
- `src/config.cppm`: default index name, config template, fallback value, add_default
- `src/cli.cppm`: lockfile source field
- `src/pm/package_fetcher.cppm`: search hit source (hardcoded → dynamic), comments
- `src/bmi_cache.cppm`, `src/pm/dep_spec.cppm`, `src/pm/lock_io.cppm`: comment updates

## Note
Part of 0.0.13 — do NOT release yet.