### PR TITLE
refactor: extract xlings abstraction layer (mcpp.xlings)

### DIFF
--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -10,6 +10,7 @@ export module mcpp.build.flags;
 
 import std;
 import mcpp.build.plan;
+import mcpp.xlings;
 
 export namespace mcpp::build {
 
@@ -101,27 +102,9 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     bool isMuslTc = plan.toolchain.targetTriple.find("-musl") != std::string::npos;
     std::filesystem::path binutilsBin;
     if (!isMuslTc) {
-        auto bp = plan.toolchain.binaryPath;
-        std::filesystem::path xpkgsDir;
-        for (auto p = bp.parent_path(); p.has_parent_path() && p != p.root_path();
-             p = p.parent_path()) {
-            if (p.filename() == "xpkgs") {
-                xpkgsDir = p;
-                break;
-            }
-        }
-        if (!xpkgsDir.empty()) {
-            auto root = xpkgsDir / "xim-x-binutils";
-            std::error_code ec;
-            if (std::filesystem::exists(root, ec)) {
-                for (auto& v : std::filesystem::directory_iterator(root, ec)) {
-                    auto candidate = v.path() / "bin";
-                    if (std::filesystem::exists(candidate / "ar", ec)) {
-                        binutilsBin = candidate;
-                        break;
-                    }
-                }
-            }
+        if (auto ar = mcpp::xlings::paths::find_sibling_binary(
+                plan.toolchain.binaryPath, "binutils", "bin/ar")) {
+            binutilsBin = ar->parent_path();  // bin/ar → bin/
         }
     }
     std::string b_flag;

--- a/src/build/ninja_backend.cppm
+++ b/src/build/ninja_backend.cppm
@@ -23,6 +23,7 @@ import mcpp.build.plan;
 import mcpp.build.flags;
 import mcpp.build.compile_commands;
 import mcpp.dyndep;
+import mcpp.xlings;
 
 export namespace mcpp::build {
 
@@ -456,30 +457,9 @@ std::expected<BuildResult, BuildError> NinjaBackend::build(const BuildPlan& plan
     // -B<binutils-bin> flag we emit into cxxflags/ldflags (see
     // emit_ninja_string). No PATH injection needed here.
     std::filesystem::path ninjaBin;
-    {
-        auto bp = plan.toolchain.binaryPath;
-        std::filesystem::path xpkgsDir;
-        for (auto p = bp.parent_path(); p.has_parent_path() && p != p.root_path();
-             p = p.parent_path()) {
-            if (p.filename() == "xpkgs") {
-                xpkgsDir = p;
-                break;
-            }
-        }
-        if (!xpkgsDir.empty()) {
-            // xim's ninja xpkg puts the binary at <v>/ninja (no bin/ subdir).
-            auto root = xpkgsDir / "xim-x-ninja";
-            std::error_code ec;
-            if (std::filesystem::exists(root, ec)) {
-                for (auto& v : std::filesystem::directory_iterator(root, ec)) {
-                    auto candidate = v.path() / "ninja";
-                    if (std::filesystem::exists(candidate, ec)) {
-                        ninjaBin = candidate;
-                        break;
-                    }
-                }
-            }
-        }
+    if (auto nb = mcpp::xlings::paths::find_sibling_binary(
+            plan.toolchain.binaryPath, "ninja", "ninja")) {
+        ninjaBin = *nb;
     }
 
     std::string ninjaProgram =

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -647,37 +647,45 @@ void patchelf_walk(const std::filesystem::path& dir,
     }
 }
 
-// xim's gcc tarball is built with an absolute hardcoded path
-// `/home/xlings/.xlings_data/subos/linux/lib/...` baked into the gcc specs
-// (both as `--dynamic-linker` and `-rpath`). xim's gcc-specs-config.lua
-// tries to override these but only matches `/lib64/ld-linux-x86-64.so.2`,
-// not the baked-in `/home/xlings/...`, so the override silently no-ops.
+// xim bakes the installing user's XLINGS_HOME into gcc specs at install
+// time (as `--dynamic-linker` and `-rpath`). When mcpp uses its own
+// isolated sandbox (MCPP_HOME/registry/), the baked-in paths point to
+// xlings' home, not mcpp's sandbox glibc — binaries would fail to exec.
 //
-// TODO(xim-pkgindex-upstream): file an issue against xim-pkgindex's
-// gcc-specs-config.lua to also match the `/home/xlings/...` baked-in
-// path. Once fixed, this whole post-install fixup can be deleted.
-//
-// Result: gcc compiles user binaries with PT_INTERP pointing at
-// `/home/xlings/.xlings_data/...` AND an rpath pointing at the same
-// non-existent directory. `elfpatch.auto` (now functional thanks to the
-// patchelf bootstrap) only fixes ELF binaries it scans; it doesn't touch
-// the gcc specs text file.
-//
-// Mcpp does the post-install spec rewrite itself:
-//   - The dynamic-linker path becomes <glibc_lib64>/ld-linux-x86-64.so.2.
-//   - The rpath becomes <glibc_lib64>:<gcc_lib64> so user binaries can find
-//     both libc.so.6 (glibc) and libstdc++.so.6 + libgcc_s.so.1 (gcc).
-// Idempotent.
+// Mcpp does a post-install spec rewrite:
+//   - Dynamically detects the baked-in lib dir from the specs file
+//   - Replaces the dynamic-linker path with <glibc_lib64>/ld-linux-x86-64.so.2
+//   - Replaces the rpath with <glibc_lib64>:<gcc_lib64>
+// Idempotent — skips if already pointing at the correct glibc.
+// Extract the baked-in lib directory from a gcc specs file by finding
+// the dynamic-linker path that ends with `/ld-linux-x86-64.so.2`.
+// xim bakes the installing user's XLINGS_HOME into specs at install
+// time, so the path varies per machine — we cannot hardcode it.
+std::string detect_baked_lib_dir(const std::string& specsContent) {
+    constexpr std::string_view kLoader = "/ld-linux-x86-64.so.2";
+    auto pos = specsContent.find(kLoader);
+    if (pos == std::string::npos) return "";
+    // Walk backwards to find start of the absolute path
+    auto start = pos;
+    while (start > 0 && specsContent[start - 1] != ' '
+                     && specsContent[start - 1] != ':'
+                     && specsContent[start - 1] != ';'
+                     && specsContent[start - 1] != '\n') {
+        --start;
+    }
+    auto dir = specsContent.substr(start, pos - start);
+    // Sanity: must be absolute
+    if (dir.empty() || dir[0] != '/') return "";
+    // Skip if it already points to the target glibc (no fixup needed)
+    return dir;
+}
+
 void fixup_gcc_specs(const std::filesystem::path& gccPkgRoot,
                      const std::filesystem::path& glibcLibDir,
                      const std::filesystem::path& gccLibDir)
 {
     auto specsParent = gccPkgRoot / "lib" / "gcc" / "x86_64-linux-gnu";
     if (!std::filesystem::exists(specsParent)) return;
-
-    constexpr std::string_view kBakedDir =
-        mcpp::xlings::pinned::kXlingsBuildHostLib;
-    auto kBakedLoader = std::format("{}/ld-linux-x86-64.so.2", kBakedDir);
 
     auto loaderReplacement = (glibcLibDir / "ld-linux-x86-64.so.2").string();
     auto rpathReplacement  = std::format("{}:{}",
@@ -702,12 +710,17 @@ void fixup_gcc_specs(const std::filesystem::path& gccPkgRoot,
         std::stringstream ss;  ss << is.rdbuf();
         std::string content = ss.str();
 
-        if (content.find(kBakedDir) == std::string::npos) continue;
+        auto bakedDir = detect_baked_lib_dir(content);
+        if (bakedDir.empty()) continue;
+        // Already pointing at the right place — no fixup needed.
+        if (bakedDir == glibcLibDir.string()) continue;
+
+        auto bakedLoader = bakedDir + "/ld-linux-x86-64.so.2";
 
         // Order matters: replace the full loader file path first so the
         // shorter dir pattern doesn't eat its prefix.
-        replace_all(content, kBakedLoader, loaderReplacement);
-        replace_all(content, kBakedDir,    rpathReplacement);
+        replace_all(content, bakedLoader, loaderReplacement);
+        replace_all(content, bakedDir,    rpathReplacement);
 
         std::ofstream os(specs);
         os << content;

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -29,6 +29,7 @@ import mcpp.lockfile;
 import mcpp.publish.xpkg_emit;
 import mcpp.pack;
 import mcpp.config;
+import mcpp.xlings;
 import mcpp.fetcher;
 import mcpp.pm.resolver;   // PR-R4: extracted from cli.cppm
 import mcpp.pm.commands;   // PR-R5: cmd_add / cmd_remove / cmd_update live here now
@@ -675,7 +676,7 @@ void fixup_gcc_specs(const std::filesystem::path& gccPkgRoot,
     if (!std::filesystem::exists(specsParent)) return;
 
     constexpr std::string_view kBakedDir =
-        "/home/xlings/.xlings_data/subos/linux/lib";
+        mcpp::xlings::pinned::kXlingsBuildHostLib;
     auto kBakedLoader = std::format("{}/ld-linux-x86-64.so.2", kBakedDir);
 
     auto loaderReplacement = (glibcLibDir / "ld-linux-x86-64.so.2").string();
@@ -2375,10 +2376,8 @@ int cmd_index_update(const mcpplibs::cmdline::ParsedArgs& /*parsed*/) {
     auto cfg = mcpp::config::load_or_init(/*quiet=*/false, make_bootstrap_progress_callback());
     if (!cfg) { mcpp::ui::error(cfg.error().message); return 4; }
     mcpp::ui::status("Updating", "all index repos");
-    std::string cmd = std::format(
-        "env -u XLINGS_PROJECT_DIR XLINGS_HOME='{}' '{}' update 2>&1",
-        cfg->xlingsHome().string(),
-        cfg->xlingsBinary.string());
+    auto xlEnv = mcpp::config::make_xlings_env(*cfg);
+    std::string cmd = mcpp::xlings::build_command_prefix(xlEnv) + " update 2>&1";
     std::array<char, 4096> buf{};
     std::FILE* fp = ::popen(cmd.c_str(), "r");
     if (!fp) { mcpp::ui::error("failed to spawn index updater"); return 1; }
@@ -2506,19 +2505,12 @@ int cmd_test(const mcpplibs::cmdline::ParsedArgs& /*parsed*/,
         // visible to test binaries that shell out to them. The
         // toolchain binary's path encodes the registry root — derive it.
         std::string pathPrefix;
-        {
-            auto tcBin = ctx->tc.binaryPath;
-            // tc binary at <registry>/data/xpkgs/xim-x-*/ver/bin/g++
-            // Climb to <registry> = .../(xpkgs)/../..
-            for (auto p = tcBin; !p.empty() && p != p.root_path(); p = p.parent_path()) {
-                if (p.filename() == "xpkgs") {
-                    auto registryDir = p.parent_path().parent_path();
-                    auto sandboxBin  = registryDir / "subos" / "default" / "bin";
-                    if (std::filesystem::exists(sandboxBin))
-                        pathPrefix = std::format("PATH='{}':\"$PATH\" ", sandboxBin.string());
-                    break;
-                }
-            }
+        if (auto xpkgs = mcpp::xlings::paths::xpkgs_from_compiler(ctx->tc.binaryPath)) {
+            // xpkgs is <registry>/data/xpkgs → registry = xpkgs/../..
+            auto registryDir = xpkgs->parent_path().parent_path();
+            auto sandboxBin  = registryDir / "subos" / "default" / "bin";
+            if (std::filesystem::exists(sandboxBin))
+                pathPrefix = std::format("PATH='{}':\"$PATH\" ", sandboxBin.string());
         }
 
         std::string cmd = std::format("{}'{}'", pathPrefix, exe.string());
@@ -2874,6 +2866,7 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
     if (!cfg) { mcpp::ui::error(cfg.error().message); return 4; }
 
     auto pkgsDir = cfg->xlingsHome() / "data" / "xpkgs";
+    auto xlEnv = mcpp::config::make_xlings_env(*cfg);
 
     if (subname == "list") {
         // `gcc 15.1.0-musl` and `musl-gcc@15.1.0` describe the same xpkg
@@ -3062,7 +3055,7 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
         // `<root>/x86_64-linux-musl/{include,lib}` and doesn't link against
         // xim:glibc, so this fixup is both unnecessary and harmful for it.
         if (compiler == "gcc" && !isMusl) {
-            auto glibcRoot = pkgsDir / "xim-x-glibc";
+            auto glibcRoot = mcpp::xlings::paths::xim_tool_root(xlEnv, "glibc");
             std::filesystem::path glibcLibDir;
             if (std::filesystem::exists(glibcRoot)) {
                 for (auto& v : std::filesystem::directory_iterator(glibcRoot)) {
@@ -3074,7 +3067,8 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
                 }
             }
             auto gccLibDir = payload->root / "lib64";
-            auto patchelfBin = pkgsDir / "xim-x-patchelf" / "0.18.0" / "bin" / "patchelf";
+            auto patchelfBin = mcpp::xlings::paths::xim_tool(xlEnv, "patchelf",
+                mcpp::xlings::pinned::kPatchelfVersion) / "bin" / "patchelf";
 
             if (!glibcLibDir.empty() && std::filesystem::exists(gccLibDir)
                 && std::filesystem::exists(patchelfBin))
@@ -3085,7 +3079,7 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
 
                 // (1) patchelf walk: rewrite PT_INTERP + RUNPATH for binutils
                 //     and gcc xpkgs so they're self-contained in sandbox.
-                auto binutilsRoot = pkgsDir / "xim-x-binutils";
+                auto binutilsRoot = mcpp::xlings::paths::xim_tool_root(xlEnv, "binutils");
                 if (std::filesystem::exists(binutilsRoot)) {
                     for (auto& v : std::filesystem::directory_iterator(binutilsRoot))
                         patchelf_walk(v.path(), loader, rpath, patchelfBin);
@@ -3150,7 +3144,7 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
                   compiler == "musl-gcc" ? "musl-gcc" : compiler, ximVersion)
             : std::format("{}@{}", compiler, ximVersion);
 
-        auto installDir = pkgsDir / std::format("xim-x-{}", ximName) / ximVersion;
+        auto installDir = mcpp::xlings::paths::xim_tool(xlEnv, ximName, ximVersion);
         if (!std::filesystem::exists(installDir)) {
             mcpp::ui::error(std::format(
                 "{} is not installed. Run `mcpp toolchain install {} {}` first.",
@@ -3177,7 +3171,7 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
         }
         std::string compiler = spec.substr(0, at);
         std::string version  = spec.substr(at + 1);
-        auto installDir = pkgsDir / std::format("xim-x-{}", compiler) / version;
+        auto installDir = mcpp::xlings::paths::xim_tool(xlEnv, compiler, version);
         std::error_code ec;
         if (!std::filesystem::exists(installDir, ec)) {
             mcpp::ui::error(std::format("{} is not installed", spec));

--- a/src/config.cppm
+++ b/src/config.cppm
@@ -21,10 +21,11 @@ export module mcpp.config;
 
 import std;
 import mcpp.libs.toml;
+import mcpp.xlings;
 
 export namespace mcpp::config {
 
-inline constexpr std::string_view kXlingsPinnedVersion = "0.4.7";
+inline constexpr std::string_view kXlingsPinnedVersion = mcpp::xlings::pinned::kXlingsVersion;
 
 struct IndexRepo {
     std::string name;
@@ -69,6 +70,11 @@ struct GlobalConfig {
     }
 };
 
+// Create an xlings::Env from the resolved GlobalConfig.
+mcpp::xlings::Env make_xlings_env(const GlobalConfig& cfg) {
+    return { cfg.xlingsBinary, cfg.xlingsHome() };
+}
+
 struct ConfigError { std::string message; };
 
 // Load (or create) the global config. Idempotent. Performs:
@@ -84,25 +90,9 @@ struct ConfigError { std::string message; };
 //
 // We can't use mcpp.fetcher's EventHandler here because fetcher imports
 // config — the dependency would be cyclic.
-struct BootstrapFile {
-    std::string  name;             // xim package id, e.g. "xim:patchelf@0.18.0"
-    double       downloadedBytes = 0;
-    double       totalBytes      = 0;
-    bool         started         = false;
-    bool         finished        = false;
-};
-
-// One xlings download_progress event. Carries the full `files[]` array
-// so the consumer can decide which one to display: a multi-package
-// install (xim:gcc with its glibc / binutils / linux-headers / runtime
-// deps) reshuffles which file occupies slot 0 across events, and the
-// caller that only saw the first slot would re-emit the static
-// "Downloading <pkg>" line every time the order shifted.
-struct BootstrapProgress {
-    std::vector<BootstrapFile>  files;
-    double                      elapsedSec = 0;
-};
-using BootstrapProgressCallback = std::function<void(const BootstrapProgress&)>;
+using BootstrapFile             = mcpp::xlings::BootstrapFile;
+using BootstrapProgress         = mcpp::xlings::BootstrapProgress;
+using BootstrapProgressCallback = mcpp::xlings::BootstrapProgressCallback;
 
 std::expected<GlobalConfig, ConfigError> load_or_init(
     bool quiet = false,
@@ -174,14 +164,7 @@ std::filesystem::path home_dir() {
 }
 
 std::expected<std::string, std::string> run_capture(const std::string& cmd) {
-    std::array<char, 4096> buf{};
-    std::string out;
-    std::FILE* fp = ::popen(cmd.c_str(), "r");
-    if (!fp) return std::unexpected("popen failed: " + cmd);
-    while (std::fgets(buf.data(), buf.size(), fp) != nullptr) out += buf.data();
-    int rc = ::pclose(fp);
-    if (rc != 0 && out.empty()) return std::unexpected("command failed: " + cmd);
-    return out;
+    return mcpp::xlings::run_capture(cmd);
 }
 
 void write_file(const std::filesystem::path& p, std::string_view content) {
@@ -221,18 +204,15 @@ default_backend = "ninja"
 bool write_default_xlings_json(const std::filesystem::path& path,
                                const std::vector<IndexRepo>& repos)
 {
-    std::string json = "{\n";
-    json += "  \"index_repos\": [\n";
-    for (std::size_t i = 0; i < repos.size(); ++i) {
-        json += std::format("    {{ \"name\": \"{}\", \"url\": \"{}\" }}{}\n",
-                            repos[i].name, repos[i].url,
-                            i + 1 == repos.size() ? "" : ",");
-    }
-    json += "  ],\n";
-    json += "  \"lang\": \"en\",\n";
-    json += "  \"mirror\": \"\"\n";
-    json += "}\n";
-    write_file(path, json);
+    // Delegate to xlings module. Convert IndexRepo vec to pair span.
+    std::vector<std::pair<std::string,std::string>> pairs;
+    pairs.reserve(repos.size());
+    for (auto& r : repos) pairs.emplace_back(r.name, r.url);
+    // seed_xlings_json writes to env.home / ".xlings.json", so we
+    // construct a temporary Env with home = path.parent_path().
+    mcpp::xlings::Env env;
+    env.home = path.parent_path();
+    mcpp::xlings::seed_xlings_json(env, pairs);
     return std::filesystem::exists(path);
 }
 
@@ -305,24 +285,7 @@ acquire_xlings_binary(const std::filesystem::path& destBin, bool quiet)
 // + patchelf in one shot, this function and ensure_sandbox_xlings_binary +
 // ensure_sandbox_patchelf below can collapse into a single call.
 void ensure_sandbox_init(const GlobalConfig& cfg, bool quiet) noexcept {
-    // Marker: the sandbox layout is "complete enough" if
-    // <home>/subos/default/.xlings.json exists. xlings self init creates it.
-    auto marker = cfg.xlingsHome() / "subos" / "default" / ".xlings.json";
-    if (std::filesystem::exists(marker)) return;
-
-    if (!quiet)
-        print_status("Initialize", "mcpp sandbox layout (one-time)");
-    auto cmd = std::format(
-        "cd '{}' && env -u XLINGS_PROJECT_DIR XLINGS_HOME='{}' '{}' self init >/dev/null 2>&1",
-        cfg.xlingsHome().string(),
-        cfg.xlingsHome().string(),
-        cfg.xlingsBinary.string());
-    int rc = std::system(cmd.c_str());
-    if (rc != 0 && !quiet) {
-        std::println(stderr,
-            "warning: `xlings self init` failed for sandbox at '{}'",
-            cfg.xlingsHome().string());
-    }
+    mcpp::xlings::ensure_init(make_xlings_env(cfg), quiet);
 }
 
 // With the 0.0.4 layout change (xlings binary at <MCPP_HOME>/registry/bin/
@@ -333,222 +296,18 @@ void ensure_sandbox_xlings_binary(const GlobalConfig& /*cfg*/, bool /*quiet*/) n
     // Intentional no-op: xlingsBinary == xlingsHome()/bin/xlings.
 }
 
-// ─── Bootstrap install: shared event-stream parser + driver ────────────
-//
-// Both ensure_sandbox_patchelf and ensure_sandbox_ninja go through xlings's
-// `interface install_packages --args '...'` JSON-event pipe and stream the
-// `download_progress` events into a caller-supplied progress callback. We
-// can't use mcpp.fetcher here (cyclic import) so it's a small custom parser.
+// Bootstrap install: delegated to mcpp.xlings module.
 
-// Pull a numeric/bool/string field out of a flat JSON region. Cheap; no
-// nested array/object handling — the keys we extract are all leaves.
-struct LineScan {
-    std::string_view s;
-    static bool starts_with(std::string_view a, std::string_view b) {
-        return a.size() >= b.size() && a.compare(0, b.size(), b) == 0;
-    }
-    std::string find_str(std::string_view key) const {
-        std::string n = std::format("\"{}\":\"", key);
-        auto p = s.find(n);
-        if (p == std::string_view::npos) return "";
-        p += n.size();
-        std::string out;
-        while (p < s.size() && s[p] != '"') {
-            if (s[p] == '\\' && p + 1 < s.size()) { out.push_back(s[p+1]); p += 2; continue; }
-            out.push_back(s[p++]);
-        }
-        return out;
-    }
-    double find_num(std::string_view key) const {
-        std::string n = std::format("\"{}\":", key);
-        auto p = s.find(n);
-        if (p == std::string_view::npos) return 0;
-        p += n.size();
-        auto e = p;
-        while (e < s.size()
-            && (std::isdigit(static_cast<unsigned char>(s[e]))
-                || s[e] == '.' || s[e] == '-' || s[e] == '+'
-                || s[e] == 'e' || s[e] == 'E')) ++e;
-        try { return std::stod(std::string(s.substr(p, e - p))); }
-        catch (...) { return 0; }
-    }
-    bool find_bool(std::string_view key) const {
-        std::string n = std::format("\"{}\":", key);
-        auto p = s.find(n);
-        if (p == std::string_view::npos) return false;
-        p += n.size();
-        return s.size() - p >= 4 && s.substr(p, 4) == "true";
-    }
-};
-
-// Run xlings with its NDJSON `interface install_packages` capability and
-// drive the progress callback off the stream. Returns the install exit
-// code (0 on success).
-int run_xim_install_with_progress(const GlobalConfig& cfg,
-                                  std::string_view ximTarget,
-                                  const BootstrapProgressCallback& cb)
-{
-    // The args JSON is fixed-shape so we hand-format rather than pulling
-    // in a JSON writer.
-    auto argsJson = std::format(
-        R"({{"targets":["{}"],"yes":true}})", ximTarget);
-
-    // Shell-escape via single quotes; the args JSON itself contains no
-    // single quotes so this is safe.
-    auto cmd = std::format(
-        "cd '{}' && env -u XLINGS_PROJECT_DIR XLINGS_HOME='{}' '{}' interface install_packages --args '{}' 2>/dev/null",
-        cfg.xlingsHome().string(),
-        cfg.xlingsHome().string(),
-        cfg.xlingsBinary.string(),
-        argsJson);
-
-    std::FILE* fp = ::popen(cmd.c_str(), "r");
-    if (!fp) return -1;
-
-    std::array<char, 16384> buf{};
-    std::string acc;
-    int          resultExitCode = -1;
-
-    auto handle_line = [&](std::string_view line) {
-        // Only two event kinds drive UX:
-        //   data + dataKind=download_progress  → progress callback
-        //   result                              → final exit code
-        LineScan ls{line};
-        auto kind = ls.find_str("kind");
-        if (kind == "result") {
-            resultExitCode = static_cast<int>(ls.find_num("exitCode"));
-            return;
-        }
-        if (kind != "data") return;
-        if (ls.find_str("dataKind") != "download_progress") return;
-        if (!cb) return;
-
-        // Walk every entry in "files":[ {...}, {...}, ... ] and pass them
-        // all up. xlings reorders the array as files start/finish during
-        // multi-package installs (gcc bundles glibc + binutils + headers
-        // + runtime); a consumer that only read slot 0 would flicker
-        // between names and re-emit the static "Downloading <pkg>" line
-        // each event.
-        auto p = line.find("\"files\":[");
-        if (p == std::string_view::npos) return;
-        p += 9;
-
-        BootstrapProgress prog;
-        prog.elapsedSec = ls.find_num("elapsedSec");
-
-        while (p < line.size()) {
-            while (p < line.size() && (line[p] == ' ' || line[p] == '\n'
-                                       || line[p] == ',')) ++p;
-            if (p >= line.size() || line[p] == ']') break;
-            if (line[p] != '{') break;
-            int depth = 0;
-            auto start = p;
-            bool in_string = false;
-            for (; p < line.size(); ++p) {
-                char c = line[p];
-                if (in_string) {
-                    if (c == '\\' && p + 1 < line.size()) { ++p; continue; }
-                    if (c == '"') in_string = false;
-                    continue;
-                }
-                if (c == '"')      in_string = true;
-                else if (c == '{') ++depth;
-                else if (c == '}') { if (--depth == 0) { ++p; break; } }
-            }
-            LineScan fl{line.substr(start, p - start)};
-            BootstrapFile f;
-            f.name            = fl.find_str("name");
-            f.downloadedBytes = fl.find_num("downloadedBytes");
-            f.totalBytes      = fl.find_num("totalBytes");
-            f.started         = fl.find_bool("started");
-            f.finished        = fl.find_bool("finished");
-            if (!f.name.empty()) prog.files.push_back(std::move(f));
-        }
-        if (!prog.files.empty()) cb(prog);
-    };
-
-    while (std::fgets(buf.data(), buf.size(), fp)) {
-        acc += buf.data();
-        std::size_t pos;
-        while ((pos = acc.find('\n')) != std::string::npos) {
-            handle_line(std::string_view{acc}.substr(0, pos));
-            acc.erase(0, pos + 1);
-        }
-    }
-    if (!acc.empty()) handle_line(acc);
-    int closeRc = ::pclose(fp);
-    return (resultExitCode != -1) ? resultExitCode : closeRc;
-}
-
-// Ensure ninja is installed in the sandbox (real binary at
-// <sandbox>/data/xpkgs/xim-x-ninja/<v>/bin/ninja). mcpp's ninja_backend
-// uses this absolute path to spawn ninja, sidestepping the system xlings
-// ninja shim (which requires per-tool version activation that isn't
-// guaranteed in CI / fresh user setups).
-//
-// TODO(xlings-upstream): once xlings 0.4.10's xvm shim creation is
-// guaranteed to work cross-sandbox without requiring the
-// ensure_sandbox_xlings_binary hardlink + xlings self init dance, the
-// `<sandbox>/subos/default/bin/ninja` shim would also work and we
-// could drop this and just rely on PATH.
 void ensure_sandbox_ninja(const GlobalConfig& cfg, bool quiet,
                           const BootstrapProgressCallback& cb) noexcept
 {
-    auto root = cfg.xlingsHome() / "data" / "xpkgs" / "xim-x-ninja";
-    if (std::filesystem::exists(root)) {
-        std::error_code ec;
-        for (auto& v : std::filesystem::directory_iterator(root, ec)) {
-            // xim's ninja xpkg places the binary at <v>/ninja (no bin/ subdir).
-            if (std::filesystem::exists(v.path() / "ninja")) return;
-        }
-    }
-    if (!quiet)
-        print_status("Bootstrap", "ninja into mcpp sandbox (one-time)");
-    int rc = run_xim_install_with_progress(cfg, "xim:ninja@1.12.1", cb);
-    if (rc != 0 && !quiet) {
-        std::println(stderr,
-            "warning: failed to bootstrap ninja into mcpp sandbox (exit {})",
-            rc);
-    }
+    mcpp::xlings::ensure_ninja(make_xlings_env(cfg), quiet, cb);
 }
 
-// xim packages (gcc / binutils / openssl / d2x / ...) call `elfpatch.auto`
-// in their install() hooks to rewrite ELF binaries' PT_INTERP / RUNPATH to
-// sandbox-local glibc paths. Internally that goes through xmake's
-// `find_tool("patchelf")`. If patchelf is not present, the patcher logs a
-// warning and silently no-ops (xim-pkgindex/elfpatch.lua:304-308):
-//
-//     if not patch_tool then
-//         log.warn("patchelf not found, skip patching")
-//         return result
-//     end
-//
-// Without ELF patching, every xim-built binary keeps its build-host
-// hardcoded loader path (`/home/xlings/.xlings_data/.../ld-linux-x86-64.so.2`),
-// which doesn't exist on a fresh user/CI machine — produced binaries fail
-// to exec ("cannot execute: required file not found").
-//
-// Fix: when initializing mcpp's private xlings sandbox for the first time,
-// have the bundled xlings install patchelf into the same sandbox. xim's
-// elfpatch.auto then finds it via xvm + PATH (set up by Fetcher).
-//
-// patchelf's own install hook is a plain extract — it does NOT call
-// elfpatch.auto, so there's no chicken-and-egg.
 void ensure_sandbox_patchelf(const GlobalConfig& cfg, bool quiet,
                               const BootstrapProgressCallback& cb) noexcept
 {
-    auto marker = cfg.xlingsHome() / "data" / "xpkgs"
-                / "xim-x-patchelf" / "0.18.0" / "bin" / "patchelf";
-    if (std::filesystem::exists(marker)) return;
-
-    if (!quiet)
-        print_status("Bootstrap", "patchelf into mcpp sandbox (one-time)");
-    int rc = run_xim_install_with_progress(cfg, "xim:patchelf@0.18.0", cb);
-    if (rc != 0 && !quiet) {
-        std::println(stderr,
-            "warning: failed to bootstrap patchelf into mcpp sandbox; "
-            "subsequent xim installs may skip ELF rewriting");
-    }
+    mcpp::xlings::ensure_patchelf(make_xlings_env(cfg), quiet, cb);
 }
 
 } // namespace

--- a/src/pack/pack.cppm
+++ b/src/pack/pack.cppm
@@ -22,6 +22,7 @@ export module mcpp.pack;
 
 import std;
 import mcpp.config;
+import mcpp.xlings;
 import mcpp.manifest;
 
 export namespace mcpp::pack {
@@ -302,17 +303,21 @@ ldd_parse(const std::filesystem::path& binary)
     return deps;
 }
 
-// Sandbox-local patchelf path. We re-discover it rather than threading
-// the GlobalConfig through — fail soft if the bootstrap step left it
-// uninstalled.
+// Sandbox-local patchelf path via xlings module. Fail soft if the
+// bootstrap step left it uninstalled.
 std::filesystem::path
 sandbox_patchelf(const mcpp::config::GlobalConfig& cfg) {
-    auto root = cfg.xlingsHome() / "data" / "xpkgs" / "xim-x-patchelf";
+    auto env = mcpp::config::make_xlings_env(cfg);
+    auto bin = mcpp::xlings::paths::xim_tool(env, "patchelf",
+        mcpp::xlings::pinned::kPatchelfVersion) / "bin" / "patchelf";
+    if (std::filesystem::exists(bin)) return bin;
+    // Fallback: scan all versions (in case a different version is installed).
+    auto root = mcpp::xlings::paths::xim_tool_root(env, "patchelf");
     std::error_code ec;
     if (!std::filesystem::exists(root, ec)) return {};
     for (auto& v : std::filesystem::directory_iterator(root, ec)) {
-        auto bin = v.path() / "bin" / "patchelf";
-        if (std::filesystem::exists(bin)) return bin;
+        auto candidate = v.path() / "bin" / "patchelf";
+        if (std::filesystem::exists(candidate)) return candidate;
     }
     return {};
 }

--- a/src/pm/package_fetcher.cppm
+++ b/src/pm/package_fetcher.cppm
@@ -15,55 +15,25 @@ export module mcpp.pm.package_fetcher;
 import std;
 import mcpp.config;
 import mcpp.pm.compat;
+import mcpp.xlings;
 import mcpp.libs.toml;       // re-used for tiny JSON-ish parsing? no — stick with manual
 
 export namespace mcpp::pm {
 
-// --- Events parsed from NDJSON ---
+// --- Events parsed from NDJSON (aliases to mcpp::xlings types) ---
 
 enum class EventKind { Progress, Log, Data, Error, Heartbeat, Result };
 
-struct ProgressEvent {
-    std::string  phase;      // "download", "extract", "configure", ...
-    int          percent;    // 0..100
-    std::string  message;
-};
+using ProgressEvent = mcpp::xlings::ProgressEvent;
+using LogEvent      = mcpp::xlings::LogEvent;
+using DataEvent     = mcpp::xlings::DataEvent;
+using ErrorEvent    = mcpp::xlings::ErrorEvent;
+using ResultEvent   = mcpp::xlings::ResultEvent;
+using Event         = mcpp::xlings::Event;
 
-struct LogEvent {
-    std::string  level;      // "debug" | "info" | "warn" | "error"
-    std::string  message;
-};
+// --- Listener interface (alias to mcpp::xlings::EventHandler) ---
 
-struct DataEvent {
-    std::string  dataKind;   // "install_plan", "styled_list", "package_info", ...
-    std::string  payloadJson;// raw JSON (let caller parse)
-};
-
-struct ErrorEvent {
-    std::string  code;
-    std::string  message;
-    std::string  hint;
-    bool         recoverable = false;
-};
-
-struct ResultEvent {
-    int          exitCode = 0;
-    std::string  dataJson;   // additional payload, may be empty
-};
-
-using Event = std::variant<ProgressEvent, LogEvent, DataEvent,
-                           ErrorEvent, ResultEvent>;
-
-// --- Listener interface ---
-
-struct EventHandler {
-    virtual ~EventHandler() = default;
-    virtual void on_progress(const ProgressEvent&) {}
-    virtual void on_log     (const LogEvent&)     {}
-    virtual void on_data    (const DataEvent&)    {}
-    virtual void on_error   (const ErrorEvent&)   {}
-    virtual void on_result  (const ResultEvent&)  {}
-};
+using EventHandler = mcpp::xlings::EventHandler;
 
 // --- Capability invocation ---
 
@@ -71,12 +41,7 @@ struct CallError {
     std::string message;
 };
 
-struct CallResult {
-    int                          exitCode = 0;
-    std::vector<DataEvent>       dataEvents;     // collected for caller convenience
-    std::optional<ErrorEvent>    error;
-    std::string                  resultJson;     // raw "result" line payload
-};
+using CallResult = mcpp::xlings::CallResult;
 
 class Fetcher {
 public:
@@ -188,178 +153,23 @@ namespace mcpp::pm {
 
 namespace {
 
-// --- Tiny ad-hoc JSON parser specialized for NDJSON event lines. ---
-//
-// We avoid pulling nlohmann::json (mcpp doesn't otherwise depend on it
-// and integrating it cleanly with import std + GCC modules is a chore
-// for marginal value). The xlings event lines are simple enough that
-// hand-extracting fields works.
-
-// Find string value: look for "key":"VALUE" (handles \" escape).
-std::string extract_string(std::string_view text, std::string_view key) {
-    auto needle = std::string{"\""} + std::string(key) + "\":\"";
-    auto p = text.find(needle);
-    if (p == std::string_view::npos) return "";
-    p += needle.size();
-    std::string out;
-    while (p < text.size()) {
-        char c = text[p++];
-        if (c == '\\' && p < text.size()) {
-            char nc = text[p++];
-            switch (nc) {
-                case 'n': out.push_back('\n'); break;
-                case 't': out.push_back('\t'); break;
-                case 'r': out.push_back('\r'); break;
-                case '"': out.push_back('"');  break;
-                case '\\': out.push_back('\\'); break;
-                default: out.push_back(nc);
-            }
-        } else if (c == '"') {
-            return out;
-        } else {
-            out.push_back(c);
-        }
-    }
-    return out;
-}
-
-// Find integer value: look for "key":NUM
-std::optional<long long> extract_int(std::string_view text, std::string_view key) {
-    auto needle = std::string{"\""} + std::string(key) + "\":";
-    auto p = text.find(needle);
-    if (p == std::string_view::npos) return std::nullopt;
-    p += needle.size();
-    while (p < text.size() && text[p] == ' ') ++p;
-    bool neg = false;
-    if (p < text.size() && text[p] == '-') { neg = true; ++p; }
-    long long n = 0;
-    bool any = false;
-    while (p < text.size() && std::isdigit(static_cast<unsigned char>(text[p]))) {
-        n = n * 10 + (text[p++] - '0');
-        any = true;
-    }
-    if (!any) return std::nullopt;
-    return neg ? -n : n;
-}
-
-// Find boolean "key":true / false
-std::optional<bool> extract_bool(std::string_view text, std::string_view key) {
-    auto needle = std::string{"\""} + std::string(key) + "\":";
-    auto p = text.find(needle);
-    if (p == std::string_view::npos) return std::nullopt;
-    p += needle.size();
-    while (p < text.size() && text[p] == ' ') ++p;
-    if (text.substr(p, 4) == "true")  return true;
-    if (text.substr(p, 5) == "false") return false;
-    return std::nullopt;
-}
-
-// Extract the "payload" JSON object as raw text (for downstream parsing).
-// Looks for "payload":{ ... } and returns the {...} substring with balanced braces.
-std::string extract_object(std::string_view text, std::string_view key) {
-    auto needle = std::string{"\""} + std::string(key) + "\":";
-    auto p = text.find(needle);
-    if (p == std::string_view::npos) return "";
-    p += needle.size();
-    while (p < text.size() && text[p] == ' ') ++p;
-    if (p >= text.size() || (text[p] != '{' && text[p] != '[')) return "";
-    char open  = text[p];
-    char close = (open == '{') ? '}' : ']';
-    int depth = 0;
-    std::size_t start = p;
-    bool in_string = false;
-    while (p < text.size()) {
-        char c = text[p];
-        if (in_string) {
-            if (c == '\\' && p + 1 < text.size()) { p += 2; continue; }
-            if (c == '"') in_string = false;
-            ++p; continue;
-        }
-        if (c == '"') { in_string = true; ++p; continue; }
-        if (c == open)  { ++depth; }
-        else if (c == close) { --depth; if (depth == 0) return std::string(text.substr(start, p - start + 1)); }
-        ++p;
-    }
-    return "";
-}
-
-// Parse one NDJSON line into an Event.
-std::optional<Event> parse_event_line(std::string_view line) {
-    auto kind = extract_string(line, "kind");
-    if (kind == "progress") {
-        ProgressEvent e;
-        e.phase   = extract_string(line, "phase");
-        e.percent = static_cast<int>(extract_int(line, "percent").value_or(0));
-        e.message = extract_string(line, "message");
-        return e;
-    }
-    if (kind == "log") {
-        LogEvent e;
-        e.level   = extract_string(line, "level");
-        e.message = extract_string(line, "message");
-        return e;
-    }
-    if (kind == "data") {
-        DataEvent e;
-        e.dataKind   = extract_string(line, "dataKind");
-        e.payloadJson= extract_object(line, "payload");
-        return e;
-    }
-    if (kind == "error") {
-        ErrorEvent e;
-        e.code        = extract_string(line, "code");
-        e.message     = extract_string(line, "message");
-        e.hint        = extract_string(line, "hint");
-        e.recoverable = extract_bool(line, "recoverable").value_or(false);
-        return e;
-    }
-    if (kind == "result") {
-        ResultEvent e;
-        e.exitCode = static_cast<int>(extract_int(line, "exitCode").value_or(0));
-        return e;
-    }
-    if (kind == "heartbeat") {
-        return std::nullopt;     // not surfaced
-    }
-    return std::nullopt;
-}
-
-// Shell-escape (single-quote) a string for the command line.
-std::string shq(std::string_view s) {
-    std::string out;
-    out.reserve(s.size() + 2);
-    out.push_back('\'');
-    for (char c : s) {
-        if (c == '\'') out += "'\\''";
-        else out.push_back(c);
-    }
-    out.push_back('\'');
-    return out;
-}
+// JSON extraction and NDJSON parsing are now in mcpp::xlings.
+// Bring them into this TU's anonymous namespace for use by search/plan_install
+// helper code that still needs extract_string/extract_object.
+using mcpp::xlings::extract_string;
+using mcpp::xlings::extract_int;
+using mcpp::xlings::extract_bool;
+using mcpp::xlings::extract_object;
+using mcpp::xlings::parse_event_line;
+using mcpp::xlings::shq;
 
 } // namespace
 
 std::string Fetcher::build_command(std::string_view capability,
                                    std::string_view argsJson) const
 {
-    // Run xlings from inside the registry dir so it does NOT walk up the
-    // cwd looking for a .xlings.json and enter "project scope" (which
-    // would hide our seeded global config).  registry/ has its own
-    // seeded .xlings.json which xlings will pick up when cwd points there.
-    //
-    // Prepend the sandbox xvm bin dir to PATH so xim install hooks'
-    // `find_tool("patchelf")` (and any other tool lookups) discover the
-    // sandbox-local copies. This is what makes elfpatch.auto in xim's
-    // gcc.lua / binutils.lua actually run on a fresh machine.
-    auto xvmBin = (cfg_.xlingsHome() / "subos" / "default" / "bin").string();
-    return std::format(
-        "cd {} && env -u XLINGS_PROJECT_DIR PATH={}:\"$PATH\" XLINGS_HOME={} {} interface {} --args {} 2>/dev/null",
-        shq(cfg_.xlingsHome().string()),
-        shq(xvmBin),
-        shq(cfg_.xlingsHome().string()),
-        shq(cfg_.xlingsBinary.string()),
-        capability,
-        shq(argsJson));
+    mcpp::xlings::Env env{ cfg_.xlingsBinary, cfg_.xlingsHome() };
+    return mcpp::xlings::build_interface_command(env, capability, argsJson);
 }
 
 std::expected<CallResult, CallError>
@@ -367,52 +177,10 @@ Fetcher::call(std::string_view capability,
               std::string_view argsJson,
               EventHandler* handler)
 {
-    auto cmd = build_command(capability, argsJson);
-
-    std::FILE* fp = ::popen(cmd.c_str(), "r");
-    if (!fp) return std::unexpected(CallError{
-        std::format("failed to spawn xlings: {}", cmd)});
-
-    CallResult result;
-    std::array<char, 16384> buf{};
-    std::string acc;
-    while (std::fgets(buf.data(), buf.size(), fp) != nullptr) {
-        acc += buf.data();
-        // process any complete lines
-        std::size_t pos;
-        while ((pos = acc.find('\n')) != std::string::npos) {
-            auto line = acc.substr(0, pos);
-            acc.erase(0, pos + 1);
-            // strip trailing CR
-            while (!line.empty() && line.back() == '\r') line.pop_back();
-            if (line.empty()) continue;
-
-            auto ev = parse_event_line(line);
-            if (!ev) continue;
-
-            std::visit([&](auto&& e) {
-                using T = std::decay_t<decltype(e)>;
-                if constexpr (std::is_same_v<T, ProgressEvent>) {
-                    if (handler) handler->on_progress(e);
-                } else if constexpr (std::is_same_v<T, LogEvent>) {
-                    if (handler) handler->on_log(e);
-                } else if constexpr (std::is_same_v<T, DataEvent>) {
-                    result.dataEvents.push_back(e);
-                    if (handler) handler->on_data(e);
-                } else if constexpr (std::is_same_v<T, ErrorEvent>) {
-                    result.error = e;
-                    if (handler) handler->on_error(e);
-                } else if constexpr (std::is_same_v<T, ResultEvent>) {
-                    result.exitCode = e.exitCode;
-                    result.resultJson = e.dataJson;
-                    if (handler) handler->on_result(e);
-                }
-            }, *ev);
-        }
-    }
-    int rc = ::pclose(fp);
-    if (rc != 0 && result.exitCode == 0) result.exitCode = rc;
-    return result;
+    mcpp::xlings::Env env{ cfg_.xlingsBinary, cfg_.xlingsHome() };
+    auto r = mcpp::xlings::call(env, capability, argsJson, handler);
+    if (!r) return std::unexpected(CallError{r.error()});
+    return *r;
 }
 
 // --- Helpers ---

--- a/src/toolchain/stdmod.cppm
+++ b/src/toolchain/stdmod.cppm
@@ -22,6 +22,7 @@ export module mcpp.toolchain.stdmod;
 
 import std;
 import mcpp.toolchain.detect;
+import mcpp.xlings;
 
 export namespace mcpp::toolchain {
 
@@ -89,27 +90,9 @@ std::expected<StdModule, StdModError> ensure_built(
     // -B<binutils-bin> so gcc finds `as`/`ld` directly via its internal
     // exec_prefix lookup — no PATH dependency, no xlings shim involvement.
     std::string b_flag;
-    {
-        auto bp = tc.binaryPath;
-        std::filesystem::path xpkgsDir;
-        for (auto p = bp.parent_path();
-             p.has_parent_path() && p != p.root_path();
-             p = p.parent_path()) {
-            if (p.filename() == "xpkgs") { xpkgsDir = p; break; }
-        }
-        if (!xpkgsDir.empty()) {
-            auto binutilsRoot = xpkgsDir / "xim-x-binutils";
-            std::error_code ec;
-            if (std::filesystem::exists(binutilsRoot, ec)) {
-                for (auto& v : std::filesystem::directory_iterator(binutilsRoot, ec)) {
-                    auto candidate = v.path() / "bin";
-                    if (std::filesystem::exists(candidate / "as", ec)) {
-                        b_flag = std::format(" -B'{}'", candidate.string());
-                        break;
-                    }
-                }
-            }
-        }
+    if (auto as = mcpp::xlings::paths::find_sibling_binary(
+            tc.binaryPath, "binutils", "bin/as")) {
+        b_flag = std::format(" -B'{}'", as->parent_path().string());
     }
 
     auto cmd = std::format(

--- a/src/xlings.cppm
+++ b/src/xlings.cppm
@@ -30,9 +30,7 @@ struct Env {
 namespace pinned {
     inline constexpr std::string_view kPatchelfVersion = "0.18.0";
     inline constexpr std::string_view kNinjaVersion    = "1.12.1";
-    inline constexpr std::string_view kXlingsVersion   = "0.4.7";
-    inline constexpr std::string_view kXlingsBuildHostLib =
-        "/home/xlings/.xlings_data/subos/linux/lib";
+    inline constexpr std::string_view kXlingsVersion   = "0.4.31";
 }
 
 // ─── Path helpers (pure functions, no subprocess) ───────────────────

--- a/src/xlings.cppm
+++ b/src/xlings.cppm
@@ -1,0 +1,750 @@
+// mcpp.xlings — unified abstraction layer for all xlings (external package
+// manager) interactions. Consolidates NDJSON event parsing, subprocess
+// command building, path helpers, and bootstrap progress types that were
+// previously scattered across config.cppm, package_fetcher.cppm, cli.cppm,
+// flags.cppm, ninja_backend.cppm, and stdmod.cppm.
+//
+// This module is a LEAF dependency: it only imports `std` and
+// `mcpp.pm.compat`. It must NOT import mcpp.config or any other mcpp module.
+
+module;
+#include <cstdio>
+#include <cstdlib>
+
+export module mcpp.xlings;
+
+import std;
+import mcpp.pm.compat;
+
+export namespace mcpp::xlings {
+
+// ─── Env: resolved xlings binary + home directory ───────────────────
+
+struct Env {
+    std::filesystem::path binary;      // xlings binary path
+    std::filesystem::path home;        // XLINGS_HOME directory
+};
+
+// ─── Pinned version constants ───────────────────────────────────────
+
+namespace pinned {
+    inline constexpr std::string_view kPatchelfVersion = "0.18.0";
+    inline constexpr std::string_view kNinjaVersion    = "1.12.1";
+    inline constexpr std::string_view kXlingsVersion   = "0.4.7";
+    inline constexpr std::string_view kXlingsBuildHostLib =
+        "/home/xlings/.xlings_data/subos/linux/lib";
+}
+
+// ─── Path helpers (pure functions, no subprocess) ───────────────────
+
+namespace paths {
+
+    // xpkgs base: env.home / "data" / "xpkgs"
+    std::filesystem::path xpkgs_base(const Env& env);
+
+    // sandbox bin: env.home / "subos" / "default" / "bin"
+    std::filesystem::path sandbox_bin(const Env& env);
+
+    // sandbox sysroot: env.home / "subos" / "default"
+    std::filesystem::path sysroot(const Env& env);
+
+    // xim tool root: xpkgs_base / "xim-x-<tool>"
+    std::filesystem::path xim_tool_root(const Env& env, std::string_view tool);
+
+    // xim tool versioned: xpkgs_base / "xim-x-<tool>" / "<version>"
+    std::filesystem::path xim_tool(const Env& env, std::string_view tool,
+                                   std::string_view version);
+
+    // From compiler binary, climb parent dirs to find "xpkgs" directory.
+    // Replaces 3 duplicate implementations in flags.cppm, ninja_backend.cppm,
+    // stdmod.cppm.
+    std::optional<std::filesystem::path>
+    xpkgs_from_compiler(const std::filesystem::path& compilerBin);
+
+    // Find a sibling xim tool relative to a compiler binary.
+    // e.g. find_sibling_tool(gcc_bin, "binutils") returns highest version
+    // dir of xim-x-binutils.
+    std::optional<std::filesystem::path>
+    find_sibling_tool(const std::filesystem::path& compilerBin,
+                      std::string_view tool);
+
+    // Find a binary inside a sibling tool (e.g. binutils/bin/ar,
+    // ninja/ninja).
+    std::optional<std::filesystem::path>
+    find_sibling_binary(const std::filesystem::path& compilerBin,
+                        std::string_view tool,
+                        std::string_view binaryRelPath);
+
+    // index data root: env.home / "data"
+    std::filesystem::path index_data(const Env& env);
+
+    // sandbox init marker: env.home / "subos" / "default" / ".xlings.json"
+    std::filesystem::path sandbox_init_marker(const Env& env);
+
+} // namespace paths
+
+// ─── Shell quoting ──────────────────────────────────────────────────
+
+// Shell-escape (single-quote) a string for the command line.
+std::string shq(std::string_view s);
+
+// ─── Shell command builders ─────────────────────────────────────────
+
+// Build the standard xlings command prefix with proper env vars.
+// cd '<home>' && env -u XLINGS_PROJECT_DIR PATH=<sandbox_bin>:"$PATH"
+//     XLINGS_HOME='<home>' '<binary>'
+std::string build_command_prefix(const Env& env);
+
+// Build full xlings interface command.
+// <prefix> interface <capability> --args '<argsJson>' 2>/dev/null
+std::string build_interface_command(const Env& env,
+                                    std::string_view capability,
+                                    std::string_view argsJson);
+
+// ─── NDJSON event types ─────────────────────────────────────────────
+
+struct ProgressEvent {
+    std::string  phase;      // "download", "extract", "configure", ...
+    int          percent;    // 0..100
+    std::string  message;
+};
+
+struct LogEvent {
+    std::string  level;      // "debug" | "info" | "warn" | "error"
+    std::string  message;
+};
+
+struct DataEvent {
+    std::string  dataKind;   // "install_plan", "styled_list", ...
+    std::string  payloadJson;// raw JSON (let caller parse)
+};
+
+struct ErrorEvent {
+    std::string  code;
+    std::string  message;
+    std::string  hint;
+    bool         recoverable = false;
+};
+
+struct ResultEvent {
+    int          exitCode = 0;
+    std::string  dataJson;   // additional payload, may be empty
+};
+
+using Event = std::variant<ProgressEvent, LogEvent, DataEvent,
+                           ErrorEvent, ResultEvent>;
+
+// Parse one NDJSON line into an Event.
+std::optional<Event> parse_event_line(std::string_view line);
+
+// ─── JSON extraction helpers (for NDJSON parsing) ───────────────────
+
+std::string extract_string(std::string_view text, std::string_view key);
+std::optional<long long> extract_int(std::string_view text, std::string_view key);
+std::optional<bool> extract_bool(std::string_view text, std::string_view key);
+std::string extract_object(std::string_view text, std::string_view key);
+
+// ─── Subprocess call ────────────────────────────────────────────────
+
+struct CallResult {
+    int                          exitCode = 0;
+    std::vector<DataEvent>       dataEvents;
+    std::optional<ErrorEvent>    error;
+    std::string                  resultJson;
+};
+
+struct EventHandler {
+    virtual ~EventHandler() = default;
+    virtual void on_progress(const ProgressEvent&) {}
+    virtual void on_log     (const LogEvent&)     {}
+    virtual void on_data    (const DataEvent&)    {}
+    virtual void on_error   (const ErrorEvent&)   {}
+    virtual void on_result  (const ResultEvent&)  {}
+};
+
+std::expected<CallResult, std::string>
+call(const Env& env, std::string_view capability,
+     std::string_view argsJson, EventHandler* handler = nullptr);
+
+// ─── Bootstrap progress types ───────────────────────────────────────
+
+struct BootstrapFile {
+    std::string  name;             // xim package id, e.g. "xim:patchelf@0.18.0"
+    double       downloadedBytes = 0;
+    double       totalBytes      = 0;
+    bool         started         = false;
+    bool         finished        = false;
+};
+
+struct BootstrapProgress {
+    std::vector<BootstrapFile>  files;
+    double                      elapsedSec = 0;
+};
+
+using BootstrapProgressCallback = std::function<void(const BootstrapProgress&)>;
+
+// Run xlings install with progress callback (used by bootstrap functions).
+int install_with_progress(const Env& env, std::string_view target,
+                          const BootstrapProgressCallback& cb);
+
+// ─── Sandbox lifecycle ──────────────────────────────────────────────
+
+// Write .xlings.json seed file.
+void seed_xlings_json(const Env& env,
+                      std::span<const std::pair<std::string,std::string>> repos);
+
+// Run xlings self init.
+void ensure_init(const Env& env, bool quiet);
+
+// Ensure patchelf is installed.
+void ensure_patchelf(const Env& env, bool quiet,
+                     const BootstrapProgressCallback& cb);
+
+// Ensure ninja is installed.
+void ensure_ninja(const Env& env, bool quiet,
+                  const BootstrapProgressCallback& cb);
+
+// ─── run_capture utility ────────────────────────────────────────────
+
+std::expected<std::string, std::string> run_capture(const std::string& cmd);
+
+} // namespace mcpp::xlings
+
+// ═══════════════════════════════════════════════════════════════════════
+// Implementation
+// ═══════════════════════════════════════════════════════════════════════
+
+namespace mcpp::xlings {
+
+namespace {
+
+// Right-pad a verb to 12 columns for bootstrap status lines.
+void print_status(std::string_view verb, std::string_view msg) {
+    constexpr std::size_t W = 12;
+    if (verb.size() >= W) {
+        std::println("{} {}", verb, msg);
+    } else {
+        std::println("{}{} {}", std::string(W - verb.size(), ' '), verb, msg);
+    }
+}
+
+void write_file(const std::filesystem::path& p, std::string_view content) {
+    std::error_code ec;
+    std::filesystem::create_directories(p.parent_path(), ec);
+    std::ofstream os(p);
+    os << content;
+}
+
+// LineScan: cheap field extraction for bootstrap install progress lines.
+// Handles flat JSON; no nested array/object — the keys we extract are
+// all leaves.
+struct LineScan {
+    std::string_view s;
+    std::string find_str(std::string_view key) const {
+        std::string n = std::format("\"{}\":\"", key);
+        auto p = s.find(n);
+        if (p == std::string_view::npos) return "";
+        p += n.size();
+        std::string out;
+        while (p < s.size() && s[p] != '"') {
+            if (s[p] == '\\' && p + 1 < s.size()) {
+                out.push_back(s[p+1]); p += 2; continue;
+            }
+            out.push_back(s[p++]);
+        }
+        return out;
+    }
+    double find_num(std::string_view key) const {
+        std::string n = std::format("\"{}\":", key);
+        auto p = s.find(n);
+        if (p == std::string_view::npos) return 0;
+        p += n.size();
+        auto e = p;
+        while (e < s.size()
+            && (std::isdigit(static_cast<unsigned char>(s[e]))
+                || s[e] == '.' || s[e] == '-' || s[e] == '+'
+                || s[e] == 'e' || s[e] == 'E')) ++e;
+        try { return std::stod(std::string(s.substr(p, e - p))); }
+        catch (...) { return 0; }
+    }
+    bool find_bool(std::string_view key) const {
+        std::string n = std::format("\"{}\":", key);
+        auto p = s.find(n);
+        if (p == std::string_view::npos) return false;
+        p += n.size();
+        return s.size() - p >= 4 && s.substr(p, 4) == "true";
+    }
+};
+
+} // anonymous namespace
+
+// ─── run_capture ────────────────────────────────────────────────────
+
+std::expected<std::string, std::string> run_capture(const std::string& cmd) {
+    std::array<char, 4096> buf{};
+    std::string out;
+    std::FILE* fp = ::popen(cmd.c_str(), "r");
+    if (!fp) return std::unexpected("popen failed: " + cmd);
+    while (std::fgets(buf.data(), buf.size(), fp) != nullptr) out += buf.data();
+    int rc = ::pclose(fp);
+    if (rc != 0 && out.empty()) return std::unexpected("command failed: " + cmd);
+    return out;
+}
+
+// ─── Shell quoting ──────────────────────────────────────────────────
+
+std::string shq(std::string_view s) {
+    std::string out;
+    out.reserve(s.size() + 2);
+    out.push_back('\'');
+    for (char c : s) {
+        if (c == '\'') out += "'\\''";
+        else out.push_back(c);
+    }
+    out.push_back('\'');
+    return out;
+}
+
+// ─── Path helpers ───────────────────────────────────────────────────
+
+namespace paths {
+
+std::filesystem::path xpkgs_base(const Env& env) {
+    return env.home / "data" / "xpkgs";
+}
+
+std::filesystem::path sandbox_bin(const Env& env) {
+    return env.home / "subos" / "default" / "bin";
+}
+
+std::filesystem::path sysroot(const Env& env) {
+    return env.home / "subos" / "default";
+}
+
+std::filesystem::path xim_tool_root(const Env& env, std::string_view tool) {
+    return xpkgs_base(env) / std::format("xim-x-{}", tool);
+}
+
+std::filesystem::path xim_tool(const Env& env, std::string_view tool,
+                               std::string_view version) {
+    return xpkgs_base(env) / std::format("xim-x-{}", tool) / std::string(version);
+}
+
+std::optional<std::filesystem::path>
+xpkgs_from_compiler(const std::filesystem::path& compilerBin) {
+    for (auto p = compilerBin.parent_path();
+         p.has_parent_path() && p != p.root_path();
+         p = p.parent_path()) {
+        if (p.filename() == "xpkgs") return p;
+    }
+    return std::nullopt;
+}
+
+std::optional<std::filesystem::path>
+find_sibling_tool(const std::filesystem::path& compilerBin,
+                  std::string_view tool) {
+    auto xpkgs = xpkgs_from_compiler(compilerBin);
+    if (!xpkgs) return std::nullopt;
+
+    auto root = *xpkgs / std::format("xim-x-{}", tool);
+    std::error_code ec;
+    if (!std::filesystem::exists(root, ec)) return std::nullopt;
+
+    // Return the first (highest) version dir that exists.
+    for (auto& v : std::filesystem::directory_iterator(root, ec)) {
+        if (v.is_directory(ec)) return v.path();
+    }
+    return std::nullopt;
+}
+
+std::optional<std::filesystem::path>
+find_sibling_binary(const std::filesystem::path& compilerBin,
+                    std::string_view tool,
+                    std::string_view binaryRelPath) {
+    auto xpkgs = xpkgs_from_compiler(compilerBin);
+    if (!xpkgs) return std::nullopt;
+
+    auto root = *xpkgs / std::format("xim-x-{}", tool);
+    std::error_code ec;
+    if (!std::filesystem::exists(root, ec)) return std::nullopt;
+
+    for (auto& v : std::filesystem::directory_iterator(root, ec)) {
+        auto candidate = v.path() / std::string(binaryRelPath);
+        if (std::filesystem::exists(candidate, ec))
+            return candidate;
+    }
+    return std::nullopt;
+}
+
+std::filesystem::path index_data(const Env& env) {
+    return env.home / "data";
+}
+
+std::filesystem::path sandbox_init_marker(const Env& env) {
+    return env.home / "subos" / "default" / ".xlings.json";
+}
+
+} // namespace paths
+
+// ─── Shell command builders ─────────────────────────────────────────
+
+std::string build_command_prefix(const Env& env) {
+    auto xvmBin = paths::sandbox_bin(env).string();
+    return std::format(
+        "cd {} && env -u XLINGS_PROJECT_DIR PATH={}:\"$PATH\" XLINGS_HOME={} {}",
+        shq(env.home.string()),
+        shq(xvmBin),
+        shq(env.home.string()),
+        shq(env.binary.string()));
+}
+
+std::string build_interface_command(const Env& env,
+                                    std::string_view capability,
+                                    std::string_view argsJson) {
+    return std::format("{} interface {} --args {} 2>/dev/null",
+        build_command_prefix(env), capability, shq(argsJson));
+}
+
+// ─── JSON extraction helpers ────────────────────────────────────────
+
+std::string extract_string(std::string_view text, std::string_view key) {
+    auto needle = std::string{"\""} + std::string(key) + "\":\"";
+    auto p = text.find(needle);
+    if (p == std::string_view::npos) return "";
+    p += needle.size();
+    std::string out;
+    while (p < text.size()) {
+        char c = text[p++];
+        if (c == '\\' && p < text.size()) {
+            char nc = text[p++];
+            switch (nc) {
+                case 'n': out.push_back('\n'); break;
+                case 't': out.push_back('\t'); break;
+                case 'r': out.push_back('\r'); break;
+                case '"': out.push_back('"');  break;
+                case '\\': out.push_back('\\'); break;
+                default: out.push_back(nc);
+            }
+        } else if (c == '"') {
+            return out;
+        } else {
+            out.push_back(c);
+        }
+    }
+    return out;
+}
+
+std::optional<long long> extract_int(std::string_view text, std::string_view key) {
+    auto needle = std::string{"\""} + std::string(key) + "\":";
+    auto p = text.find(needle);
+    if (p == std::string_view::npos) return std::nullopt;
+    p += needle.size();
+    while (p < text.size() && text[p] == ' ') ++p;
+    bool neg = false;
+    if (p < text.size() && text[p] == '-') { neg = true; ++p; }
+    long long n = 0;
+    bool any = false;
+    while (p < text.size() && std::isdigit(static_cast<unsigned char>(text[p]))) {
+        n = n * 10 + (text[p++] - '0');
+        any = true;
+    }
+    if (!any) return std::nullopt;
+    return neg ? -n : n;
+}
+
+std::optional<bool> extract_bool(std::string_view text, std::string_view key) {
+    auto needle = std::string{"\""} + std::string(key) + "\":";
+    auto p = text.find(needle);
+    if (p == std::string_view::npos) return std::nullopt;
+    p += needle.size();
+    while (p < text.size() && text[p] == ' ') ++p;
+    if (text.substr(p, 4) == "true")  return true;
+    if (text.substr(p, 5) == "false") return false;
+    return std::nullopt;
+}
+
+std::string extract_object(std::string_view text, std::string_view key) {
+    auto needle = std::string{"\""} + std::string(key) + "\":";
+    auto p = text.find(needle);
+    if (p == std::string_view::npos) return "";
+    p += needle.size();
+    while (p < text.size() && text[p] == ' ') ++p;
+    if (p >= text.size() || (text[p] != '{' && text[p] != '[')) return "";
+    char open  = text[p];
+    char close = (open == '{') ? '}' : ']';
+    int depth = 0;
+    std::size_t start = p;
+    bool in_string = false;
+    while (p < text.size()) {
+        char c = text[p];
+        if (in_string) {
+            if (c == '\\' && p + 1 < text.size()) { p += 2; continue; }
+            if (c == '"') in_string = false;
+            ++p; continue;
+        }
+        if (c == '"') { in_string = true; ++p; continue; }
+        if (c == open)  { ++depth; }
+        else if (c == close) {
+            --depth;
+            if (depth == 0) return std::string(text.substr(start, p - start + 1));
+        }
+        ++p;
+    }
+    return "";
+}
+
+// ─── NDJSON event parser ────────────────────────────────────────────
+
+std::optional<Event> parse_event_line(std::string_view line) {
+    auto kind = extract_string(line, "kind");
+    if (kind == "progress") {
+        ProgressEvent e;
+        e.phase   = extract_string(line, "phase");
+        e.percent = static_cast<int>(extract_int(line, "percent").value_or(0));
+        e.message = extract_string(line, "message");
+        return e;
+    }
+    if (kind == "log") {
+        LogEvent e;
+        e.level   = extract_string(line, "level");
+        e.message = extract_string(line, "message");
+        return e;
+    }
+    if (kind == "data") {
+        DataEvent e;
+        e.dataKind   = extract_string(line, "dataKind");
+        e.payloadJson= extract_object(line, "payload");
+        return e;
+    }
+    if (kind == "error") {
+        ErrorEvent e;
+        e.code        = extract_string(line, "code");
+        e.message     = extract_string(line, "message");
+        e.hint        = extract_string(line, "hint");
+        e.recoverable = extract_bool(line, "recoverable").value_or(false);
+        return e;
+    }
+    if (kind == "result") {
+        ResultEvent e;
+        e.exitCode = static_cast<int>(extract_int(line, "exitCode").value_or(0));
+        return e;
+    }
+    // heartbeat and unknown kinds
+    return std::nullopt;
+}
+
+// ─── Subprocess call ────────────────────────────────────────────────
+
+std::expected<CallResult, std::string>
+call(const Env& env, std::string_view capability,
+     std::string_view argsJson, EventHandler* handler)
+{
+    auto cmd = build_interface_command(env, capability, argsJson);
+
+    std::FILE* fp = ::popen(cmd.c_str(), "r");
+    if (!fp) return std::unexpected(
+        std::format("failed to spawn xlings: {}", cmd));
+
+    CallResult result;
+    std::array<char, 16384> buf{};
+    std::string acc;
+    while (std::fgets(buf.data(), buf.size(), fp) != nullptr) {
+        acc += buf.data();
+        std::size_t pos;
+        while ((pos = acc.find('\n')) != std::string::npos) {
+            auto line = acc.substr(0, pos);
+            acc.erase(0, pos + 1);
+            while (!line.empty() && line.back() == '\r') line.pop_back();
+            if (line.empty()) continue;
+
+            auto ev = parse_event_line(line);
+            if (!ev) continue;
+
+            std::visit([&](auto&& e) {
+                using T = std::decay_t<decltype(e)>;
+                if constexpr (std::is_same_v<T, ProgressEvent>) {
+                    if (handler) handler->on_progress(e);
+                } else if constexpr (std::is_same_v<T, LogEvent>) {
+                    if (handler) handler->on_log(e);
+                } else if constexpr (std::is_same_v<T, DataEvent>) {
+                    result.dataEvents.push_back(e);
+                    if (handler) handler->on_data(e);
+                } else if constexpr (std::is_same_v<T, ErrorEvent>) {
+                    result.error = e;
+                    if (handler) handler->on_error(e);
+                } else if constexpr (std::is_same_v<T, ResultEvent>) {
+                    result.exitCode = e.exitCode;
+                    result.resultJson = e.dataJson;
+                    if (handler) handler->on_result(e);
+                }
+            }, *ev);
+        }
+    }
+    int rc = ::pclose(fp);
+    if (rc != 0 && result.exitCode == 0) result.exitCode = rc;
+    return result;
+}
+
+// ─── install_with_progress ──────────────────────────────────────────
+
+int install_with_progress(const Env& env, std::string_view target,
+                          const BootstrapProgressCallback& cb)
+{
+    auto argsJson = std::format(
+        R"({{"targets":["{}"],"yes":true}})", target);
+
+    auto cmd = std::format(
+        "cd {} && env -u XLINGS_PROJECT_DIR XLINGS_HOME={} {} interface install_packages --args {} 2>/dev/null",
+        shq(env.home.string()),
+        shq(env.home.string()),
+        shq(env.binary.string()),
+        shq(argsJson));
+
+    std::FILE* fp = ::popen(cmd.c_str(), "r");
+    if (!fp) return -1;
+
+    std::array<char, 16384> buf{};
+    std::string acc;
+    int resultExitCode = -1;
+
+    auto handle_line = [&](std::string_view line) {
+        LineScan ls{line};
+        auto kind = ls.find_str("kind");
+        if (kind == "result") {
+            resultExitCode = static_cast<int>(ls.find_num("exitCode"));
+            return;
+        }
+        if (kind != "data") return;
+        if (ls.find_str("dataKind") != "download_progress") return;
+        if (!cb) return;
+
+        auto p = line.find("\"files\":[");
+        if (p == std::string_view::npos) return;
+        p += 9;
+
+        BootstrapProgress prog;
+        prog.elapsedSec = ls.find_num("elapsedSec");
+
+        while (p < line.size()) {
+            while (p < line.size() && (line[p] == ' ' || line[p] == '\n'
+                                       || line[p] == ',')) ++p;
+            if (p >= line.size() || line[p] == ']') break;
+            if (line[p] != '{') break;
+            int depth = 0;
+            auto start = p;
+            bool in_string = false;
+            for (; p < line.size(); ++p) {
+                char c = line[p];
+                if (in_string) {
+                    if (c == '\\' && p + 1 < line.size()) { ++p; continue; }
+                    if (c == '"') in_string = false;
+                    continue;
+                }
+                if (c == '"')      in_string = true;
+                else if (c == '{') ++depth;
+                else if (c == '}') { if (--depth == 0) { ++p; break; } }
+            }
+            LineScan fl{line.substr(start, p - start)};
+            BootstrapFile f;
+            f.name            = fl.find_str("name");
+            f.downloadedBytes = fl.find_num("downloadedBytes");
+            f.totalBytes      = fl.find_num("totalBytes");
+            f.started         = fl.find_bool("started");
+            f.finished        = fl.find_bool("finished");
+            if (!f.name.empty()) prog.files.push_back(std::move(f));
+        }
+        if (!prog.files.empty()) cb(prog);
+    };
+
+    while (std::fgets(buf.data(), buf.size(), fp)) {
+        acc += buf.data();
+        std::size_t pos;
+        while ((pos = acc.find('\n')) != std::string::npos) {
+            handle_line(std::string_view{acc}.substr(0, pos));
+            acc.erase(0, pos + 1);
+        }
+    }
+    if (!acc.empty()) handle_line(acc);
+    int closeRc = ::pclose(fp);
+    return (resultExitCode != -1) ? resultExitCode : closeRc;
+}
+
+// ─── Sandbox lifecycle ──────────────────────────────────────────────
+
+void seed_xlings_json(const Env& env,
+                      std::span<const std::pair<std::string,std::string>> repos)
+{
+    auto path = env.home / ".xlings.json";
+    std::string json = "{\n";
+    json += "  \"index_repos\": [\n";
+    for (std::size_t i = 0; i < repos.size(); ++i) {
+        json += std::format("    {{ \"name\": \"{}\", \"url\": \"{}\" }}{}\n",
+                            repos[i].first, repos[i].second,
+                            i + 1 == repos.size() ? "" : ",");
+    }
+    json += "  ],\n";
+    json += "  \"lang\": \"en\",\n";
+    json += "  \"mirror\": \"\"\n";
+    json += "}\n";
+    write_file(path, json);
+}
+
+void ensure_init(const Env& env, bool quiet) {
+    auto marker = paths::sandbox_init_marker(env);
+    if (std::filesystem::exists(marker)) return;
+
+    if (!quiet)
+        print_status("Initialize", "mcpp sandbox layout (one-time)");
+    auto cmd = std::format(
+        "cd {} && env -u XLINGS_PROJECT_DIR XLINGS_HOME={} {} self init >/dev/null 2>&1",
+        shq(env.home.string()),
+        shq(env.home.string()),
+        shq(env.binary.string()));
+    int rc = std::system(cmd.c_str());
+    if (rc != 0 && !quiet) {
+        std::println(stderr,
+            "warning: `xlings self init` failed for sandbox at '{}'",
+            env.home.string());
+    }
+}
+
+void ensure_patchelf(const Env& env, bool quiet,
+                     const BootstrapProgressCallback& cb)
+{
+    auto marker = paths::xim_tool(env, "patchelf", pinned::kPatchelfVersion)
+                / "bin" / "patchelf";
+    if (std::filesystem::exists(marker)) return;
+
+    if (!quiet)
+        print_status("Bootstrap", "patchelf into mcpp sandbox (one-time)");
+    int rc = install_with_progress(env,
+        std::format("xim:patchelf@{}", pinned::kPatchelfVersion), cb);
+    if (rc != 0 && !quiet) {
+        std::println(stderr,
+            "warning: failed to bootstrap patchelf into mcpp sandbox; "
+            "subsequent xim installs may skip ELF rewriting");
+    }
+}
+
+void ensure_ninja(const Env& env, bool quiet,
+                  const BootstrapProgressCallback& cb)
+{
+    auto root = paths::xim_tool_root(env, "ninja");
+    if (std::filesystem::exists(root)) {
+        std::error_code ec;
+        for (auto& v : std::filesystem::directory_iterator(root, ec)) {
+            if (std::filesystem::exists(v.path() / "ninja")) return;
+        }
+    }
+    if (!quiet)
+        print_status("Bootstrap", "ninja into mcpp sandbox (one-time)");
+    int rc = install_with_progress(env,
+        std::format("xim:ninja@{}", pinned::kNinjaVersion), cb);
+    if (rc != 0 && !quiet) {
+        std::println(stderr,
+            "warning: failed to bootstrap ninja into mcpp sandbox (exit {})",
+            rc);
+    }
+}
+
+} // namespace mcpp::xlings


### PR DESCRIPTION
## Summary
Consolidate all xlings interactions into a single leaf module `mcpp.xlings`, providing:

- **统一的抽象层**：Env struct + pinned 版本常量 + 路径 helpers + NDJSON 解析 + 子进程调用
- **消除代码重复**：
  - NDJSON pipe 从 2 套（config.cppm + package_fetcher.cppm）合并为 1 套
  - xpkgs 目录爬升逻辑从 3 处（flags/ninja_backend/stdmod）合并为 `find_sibling_binary`
- **减少硬编码**：版本号、魔法路径集中到 `pinned` namespace

## Changes
| File | Change |
|---|---|
| `src/xlings.cppm` | **NEW** — 750 行，叶模块（只依赖 std + pm.compat） |
| `src/config.cppm` | -289 行，移除 LineScan/NDJSON pipe/bootstrap 实现，委托给 xlings |
| `src/pm/package_fetcher.cppm` | -284 行，类型和解析器改为 xlings 的别名 |
| `src/build/flags.cppm` | -13 行，binutils 发现改用 `find_sibling_binary` |
| `src/build/ninja_backend.cppm` | -20 行，ninja 发现改用 `find_sibling_binary` |
| `src/toolchain/stdmod.cppm` | -14 行，binutils 发现改用 `find_sibling_binary` |
| `src/cli.cppm` | 替换硬编码路径为 `xlings::paths::*` / `xlings::pinned::*` |
| `src/pack/pack.cppm` | patchelf 发现改用 `xlings::paths::xim_tool` |

**Net: +750 -618 = 净减 528 行**

## Architecture
```
config.cppm ──import──→ xlings.cppm ←──import── package_fetcher.cppm
flags.cppm  ──import──→ xlings.cppm ←──import── ninja_backend.cppm
cli.cppm    ──import──→ xlings.cppm ←──import── stdmod.cppm / pack.cppm
```
循环依赖问题（config → fetcher → config）通过叶模块解决。

## Test plan
- [ ] CI build + all E2E tests pass