### PR TITLE
fix: implement index auto-refresh (searchTtlSeconds)

### DIFF
--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -1191,6 +1191,22 @@ prepare_build(bool print_fingerprint,
     // and ODR-respecting symbols, so the same `(ns, name)` resolved to
     // two different exact versions is an error — mcpp prints both
     // requesting parents and asks the user to align them.
+
+    // Auto-refresh the package index if the project has version-source
+    // dependencies and the local index is missing or stale.
+    if (!m->dependencies.empty()) {
+        bool hasVersionDeps = false;
+        for (auto& [_, spec] : m->dependencies) {
+            if (!spec.isPath() && !spec.isGit()) { hasVersionDeps = true; break; }
+        }
+        if (hasVersionDeps) {
+            auto cfg2 = get_cfg();
+            if (cfg2) {
+                auto xlEnv = mcpp::config::make_xlings_env(**cfg2);
+                mcpp::xlings::ensure_index_fresh(xlEnv, (*cfg2)->searchTtlSeconds);
+            }
+        }
+    }
     std::vector<mcpp::modgraph::PackageRoot> packages;
     packages.push_back({*root, *m});
 
@@ -2311,7 +2327,8 @@ int cmd_search(const mcpplibs::cmdline::ParsedArgs& parsed) {
     auto cfg = mcpp::config::load_or_init(/*quiet=*/false, make_bootstrap_progress_callback());
     if (!cfg) { mcpp::ui::error(cfg.error().message); return 4; }
 
-    mcpp::ui::info("Updating", std::format("registry index `{}`", cfg->defaultIndex));
+    auto xlEnv = mcpp::config::make_xlings_env(*cfg);
+    mcpp::xlings::ensure_index_fresh(xlEnv, cfg->searchTtlSeconds);
 
     mcpp::fetcher::Fetcher f(*cfg);
     auto hits = f.search(keyword);
@@ -2390,14 +2407,7 @@ int cmd_index_update(const mcpplibs::cmdline::ParsedArgs& /*parsed*/) {
     if (!cfg) { mcpp::ui::error(cfg.error().message); return 4; }
     mcpp::ui::status("Updating", "all index repos");
     auto xlEnv = mcpp::config::make_xlings_env(*cfg);
-    std::string cmd = mcpp::xlings::build_command_prefix(xlEnv) + " update 2>&1";
-    std::array<char, 4096> buf{};
-    std::FILE* fp = ::popen(cmd.c_str(), "r");
-    if (!fp) { mcpp::ui::error("failed to spawn index updater"); return 1; }
-    while (std::fgets(buf.data(), buf.size(), fp)) {
-        std::fputs(buf.data(), stdout);
-    }
-    int rc = ::pclose(fp);
+    int rc = mcpp::xlings::update_index(xlEnv);
     if (rc != 0) { mcpp::ui::error("index update failed"); return 1; }
     mcpp::ui::status("Updated", "index refresh complete");
     return 0;

--- a/src/xlings.cppm
+++ b/src/xlings.cppm
@@ -202,6 +202,21 @@ void ensure_patchelf(const Env& env, bool quiet,
 void ensure_ninja(const Env& env, bool quiet,
                   const BootstrapProgressCallback& cb);
 
+// ─── Index freshness ────────────────────────────────────────────────
+
+// Check whether local index data exists and is fresh (within ttlSeconds).
+// Returns true if index is present and fresh, false otherwise.
+bool is_index_fresh(const Env& env, std::int64_t ttlSeconds);
+
+// Run `xlings update` to refresh all index repos. Streams output to stdout.
+// Returns the xlings exit code.
+int update_index(const Env& env, bool quiet = false);
+
+// Ensure the local index is present and fresh. Runs `xlings update` if
+// the index is missing or older than ttlSeconds. Idempotent and quiet
+// when no update is needed.
+void ensure_index_fresh(const Env& env, std::int64_t ttlSeconds, bool quiet = false);
+
 // ─── run_capture utility ────────────────────────────────────────────
 
 std::expected<std::string, std::string> run_capture(const std::string& cmd);
@@ -743,6 +758,51 @@ void ensure_ninja(const Env& env, bool quiet,
             "warning: failed to bootstrap ninja into mcpp sandbox (exit {})",
             rc);
     }
+}
+
+// ─── Index freshness ────────────────────────────────────────────────
+
+bool is_index_fresh(const Env& env, std::int64_t ttlSeconds) {
+    auto data = paths::index_data(env);
+    if (!std::filesystem::exists(data)) return false;
+
+    // Look for any directory under data/ that has a pkgs/ subdirectory —
+    // that's a cloned index repo.
+    std::error_code ec;
+    bool hasIndex = false;
+    std::filesystem::file_time_type newest{};
+    for (auto& entry : std::filesystem::directory_iterator(data, ec)) {
+        if (!entry.is_directory()) continue;
+        auto pkgsDir = entry.path() / "pkgs";
+        if (!std::filesystem::exists(pkgsDir)) continue;
+        hasIndex = true;
+        auto t = std::filesystem::last_write_time(pkgsDir, ec);
+        if (!ec && t > newest) newest = t;
+    }
+    if (!hasIndex) return false;
+
+    // Check TTL
+    auto now = std::filesystem::file_time_type::clock::now();
+    auto age = std::chrono::duration_cast<std::chrono::seconds>(now - newest);
+    return age.count() < ttlSeconds;
+}
+
+int update_index(const Env& env, bool quiet) {
+    std::string cmd = build_command_prefix(env) + " update 2>&1";
+    std::array<char, 4096> buf{};
+    std::FILE* fp = ::popen(cmd.c_str(), "r");
+    if (!fp) return -1;
+    while (std::fgets(buf.data(), buf.size(), fp)) {
+        if (!quiet) std::fputs(buf.data(), stdout);
+    }
+    return ::pclose(fp);
+}
+
+void ensure_index_fresh(const Env& env, std::int64_t ttlSeconds, bool quiet) {
+    if (is_index_fresh(env, ttlSeconds)) return;
+    if (!quiet)
+        print_status("Updating", "package index (auto-refresh)");
+    update_index(env, quiet);
 }
 
 } // namespace mcpp::xlings


### PR DESCRIPTION
## Summary
三项包索引更新机制改进：

1. **实现 `searchTtlSeconds` 自动刷新** — 新增 `ensure_index_fresh()`，检查本地索引是否存在且在 TTL 内（默认 3600 秒），过期或缺失时自动执行 `xlings update`
2. **`mcpp build` 自动触发索引更新** — 依赖解析前检查是否有 version-source 依赖且索引缺失/过期，防止新装 mcpp 后构建静默失败
3. **修复 `mcpp search` 误导性输出** — 移除无条件的 "Updating registry index" 提示，改为 `ensure_index_fresh()` 按需刷新，仅在实际更新时打印

附带：`cmd_index_update` 改用 `xlings::update_index()` 替代手动 popen。

## Changes
- `src/xlings.cppm`: 新增 `is_index_fresh()`, `update_index()`, `ensure_index_fresh()`
- `src/cli.cppm`: 
  - `cmd_search`: 移除假 "Updating"，加 `ensure_index_fresh`
  - `cmd_index_update`: 改用 `xlings::update_index`
  - `prepare_build`: 依赖解析前对 version-source deps 触发 `ensure_index_fresh`

## Test plan
- [ ] CI passes
- [ ] `mcpp search` 不再无条件打印 "Updating"
- [ ] `mcpp build` 有依赖时自动刷新索引