### PR TITLE
[codex] Add LLVM import std and self mirror config

### DIFF
--- a/.agents/docs/2026-05-13-llvm-clang-toolchain-support-design.md
+++ b/.agents/docs/2026-05-13-llvm-clang-toolchain-support-design.md
@@ -1,0 +1,696 @@
+# MCPP LLVM/Clang Toolchain Support Analysis and Design
+
+Date: 2026-05-13
+
+## Summary
+
+xlings now provides the Linux LLVM toolchain package MCPP needs to start
+supporting Clang as a first-class compiler family. I installed
+`llvm@20.1.7` into MCPP's isolated registry and verified the package layout.
+
+The main conclusion is that MCPP should not add Clang support as scattered
+`if clang` branches. Current build behavior is tightly coupled to GCC:
+`bits/std.cc`, `gcm.cache/*.gcm`, `-fmodules`, GCC P1689 flags,
+`-static-libstdc++`, and binutils `ar` are all assumed in different modules.
+Clang support needs a small toolchain abstraction layer that separates
+toolchain resolution, executable launch environment, compiler probing,
+standard-library module handling, module BMI dialect, and link/runtime
+policy.
+
+## Installed Toolchain
+
+Command used from this repository:
+
+```bash
+target/x86_64-linux-gnu/407914674e90df09/bin/mcpp toolchain install llvm 20.1.7
+```
+
+Result:
+
+```text
+Installed llvm@20.1.7 -> /home/speak/.mcpp/registry/data/xpkgs/xim-x-llvm/20.1.7/bin/clang++
+```
+
+MCPP isolated environment:
+
+```text
+MCPP_HOME    = /home/speak/.mcpp
+xlings home  = /home/speak/.mcpp/registry
+llvm root    = /home/speak/.mcpp/registry/data/xpkgs/xim-x-llvm/20.1.7
+```
+
+`mcpp toolchain list` now sees the installed toolchain:
+
+```text
+Installed:
+     TOOLCHAIN               BINARY
+     llvm 20.1.7             @mcpp/registry/data/xpkgs/xim-x-llvm/20.1.7/bin/clang++
+```
+
+Before this implementation, MCPP CLI did not list LLVM in the `Available`
+section because `cmd_toolchain list` explicitly enumerated only `gcc` and
+`musl-gcc`. Exact install still worked because the install path could resolve
+`xim:llvm@20.1.7`.
+
+## xlings Package Findings
+
+The relevant package file is:
+
+```text
+/home/speak/.mcpp/registry/data/xim-pkgindex/pkgs/l/llvm.lua
+```
+
+Important package facts:
+
+- Package name: `llvm`
+- Version: `20.1.7`
+- Linux artifact: `llvm-20.1.7-linux-x86_64.tar.xz`
+- Declared Linux dependencies: `xim:glibc@2.39`, `xim:linux-headers@5.11.1`
+- Tools: `clang`, `clang++`, `lld`, `ld.lld`, `llvm-ar`, `llvm-ranlib`,
+  `llvm-nm`, `llvm-objdump`, `llvm-readobj`, `llvm-strip`, etc.
+- Config files: `bin/clang.cfg`, `bin/clang-20.cfg`, `bin/clang++.cfg`
+- C++ runtime: bundled libc++/libc++abi/libunwind under
+  `lib/x86_64-unknown-linux-gnu`
+- Compiler runtime: compiler-rt under `lib/clang/20/lib/x86_64-unknown-linux-gnu`
+
+`clang++.cfg` is the key package integration point:
+
+```text
+--sysroot=/home/speak/.mcpp/registry/subos/default
+-Wl,--dynamic-linker=/home/speak/.mcpp/registry/subos/default/lib/ld-linux-x86-64.so.2
+-Wl,--enable-new-dtags,-rpath,/home/speak/.mcpp/registry/subos/default/lib
+-Wl,-rpath-link,/home/speak/.mcpp/registry/subos/default/lib
+-fuse-ld=lld
+--rtlib=compiler-rt
+--unwindlib=libunwind
+-nostdinc++
+-stdlib=libc++
+-isystem /home/speak/.mcpp/registry/data/xpkgs/xim-x-llvm/20.1.7/include/c++/v1
+-isystem /home/speak/.mcpp/registry/data/xpkgs/xim-x-llvm/20.1.7/include/x86_64-unknown-linux-gnu/c++/v1
+-L/home/speak/.mcpp/registry/data/xpkgs/xim-x-llvm/20.1.7/lib/x86_64-unknown-linux-gnu
+-Wl,-rpath,/home/speak/.mcpp/registry/data/xpkgs/xim-x-llvm/20.1.7/lib/x86_64-unknown-linux-gnu
+```
+
+This is good for MCPP: the package already encodes the intended libc++,
+compiler-rt, lld, sysroot, dynamic linker, and rpath choices. MCPP should not
+reconstruct all of these manually if the compiler config file is present.
+
+## Direct Usage Observations
+
+Direct execution currently fails without an additional runtime path:
+
+```text
+clang++: error while loading shared libraries: libz.so.1: cannot open shared object file
+```
+
+With host zlib in `LD_LIBRARY_PATH`, the compiler itself works:
+
+```bash
+LD_LIBRARY_PATH=/lib/x86_64-linux-gnu \
+  ~/.mcpp/registry/data/xpkgs/xim-x-llvm/20.1.7/bin/clang++ --version
+```
+
+Output:
+
+```text
+clang version 20.1.7
+Target: x86_64-unknown-linux-gnu
+Configuration file: .../bin/clang++.cfg
+```
+
+Simple C and C++ builds work with the same launch environment:
+
+```bash
+LD_LIBRARY_PATH=/lib/x86_64-linux-gnu clang -std=c11 hello.c -o hello
+LD_LIBRARY_PATH=/lib/x86_64-linux-gnu clang++ -std=c++23 hello.cpp -o hello
+```
+
+The produced C++ binary may also need `libatomic.so.1` at runtime. On this
+machine, `libatomic.so.1` exists in the host system and in
+`~/.mcpp/registry/data/xpkgs/xim-x-gcc-runtime/15.1.0/lib64`, but not in the
+LLVM package rpath or default subos lib path. This means MCPP needs a
+toolchain runtime environment concept instead of assuming an absolute compiler
+binary is self-sufficient.
+
+## Standard Library Module Findings
+
+The LLVM package includes:
+
+```text
+lib/x86_64-unknown-linux-gnu/libc++.modules.json
+```
+
+It declares:
+
+```json
+{
+  "logical-name": "std",
+  "source-path": "../../share/libc++/v1/std.cppm"
+}
+```
+
+and:
+
+```json
+{
+  "logical-name": "std.compat",
+  "source-path": "../../share/libc++/v1/std.compat.cppm"
+}
+```
+
+However, the referenced files are not present in this installed package:
+
+```text
+share/libc++/v1/std.cppm          missing
+share/libc++/v1/std.compat.cppm   missing
+```
+
+As expected, direct `import std` compilation fails:
+
+```text
+fatal error: module 'std' not found
+```
+
+This is an important integration decision:
+
+- MCPP can support Clang for non-`import std` C++ and C sources first.
+- First-class `import std` support requires either the LLVM package to ship
+  `std.cppm`/`std.compat.cppm`, or MCPP must have a separate source provider
+  for libc++ standard module sources.
+- MCPP should report this as a clear capability failure, not as a generic
+  compiler failure.
+
+Official Clang/libc++ documentation treats standard library modules as
+compiler/version/configuration-sensitive artifacts. The BMI is not portable
+across arbitrary compiler or flag changes. Therefore MCPP's fingerprint model
+must include the Clang resource dir, libc++ module source hash, and relevant
+module flags.
+
+References:
+
+- https://clang.llvm.org/docs/StandardCPlusPlusModules.html
+- https://libcxx.llvm.org/Modules.html
+
+## Current MCPP Failure Modes
+
+### 1. Absolute `clang++` Launch Fails
+
+MCPP resolves the installed binary correctly:
+
+```text
+Resolved llvm@20.1.7 -> @mcpp/registry/data/xpkgs/xim-x-llvm/20.1.7/bin/clang++
+```
+
+But then `detect()` runs the absolute binary directly. Without a launch
+environment, `clang++ --version` fails due `libz.so.1`.
+
+Implication: a resolved toolchain must carry an execution environment, not only
+a path.
+
+### 2. Clang Can Be Misdetected as GCC
+
+With `LD_LIBRARY_PATH=/lib/x86_64-linux-gnu`, detection gets past the loader,
+but current `detect.cppm` can classify Clang as GCC because it searches the
+entire `--version` output for the substring `gcc`. Clang's version output
+contains:
+
+```text
+Configuration file: .../bin/clang++.cfg
+```
+
+That suffix includes `gcc` inside `clang++.cfg`. The detected label becomes:
+
+```text
+gcc 6082 (x86_64-unknown-linux-gnu)
+```
+
+`6082` is extracted from the LLVM git commit hash on the first line.
+
+Implication: detection must check Clang before GCC and parse only reliable
+version fields. It should not substring-match the entire output.
+
+### 3. GCC std Module Is Mandatory
+
+Even when `[language].import_std = false`, `prepare_build()` calls
+`toolchain::ensure_built()` unconditionally. That function requires
+`Toolchain.stdModuleSource`, currently populated only for GCC `bits/std.cc`.
+
+Failure:
+
+```text
+toolchain has no std module source (import std unsupported on this compiler)
+```
+
+Implication: standard module preparation must be capability-driven and only
+required when the graph imports `std` or `std.compat`.
+
+### 4. Ninja Rules Are GCC-Specific
+
+The current Ninja backend assumes:
+
+- `-fmodules`
+- `-fdeps-format=p1689r5`
+- BMI suffix `.gcm`
+- `gcm.cache/<module>.gcm`
+- staged `std.gcm` and `std.o`
+- GCC restat behavior around `.gcm`
+
+Clang uses a different module dialect:
+
+- BMI suffix `.pcm`
+- explicit module output or precompile flows
+- `-fmodule-file=<name>=<pcm>` or prebuilt module paths
+- `clang-scan-deps` for robust dependency scanning
+- libc++ standard module sources, not GCC `bits/std.cc`
+
+## Design Goals
+
+1. Make LLVM/Clang a first-class MCPP toolchain family.
+2. Keep GCC and musl-GCC behavior stable.
+3. Avoid hardcoding one compiler's module model into the generic build plan.
+4. Preserve xlings isolation: builds should not accidentally depend on system
+   compiler PATH.
+5. Keep toolchain-specific complexity behind explicit interfaces.
+6. Support staged delivery: first Clang detection and non-`import std` builds,
+   then Clang modules, then Clang `import std`.
+
+## Proposed Architecture
+
+### Toolchain Request
+
+Normalize user-facing specs before xlings resolution.
+
+```cpp
+struct ToolchainRequest {
+    std::string family;        // "gcc", "llvm", "clang", "musl-gcc", "msvc"
+    std::string version;       // "20.1.7"
+    std::string libcFlavor;    // "", "musl"
+    std::string xpkgName;      // "gcc", "musl-gcc", "llvm"
+    std::string displaySpec;   // "llvm@20.1.7"
+};
+```
+
+Rules:
+
+- `llvm@20.1.7` -> `xim:llvm@20.1.7`
+- `clang@20.1.7` -> `xim:llvm@20.1.7`, display as `clang/llvm`
+- `gcc@15.1.0-musl` -> `xim:musl-gcc@15.1.0`
+- `musl-gcc@15.1.0` remains accepted
+
+This removes duplicated parsing in `prepare_build`, `install`, `default`,
+`remove`, and `list`.
+
+### Toolchain Resolver
+
+Return more than a compiler path.
+
+```cpp
+struct ToolchainPayload {
+    std::string displaySpec;
+    std::string xpkgName;
+    std::string version;
+    std::filesystem::path root;
+    std::filesystem::path binDir;
+    std::filesystem::path cxx;
+    std::filesystem::path cc;
+    std::filesystem::path ar;
+    std::filesystem::path ranlib;
+    std::filesystem::path scanner;
+    std::vector<std::filesystem::path> runtimeLibraryDirs;
+    std::map<std::string, std::string> env;
+};
+```
+
+For LLVM:
+
+- `cxx = bin/clang++`
+- `cc = bin/clang`
+- `ar = bin/llvm-ar`
+- `ranlib = bin/llvm-ranlib`
+- `scanner = bin/clang-scan-deps` if present
+- `runtimeLibraryDirs` must include any dirs needed to launch compiler tools
+  and linked binaries in MCPP's sandbox.
+
+The resolver should inspect package layout and config files, not assume every
+toolchain has binutils siblings.
+
+### Toolchain Launcher
+
+Every subprocess that invokes compiler-family tools should go through a
+launcher helper.
+
+```cpp
+struct ToolInvocation {
+    std::filesystem::path exe;
+    std::vector<std::string> args;
+    std::map<std::string, std::string> env;
+    std::filesystem::path cwd;
+};
+```
+
+Why this is needed:
+
+- LLVM's absolute `clang++` currently needs a runtime library path for
+  `libz.so.1`.
+- MCPP currently uses raw shell strings in detect, stdmod, scanner, and ninja.
+- Ninja build files also need to embed the required environment.
+
+Ninja can express this with rule command prefixes:
+
+```ninja
+rule cxx_object
+  command = env LD_LIBRARY_PATH=$tool_ld_library_path $cxx $cxxflags -c $in -o $out
+```
+
+The exact env should come from the resolved toolchain profile.
+
+### Compiler Profile
+
+`toolchain::detect()` should produce a richer profile:
+
+```cpp
+enum class CompilerFamily { GCC, Clang, MSVC };
+enum class StdlibFamily { Libstdcxx, Libcxx, MsvcStl, Unknown };
+enum class ModuleDialect { GccGcm, ClangPcm, MsvcIfc, None };
+
+struct CompilerProfile {
+    CompilerFamily family;
+    std::string version;
+    std::string targetTriple;
+    StdlibFamily stdlib;
+    std::string stdlibVersion;
+    ModuleDialect moduleDialect;
+    std::filesystem::path cxx;
+    std::filesystem::path cc;
+    std::filesystem::path ar;
+    std::filesystem::path ranlib;
+    std::filesystem::path resourceDir;
+    std::filesystem::path sysroot;
+    ToolLaunchEnv launchEnv;
+    StdModuleCapability stdModule;
+};
+```
+
+Detection rules:
+
+- Detect Clang before GCC.
+- Parse `clang version X.Y.Z` from the first line.
+- Parse GCC from `g++ (...) X.Y.Z` or `gcc version X.Y.Z`, not arbitrary
+  trailing numbers.
+- Do not infer `libc++` just because family is Clang; inspect config or query
+  include/link search paths when possible.
+
+### Standard Module Provider
+
+Replace the single GCC-specific `ensure_built()` with provider strategies.
+
+```cpp
+class StdModuleProvider {
+public:
+    virtual bool available(const CompilerProfile&) const = 0;
+    virtual Expected<StdModuleArtifacts, Error>
+        ensure_built(const CompilerProfile&, std::string_view fp) = 0;
+};
+```
+
+Providers:
+
+- `GccStdModuleProvider`
+  - Source: GCC `bits/std.cc`
+  - Output: `std.gcm`, `std.o`
+  - Flags: `-std=c++23 -fmodules`
+
+- `ClangLibcxxStdModuleProvider`
+  - Source: `libc++.modules.json` -> `std.cppm` / `std.compat.cppm`
+  - Output: `std.pcm`, optional object if needed by the selected flow
+  - Flags: `-std=c++23 -stdlib=libc++ -fexperimental-library` when required
+  - Hard error if `libc++.modules.json` references missing files
+
+Standard module building should be conditional:
+
+- If graph imports `std` or `std.compat`, require provider availability.
+- If no unit imports standard modules, skip std module prebuild entirely.
+
+### Module Dialect
+
+Move compiler-specific BMI naming and flags out of `ninja_backend.cppm`.
+
+```cpp
+class ModuleDialectRules {
+public:
+    virtual std::string bmi_filename(std::string_view logicalName) const = 0;
+    virtual std::string cxx_module_flags(const CompileUnit&) const = 0;
+    virtual std::string scan_rule() const = 0;
+    virtual std::string compile_rule() const = 0;
+};
+```
+
+GCC dialect:
+
+- BMI dir: `gcm.cache`
+- BMI suffix: `.gcm`
+- Compile: `-fmodules`
+- Scan: `-fdeps-format=p1689r5 -fdeps-file=...`
+
+Clang dialect:
+
+- BMI dir: `pcm.cache` or compiler-neutral `bmi.cache`
+- BMI suffix: `.pcm`
+- Compile interface: use `--precompile` or `-fmodule-output=<pcm>`
+- Compile users: pass `-fmodule-file=<logical>=<pcm>` for known imports
+- Scan: prefer `clang-scan-deps -format=p1689` when available
+
+MVP fallback:
+
+- If `clang-scan-deps` is unavailable, MCPP can use its existing graph scanner
+  and static dependency edges for project modules.
+- That fallback is acceptable for initial Clang support, but less precise than
+  compiler-driven scanning.
+
+### Link Policy
+
+Move stdlib/runtime link flags out of generic `compute_flags()`.
+
+```cpp
+struct LinkPolicy {
+    std::vector<std::string> cxxFlags;
+    std::vector<std::string> cFlags;
+    std::vector<std::string> ldFlags;
+    std::filesystem::path linker;
+    std::filesystem::path ar;
+    std::filesystem::path ranlib;
+};
+```
+
+GCC policy:
+
+- `-static-libstdc++` when requested
+- binutils `ar` from sibling package when available
+- musl target implies static linkage unless explicitly overridden
+
+LLVM policy:
+
+- Do not add `-static-libstdc++`
+- Use package config file for libc++/compiler-rt/lld where possible
+- Prefer `llvm-ar` and `llvm-ranlib`
+- Preserve or reproduce package rpath behavior for libc++ and subos libs
+- Decide separately whether MCPP supports fully static LLVM/libc++ builds
+
+## Proposed Implementation Phases
+
+### Phase 1: Make LLVM Resolvable and Detectable
+
+Scope:
+
+- Add data-driven toolchain families: `gcc`, `musl-gcc`, `llvm`, `clang`.
+- Make `clang@<ver>` alias to `llvm@<ver>`.
+- Include `llvm` in `toolchain list` Available output.
+- Resolve `cc`, `cxx`, `ar`, `ranlib` from package profile.
+- Add toolchain launch env and use it in `detect()`.
+- Fix compiler detection order and parsing.
+- Stop unconditional std module prebuild.
+
+Acceptance:
+
+- `mcpp toolchain install llvm 20.1.7`
+- `mcpp toolchain default llvm@20.1.7`
+- `mcpp build` for a project with no `import std` should reach Ninja.
+- Clear error if LLVM compiler launch env cannot be formed.
+
+### Phase 2: Clang Non-Standard-Module Build
+
+Scope:
+
+- Add Clang flag/link policy.
+- Use `clang` for `.c`, `clang++` for `.cpp/.cppm`.
+- Use `llvm-ar` for archives.
+- Generate Ninja commands with toolchain launch env.
+- For projects that do not import `std`, skip `std.pcm` entirely.
+
+Acceptance:
+
+- Pure C project builds with LLVM.
+- Header-based C++ project builds with LLVM.
+- Mixed C/C++ project builds with LLVM.
+- Static libraries use `llvm-ar`.
+- `compile_commands.json` reflects Clang commands.
+
+### Phase 3: Clang Project Modules
+
+Scope:
+
+- Add Clang PCM BMI layout.
+- Emit module interface build edges producing `.pcm` plus objects.
+- Pass explicit `-fmodule-file=<name>=<path>` for imports.
+- Use existing MCPP graph scanner as initial dependency source.
+- Add `clang-scan-deps` support once the tool is available in xlings.
+
+Acceptance:
+
+- Multi-module project without `import std` builds with LLVM.
+- Incremental rebuild works when implementation changes.
+- GCC behavior remains unchanged.
+
+### Phase 4: Clang `import std`
+
+Scope:
+
+- Implement `ClangLibcxxStdModuleProvider`.
+- Read `libc++.modules.json`.
+- Validate source paths.
+- Prebuild `std.pcm` and `std.compat.pcm`.
+- Add std module artifacts to fingerprint inputs.
+
+Dependency:
+
+- The LLVM xpkg must ship `share/libc++/v1/std.cppm` and
+  `share/libc++/v1/std.compat.cppm`, or MCPP must define another trusted source
+  for them.
+
+Acceptance:
+
+- `import std; int main(){ std::println("ok"); }` builds with LLVM.
+- Missing libc++ module sources produce a targeted diagnostic.
+
+### Phase 5: Packaging and Runtime
+
+Scope:
+
+- Teach `mcpp pack` that libc++/libc++abi/libunwind are not manylinux system
+  libraries.
+- Bundle libc++ runtime in `bundle-project`, unless explicitly skipped.
+- Ensure produced binaries do not depend on undeclared host paths.
+- Revisit `libatomic` and `libz` handling.
+
+Acceptance:
+
+- LLVM-built dynamic package runs after extraction on a clean target host.
+- `bundle-all` includes the correct loader/runtime libraries.
+
+## Required Code Areas
+
+Likely files to touch:
+
+- `src/cli.cppm`
+  - Toolchain spec parsing, install/list/default/remove, prepare_build.
+- `src/toolchain/detect.cppm`
+  - Robust family detection, profile fields, launch env.
+- `src/toolchain/stdmod.cppm`
+  - Split into provider strategies; make prebuild conditional.
+- `src/build/flags.cppm`
+  - Replace GCC-only flag assembly with profile/link policy.
+- `src/build/ninja_backend.cppm`
+  - Move module-specific rules into dialect emitters.
+- `src/build/compile_commands.cppm`
+  - Preserve Clang command/env assumptions for IDEs.
+- `src/modgraph/p1689.cppm`
+  - Rename GCC-specific implementation or add scanner strategy.
+- `src/pack/pack.cppm`
+  - Runtime bundling policy for libc++ and LLVM-built binaries.
+- `tests/e2e`
+  - Add LLVM install/detect/build tests; gate large downloads where needed.
+
+## Test Plan
+
+Unit tests:
+
+- Parse `llvm@20.1.7`, `clang@20.1.7`, `gcc@15.1.0-musl`.
+- Detect Clang from version output containing `clang++.cfg`.
+- Verify Clang does not emit `-static-libstdc++`.
+- Verify LLVM archive tool is `llvm-ar`.
+- Verify std module prebuild is skipped when no source imports `std`.
+- Verify missing libc++ `std.cppm` yields a specific diagnostic.
+
+E2E tests:
+
+- `mcpp toolchain install llvm 20.1.7` in isolated `MCPP_HOME`.
+- `mcpp toolchain list` shows installed LLVM and available LLVM versions.
+- Pure C project builds with LLVM.
+- Header-based C++ project builds with LLVM.
+- Mixed C/C++ project builds with LLVM.
+- Modular project without `import std` builds with LLVM.
+- `import std` test is skipped or expected-fails until std.cppm is available.
+- `mcpp pack` bundle-project includes libc++ runtime for LLVM-built binaries.
+
+## Open Package Questions
+
+These should be resolved with the xlings package owner before implementing
+Phase 4 and Phase 5:
+
+1. Should `llvm` declare or bundle a provider for `libz.so.1` so direct
+   absolute `bin/clang++` execution works inside MCPP without host
+   `LD_LIBRARY_PATH`?
+2. Should `llvm` include `share/libc++/v1/std.cppm` and
+   `share/libc++/v1/std.compat.cppm`, since `libc++.modules.json` references
+   them?
+3. Should `llvm` or `llvm-tools` include `clang-scan-deps`? It is the natural
+   tool for Clang module dependency scanning.
+4. Should LLVM-built binaries depend on `libatomic.so.1`, or should compiler-rt
+   and package rpaths avoid that dependency?
+
+## Recommended Path
+
+Start with Phase 1 and Phase 2. They establish the architecture and make LLVM
+usable for non-`import std` projects without committing to the full Clang module
+pipeline immediately.
+
+Do not wire Clang into the current GCC `gcm.cache` path. That would create a
+fragile hybrid that fails later around BMI format, std module sources,
+fingerprints, and incremental rebuilds.
+
+The central design rule is:
+
+```text
+BuildPlan stays compiler-neutral.
+CompilerProfile + ModuleDialect + StdModuleProvider + LinkPolicy own the
+compiler-specific behavior.
+```
+
+## Implementation Status
+
+This PR implements the first practical slice of the design:
+
+- `llvm@20.1.7` and `clang@20.1.7` resolve to the xlings `llvm` package.
+- Clang detection checks Clang before GCC and only classifies GCC from the
+  version banner, avoiding false positives from `gcc-runtime` paths in
+  `clang++.cfg`.
+- Toolchain metadata now carries compiler launch library paths and output
+  link runtime paths.
+- Ninja rules execute compiler, linker, and archive commands through the
+  toolchain launch environment when needed.
+- Clang builds use `clang`, `clang++`, `llvm-ar`, no GCC P1689 dyndep scan,
+  and no `-static-libstdc++`.
+- `import std` prebuild is conditional on the source graph actually importing
+  `std` or `std.compat`.
+- If source imports `std` with LLVM today, MCPP reports that the toolchain has
+  no std module source. This remains blocked on the xlings LLVM package
+  shipping libc++ `std.cppm` / `std.compat.cppm`.
+
+Validated behavior in this implementation:
+
+- Header-based C++ and mixed C/C++ projects build and run with
+  `llvm@20.1.7`.
+- `clang@20.1.7` works as an alias for the same package.
+- Existing GCC/musl-GCC unit and e2e coverage remains intact, except that the
+  pack e2e now pins glibc GCC explicitly so it is independent of the user's
+  global default toolchain.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,12 @@ jobs:
           # above so they don't have to reinstall the sandbox.
           export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
           test -x "$MCPP_VENDORED_XLINGS"
+          # GitHub-hosted runners are outside CN; keep CI toolchain downloads on
+          # the global mirror while mcpp's default remains CN for fresh local
+          # sandboxes. E2E tests with their own MCPP_HOME read this variable.
+          export MCPP_E2E_TOOLCHAIN_MIRROR=GLOBAL
+          "$MCPP" self config --mirror "$MCPP_E2E_TOOLCHAIN_MIRROR"
+          "$MCPP" self config
           # Pin the global default so test 28 (which exercises the
           # default-toolchain path) gets a deterministic GNU answer
           # instead of whatever auto-install picks on a fresh sandbox.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 > 本文件追踪 `mcpp-community/mcpp` 公开仓的版本演进。
 > 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [0.0.14] — 2026-05-13
+
+LLVM / Clang 工具链支持与 xlings 镜像配置完善。
+
+### 新增
+
+- ✅ **LLVM / Clang 工具链支持** —— 新增基于 `clang++`、`clang-scan-deps`、
+  `llvm-ar`、`lld` 的工具链探测与构建路径，支持 xlings `llvm` 包提供的
+  自包含 Linux LLVM 工具链。
+- ✅ **`import std` 支持** —— LLVM libc++ 模块标准库可用时，自动发现
+  `std.cppm` / `std.compat.cppm`，并接入标准库 BMI 预构建流程。
+- ✅ **`mcpp self config --mirror`** —— 通过 xlings 抽象层配置 sandbox
+  镜像，默认初始化为 `CN`，CI 可显式切换为 `GLOBAL`。
+
+### 改进
+
+- 🔧 **工具链 provider 拆分** —— 将通用模型、探测逻辑、GCC、Clang、LLVM
+  provider 与 registry 分离到独立模块，为后续更多工具链扩展预留入口。
+- 🔧 **xlings 索引兼容迁移** —— 自动将历史 `mcpp-index` 索引名迁移到
+  `mcpplibs`，避免旧 sandbox 状态影响新流程。
+
 ## [0.0.4] — 2026-05-10
 
 构建 / 环境体验优化三件套。

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.13"
+version     = "0.0.14"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -11,7 +11,7 @@ export module mcpp.build.flags;
 import std;
 import mcpp.build.plan;
 import mcpp.toolchain.detect;
-import mcpp.xlings;
+import mcpp.toolchain.registry;
 
 export namespace mcpp::build {
 
@@ -37,30 +37,8 @@ namespace mcpp::build {
 
 namespace {
 
-std::filesystem::path derive_c_compiler(const std::filesystem::path& cxxPath) {
-    auto stem = cxxPath.stem().string();
-    auto parent = cxxPath.parent_path();
-    auto ext = cxxPath.extension();
-
-    // g++ → gcc, clang++ → clang, x86_64-linux-musl-g++ → x86_64-linux-musl-gcc
-    std::string cc_stem;
-    if (stem.ends_with("++")) {
-        cc_stem = stem.substr(0, stem.size() - 2);
-        // g++ → gcc; x86_64-linux-musl-g++ → x86_64-linux-musl-gcc;
-        // clang++ → clang.
-        if (cc_stem == "g" || cc_stem.ends_with("-g"))
-            cc_stem += "cc";  // g → gcc
-        // else clang++ → clang (already correct after stripping ++)
-    } else {
-        cc_stem = stem;  // fallback: same as cxx
-    }
-    return parent / (cc_stem + ext.string());
-}
-
 std::filesystem::path staged_std_bmi_path(const BuildPlan& plan) {
-    if (plan.toolchain.compiler == mcpp::toolchain::CompilerId::Clang)
-        return plan.outputDir / "pcm.cache" / "std.pcm";
-    return plan.outputDir / "gcm.cache" / "std.gcm";
+    return mcpp::toolchain::staged_std_bmi_path(plan.toolchain, plan.outputDir);
 }
 
 // Escape a path for embedding in ninja rule strings.
@@ -81,7 +59,7 @@ std::string escape_path(const std::filesystem::path& p) {
 CompileFlags compute_flags(const BuildPlan& plan) {
     CompileFlags f;
     f.cxxBinary = plan.toolchain.binaryPath;
-    f.ccBinary = derive_c_compiler(plan.toolchain.binaryPath);
+    f.ccBinary = mcpp::toolchain::derive_c_compiler(plan.toolchain);
     f.toolEnv = mcpp::toolchain::compiler_env_prefix(plan.toolchain);
 
     // PIC?
@@ -109,14 +87,13 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     }
 
     // Binutils -B flag
-    bool isMuslTc = plan.toolchain.targetTriple.find("-musl") != std::string::npos;
-    bool isClang = plan.toolchain.compiler == mcpp::toolchain::CompilerId::Clang;
+    bool isMuslTc = mcpp::toolchain::is_musl_target(plan.toolchain);
+    bool isClang = mcpp::toolchain::is_clang(plan.toolchain);
     std::filesystem::path binutilsBin;
     if (!isMuslTc && !isClang) {
-        if (auto ar = mcpp::xlings::paths::find_sibling_binary(
-                plan.toolchain.binaryPath, "binutils", "bin/ar")) {
-            binutilsBin = ar->parent_path();  // bin/ar → bin/
-        }
+        auto ar = mcpp::toolchain::archive_tool(plan.toolchain);
+        if (!ar.empty())
+            binutilsBin = ar.parent_path();
     }
     std::string b_flag;
     if (!binutilsBin.empty()) {
@@ -125,17 +102,7 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     }
 
     // AR binary
-    if (isClang) {
-        auto llvmAr = plan.toolchain.binaryPath.parent_path() / "llvm-ar";
-        if (std::filesystem::exists(llvmAr))
-            f.arBinary = llvmAr;
-    } else if (!binutilsBin.empty()) {
-        f.arBinary = binutilsBin / "ar";
-    } else if (isMuslTc) {
-        auto muslAr = plan.toolchain.binaryPath.parent_path() / "x86_64-linux-musl-ar";
-        if (std::filesystem::exists(muslAr))
-            f.arBinary = muslAr;
-    }
+    f.arBinary = mcpp::toolchain::archive_tool(plan.toolchain);
 
     // Opt level (musl ICE workaround)
     std::string opt_flag = isMuslTc ? " -Og" : " -O2";

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -57,6 +57,12 @@ std::filesystem::path derive_c_compiler(const std::filesystem::path& cxxPath) {
     return parent / (cc_stem + ext.string());
 }
 
+std::filesystem::path staged_std_bmi_path(const BuildPlan& plan) {
+    if (plan.toolchain.compiler == mcpp::toolchain::CompilerId::Clang)
+        return plan.outputDir / "pcm.cache" / "std.pcm";
+    return plan.outputDir / "gcm.cache" / "std.gcm";
+}
+
 // Escape a path for embedding in ninja rule strings.
 std::string escape_path(const std::filesystem::path& p) {
     auto s = p.string();
@@ -152,8 +158,12 @@ CompileFlags compute_flags(const BuildPlan& plan) {
 
     // Assemble
     std::string module_flag = isClang ? "" : " -fmodules";
-    f.cxx = std::format("-std=c++23{}{}{}{}{}{}{}", module_flag, opt_flag, pic_flag,
-                        sysroot_flag, b_flag, include_flags, user_cxxflags);
+    std::string std_module_flag;
+    if (isClang && !plan.stdBmiPath.empty()) {
+        std_module_flag = " -fmodule-file=std=" + escape_path(staged_std_bmi_path(plan));
+    }
+    f.cxx = std::format("-std=c++23{}{}{}{}{}{}{}{}", module_flag, std_module_flag,
+                        opt_flag, pic_flag, sysroot_flag, b_flag, include_flags, user_cxxflags);
     f.cc = std::format("-std={}{}{}{}{}{}{}", c_std, opt_flag, pic_flag, sysroot_flag, b_flag,
                        include_flags, user_cflags);
 

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -10,6 +10,7 @@ export module mcpp.build.flags;
 
 import std;
 import mcpp.build.plan;
+import mcpp.toolchain.detect;
 import mcpp.xlings;
 
 export namespace mcpp::build {
@@ -23,6 +24,7 @@ struct CompileFlags {
     std::filesystem::path arBinary;   // ar path (may be empty → use PATH)
     std::string sysroot;              // --sysroot=... (for ninja ldflags)
     std::string bFlag;                // -B<binutils> (for ninja ldflags)
+    std::string toolEnv;              // env prefix for private toolchain executables
     bool staticStdlib = true;
     std::string linkage;  // "static" or ""
 };
@@ -44,8 +46,9 @@ std::filesystem::path derive_c_compiler(const std::filesystem::path& cxxPath) {
     std::string cc_stem;
     if (stem.ends_with("++")) {
         cc_stem = stem.substr(0, stem.size() - 2);
-        // g++ → gcc; clang++ → clang
-        if (cc_stem.ends_with("g"))
+        // g++ → gcc; x86_64-linux-musl-g++ → x86_64-linux-musl-gcc;
+        // clang++ → clang.
+        if (cc_stem == "g" || cc_stem.ends_with("-g"))
             cc_stem += "cc";  // g → gcc
         // else clang++ → clang (already correct after stripping ++)
     } else {
@@ -73,6 +76,7 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     CompileFlags f;
     f.cxxBinary = plan.toolchain.binaryPath;
     f.ccBinary = derive_c_compiler(plan.toolchain.binaryPath);
+    f.toolEnv = mcpp::toolchain::compiler_env_prefix(plan.toolchain);
 
     // PIC?
     bool need_pic = false;
@@ -100,8 +104,9 @@ CompileFlags compute_flags(const BuildPlan& plan) {
 
     // Binutils -B flag
     bool isMuslTc = plan.toolchain.targetTriple.find("-musl") != std::string::npos;
+    bool isClang = plan.toolchain.compiler == mcpp::toolchain::CompilerId::Clang;
     std::filesystem::path binutilsBin;
-    if (!isMuslTc) {
+    if (!isMuslTc && !isClang) {
         if (auto ar = mcpp::xlings::paths::find_sibling_binary(
                 plan.toolchain.binaryPath, "binutils", "bin/ar")) {
             binutilsBin = ar->parent_path();  // bin/ar → bin/
@@ -114,7 +119,11 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     }
 
     // AR binary
-    if (!binutilsBin.empty()) {
+    if (isClang) {
+        auto llvmAr = plan.toolchain.binaryPath.parent_path() / "llvm-ar";
+        if (std::filesystem::exists(llvmAr))
+            f.arBinary = llvmAr;
+    } else if (!binutilsBin.empty()) {
         f.arBinary = binutilsBin / "ar";
     } else if (isMuslTc) {
         auto muslAr = plan.toolchain.binaryPath.parent_path() / "x86_64-linux-musl-ar";
@@ -142,8 +151,9 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         plan.manifest.buildConfig.cStandard.empty() ? "c11" : plan.manifest.buildConfig.cStandard;
 
     // Assemble
-    f.cxx = std::format("-std=c++23 -fmodules{}{}{}{}{}{}", opt_flag, pic_flag, sysroot_flag,
-                        b_flag, include_flags, user_cxxflags);
+    std::string module_flag = isClang ? "" : " -fmodules";
+    f.cxx = std::format("-std=c++23{}{}{}{}{}{}{}", module_flag, opt_flag, pic_flag,
+                        sysroot_flag, b_flag, include_flags, user_cxxflags);
     f.cc = std::format("-std={}{}{}{}{}{}{}", c_std, opt_flag, pic_flag, sysroot_flag, b_flag,
                        include_flags, user_cflags);
 
@@ -151,8 +161,14 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     f.staticStdlib = plan.manifest.buildConfig.staticStdlib;
     f.linkage = plan.manifest.buildConfig.linkage;
     std::string full_static = (f.linkage == "static") ? " -static" : "";
-    std::string static_stdlib = f.staticStdlib ? " -static-libstdc++" : "";
-    f.ld = std::format("{}{}{}{}", full_static, static_stdlib, sysroot_flag, b_flag);
+    std::string static_stdlib = (f.staticStdlib && !isClang) ? " -static-libstdc++" : "";
+    std::string runtime_dirs;
+    for (auto& dir : plan.toolchain.linkRuntimeDirs) {
+        runtime_dirs += " -L" + escape_path(dir);
+        runtime_dirs += " -Wl,-rpath," + escape_path(dir);
+    }
+    f.ld = std::format("{}{}{}{}{}", full_static, static_stdlib, sysroot_flag, b_flag,
+                       runtime_dirs);
 
     return f;
 }

--- a/src/build/ninja_backend.cppm
+++ b/src/build/ninja_backend.cppm
@@ -277,8 +277,10 @@ std::string emit_ninja_string(const BuildPlan& plan) {
         append("  restat = 1\n\n");
     }
 
-    // Stage prebuilt std artifacts into our gcm.cache/
-    auto std_bmi_dst = std::filesystem::path("gcm.cache") / "std.gcm";
+    // Stage prebuilt std artifacts into the compiler-specific BMI cache.
+    auto std_bmi_dst = plan.toolchain.compiler == mcpp::toolchain::CompilerId::Clang
+        ? std::filesystem::path("pcm.cache") / "std.pcm"
+        : std::filesystem::path("gcm.cache") / "std.gcm";
     auto std_o_dst = std::filesystem::path("obj") / "std.o";
 
     bool has_std_artifacts = !plan.stdBmiPath.empty() && !plan.stdObjectPath.empty();
@@ -383,7 +385,7 @@ std::string emit_ninja_string(const BuildPlan& plan) {
                 for (auto& imp : cu.imports) {
                     if (imp == "std" || imp == "std.compat") {
                         if (has_std_artifacts)
-                            implicit += " gcm.cache/std.gcm";
+                            implicit += " " + escape_ninja_path(std_bmi_dst);
                         continue;
                     }
                     implicit += " " + bmi_path(imp);

--- a/src/build/ninja_backend.cppm
+++ b/src/build/ninja_backend.cppm
@@ -24,6 +24,7 @@ import mcpp.build.flags;
 import mcpp.build.compile_commands;
 import mcpp.dyndep;
 import mcpp.toolchain.detect;
+import mcpp.toolchain.registry;
 import mcpp.xlings;
 
 export namespace mcpp::build {
@@ -118,39 +119,6 @@ std::filesystem::path mcpp_exe_path() {
     return "mcpp";  // fall back to PATH lookup
 }
 
-// Derive a sibling C compiler from a C++ compiler binary path. Used so .c
-// sources can be compiled by the actual C frontend (cc1), not g++ which
-// rejects implicit `void*` conversions and `restrict` etc.
-//   .../bin/g++                       → .../bin/gcc
-//   .../bin/x86_64-linux-musl-g++     → .../bin/x86_64-linux-musl-gcc
-//   .../bin/clang++                   → .../bin/clang
-//   .../bin/c++                       → .../bin/cc
-// If no sibling exists, return "gcc" so PATH lookup is the final fallback
-// (this also keeps unit tests that don't touch a real toolchain happy).
-std::filesystem::path derive_c_compiler(const std::filesystem::path& cxx) {
-    auto fname = cxx.filename().string();
-    auto try_replace = [&](std::string_view from,
-                           std::string_view to) -> std::optional<std::filesystem::path> {
-        auto pos = fname.rfind(from);
-        if (pos == std::string::npos)
-            return std::nullopt;
-        std::string repl = fname;
-        repl.replace(pos, from.size(), to);
-        auto p = cxx.parent_path() / repl;
-        std::error_code ec;
-        if (std::filesystem::exists(p, ec))
-            return p;
-        return std::nullopt;
-    };
-    if (auto p = try_replace("clang++", "clang"))
-        return *p;
-    if (auto p = try_replace("g++", "gcc"))
-        return *p;
-    if (auto p = try_replace("c++", "cc"))
-        return *p;
-    return "gcc";
-}
-
 bool is_c_source(const std::filesystem::path& src) {
     return src.extension() == ".c";
 }
@@ -159,7 +127,7 @@ bool is_c_source(const std::filesystem::path& src) {
 
 std::string emit_ninja_string(const BuildPlan& plan) {
     bool dyndep = dyndep_mode_enabled()
-               && plan.toolchain.compiler == mcpp::toolchain::CompilerId::GCC;
+               && mcpp::toolchain::is_gcc(plan.toolchain);
     std::string out;
     auto append = [&](std::string s) { out += std::move(s); };
 
@@ -278,9 +246,7 @@ std::string emit_ninja_string(const BuildPlan& plan) {
     }
 
     // Stage prebuilt std artifacts into the compiler-specific BMI cache.
-    auto std_bmi_dst = plan.toolchain.compiler == mcpp::toolchain::CompilerId::Clang
-        ? std::filesystem::path("pcm.cache") / "std.pcm"
-        : std::filesystem::path("gcm.cache") / "std.gcm";
+    auto std_bmi_dst = mcpp::toolchain::staged_std_bmi_path(plan.toolchain, {});
     auto std_o_dst = std::filesystem::path("obj") / "std.o";
 
     bool has_std_artifacts = !plan.stdBmiPath.empty() && !plan.stdObjectPath.empty();

--- a/src/build/ninja_backend.cppm
+++ b/src/build/ninja_backend.cppm
@@ -23,6 +23,7 @@ import mcpp.build.plan;
 import mcpp.build.flags;
 import mcpp.build.compile_commands;
 import mcpp.dyndep;
+import mcpp.toolchain.detect;
 import mcpp.xlings;
 
 export namespace mcpp::build {
@@ -63,6 +64,16 @@ std::string escape_ninja_path(const std::filesystem::path& p) {
             out += "$ ";
         else
             out.push_back(c);
+    }
+    return out;
+}
+
+std::string escape_ninja_variable_value(std::string_view s) {
+    std::string out;
+    out.reserve(s.size());
+    for (char c : s) {
+        if (c == '$') out += "$$";
+        else          out.push_back(c);
     }
     return out;
 }
@@ -147,7 +158,8 @@ bool is_c_source(const std::filesystem::path& src) {
 }  // namespace
 
 std::string emit_ninja_string(const BuildPlan& plan) {
-    bool dyndep = dyndep_mode_enabled();
+    bool dyndep = dyndep_mode_enabled()
+               && plan.toolchain.compiler == mcpp::toolchain::CompilerId::GCC;
     std::string out;
     auto append = [&](std::string s) { out += std::move(s); };
 
@@ -167,6 +179,7 @@ std::string emit_ninja_string(const BuildPlan& plan) {
 
     append(std::format("cxx       = {}\n", escape_ninja_path(flags.cxxBinary)));
     append(std::format("cxxflags  = {}\n", flags.cxx));
+    append(std::format("toolenv   = {}\n", escape_ninja_variable_value(flags.toolEnv)));
     if (need_c_rule) {
         append(std::format("cc        = {}\n", escape_ninja_path(flags.ccBinary)));
         append(std::format("cflags    = {}\n", flags.cc));
@@ -208,7 +221,7 @@ std::string emit_ninja_string(const BuildPlan& plan) {
            "if [ -n \"$bmi_out\" ] && [ -f \"$bmi_out\" ]; then "
              "cp -p \"$bmi_out\" \"$bmi_out.bak\"; "
            "fi && "
-           "$cxx $cxxflags -c $in -o $out && "
+           "$toolenv $cxx $cxxflags -c $in -o $out && "
            "if [ -n \"$bmi_out\" ] && [ -f \"$bmi_out.bak\" ] && "
               "cmp -s \"$bmi_out\" \"$bmi_out.bak\"; then "
              "mv \"$bmi_out.bak\" \"$bmi_out\"; "
@@ -221,7 +234,7 @@ std::string emit_ninja_string(const BuildPlan& plan) {
     append("\n");
 
     append("rule cxx_object\n");
-    append("  command = $cxx $cxxflags -c $in -o $out\n");
+    append("  command = $toolenv $cxx $cxxflags -c $in -o $out\n");
     append("  description = OBJ $out\n");
     if (dyndep)
         append("  restat = 1\n");
@@ -229,7 +242,7 @@ std::string emit_ninja_string(const BuildPlan& plan) {
 
     if (need_c_rule) {
         append("rule c_object\n");
-        append("  command = $cc $cflags -c $in -o $out\n");
+        append("  command = $toolenv $cc $cflags -c $in -o $out\n");
         append("  description = CC $out\n");
         if (dyndep)
             append("  restat = 1\n");
@@ -237,22 +250,22 @@ std::string emit_ninja_string(const BuildPlan& plan) {
     }
 
     append("rule cxx_link\n");
-    append("  command = $cxx $in -o $out $ldflags\n");
+    append("  command = $toolenv $cxx $in -o $out $ldflags\n");
     append("  description = LINK $out\n\n");
 
     append("rule cxx_archive\n");
-    append("  command = $ar rcs $out $in\n");
+    append("  command = $toolenv $ar rcs $out $in\n");
     append("  description = AR $out\n\n");
 
     append("rule cxx_shared\n");
-    append("  command = $cxx -shared $in -o $out $ldflags\n");
+    append("  command = $toolenv $cxx -shared $in -o $out $ldflags\n");
     append("  description = SHARED $out\n\n");
 
     if (dyndep) {
         // Scan rule: produce P1689 .ddi for one TU.
         // -E -M -MM -MF gives us the dep file; -fdeps-* gives us the .ddi.
         append("rule cxx_scan\n");
-        append("  command = $cxx $cxxflags -fdeps-format=p1689r5 "
+        append("  command = $toolenv $cxx $cxxflags -fdeps-format=p1689r5 "
                "-fdeps-file=$out -fdeps-target=$compile_target "
                "-M -MM -MF $out.dep -E $in -o $compile_target\n");
         append("  description = SCAN $out\n\n");
@@ -268,10 +281,13 @@ std::string emit_ninja_string(const BuildPlan& plan) {
     auto std_bmi_dst = std::filesystem::path("gcm.cache") / "std.gcm";
     auto std_o_dst = std::filesystem::path("obj") / "std.o";
 
-    append(std::format("build {} : cp_bmi {}\n", escape_ninja_path(std_bmi_dst),
-                       escape_ninja_path(plan.stdBmiPath)));
-    append(std::format("build {} : cp_bmi {}\n\n", escape_ninja_path(std_o_dst),
-                       escape_ninja_path(plan.stdObjectPath)));
+    bool has_std_artifacts = !plan.stdBmiPath.empty() && !plan.stdObjectPath.empty();
+    if (has_std_artifacts) {
+        append(std::format("build {} : cp_bmi {}\n", escape_ninja_path(std_bmi_dst),
+                           escape_ninja_path(plan.stdBmiPath)));
+        append(std::format("build {} : cp_bmi {}\n\n", escape_ninja_path(std_o_dst),
+                           escape_ninja_path(plan.stdObjectPath)));
+    }
 
     auto bmi_path = [](std::string_view name) {
         std::string s = "gcm.cache/";
@@ -366,7 +382,8 @@ std::string emit_ninja_string(const BuildPlan& plan) {
             if (rule != "c_object") {
                 for (auto& imp : cu.imports) {
                     if (imp == "std" || imp == "std.compat") {
-                        implicit += " gcm.cache/std.gcm";
+                        if (has_std_artifacts)
+                            implicit += " gcm.cache/std.gcm";
                         continue;
                     }
                     implicit += " " + bmi_path(imp);
@@ -397,14 +414,16 @@ std::string emit_ninja_string(const BuildPlan& plan) {
         switch (lu.kind) {
             case LinkUnit::Binary:
             case LinkUnit::TestBinary:
-                ins += " " + escape_ninja_path(std_o_dst);
+                if (has_std_artifacts)
+                    ins += " " + escape_ninja_path(std_o_dst);
                 rule = "cxx_link";
                 break;
             case LinkUnit::StaticLibrary:
                 rule = "cxx_archive";
                 break;
             case LinkUnit::SharedLibrary:
-                ins += " " + escape_ninja_path(std_o_dst);
+                if (has_std_artifacts)
+                    ins += " " + escape_ninja_path(std_o_dst);
                 rule = "cxx_shared";
                 break;
         }

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -21,6 +21,7 @@ import mcpp.modgraph.scanner;
 import mcpp.modgraph.validate;
 import mcpp.toolchain.detect;
 import mcpp.toolchain.fingerprint;
+import mcpp.toolchain.registry;
 import mcpp.toolchain.stdmod;
 import mcpp.build.plan;
 import mcpp.build.backend;
@@ -438,34 +439,6 @@ mcpp::ui::PathContext make_path_ctx(const mcpp::config::GlobalConfig* cfg,
     if (cfg) ctx.mcpp_home = cfg->mcppHome;
     if (auto* h = std::getenv("HOME"); h && *h) ctx.home = h;
     return ctx;
-}
-
-// Toolchain frontend lookup. Different xim packages ship the C++ frontend
-// under different binary names — `gcc` ships `g++`, `musl-gcc` only ships
-// the triple-prefixed `x86_64-linux-musl-g++`, etc. Returns the path to
-// the frontend, or empty if none of the known candidates exist.
-std::filesystem::path
-toolchain_frontend(const std::filesystem::path& binDir,
-                   std::string_view compiler)
-{
-    std::vector<std::string> cands;
-    if (compiler == "musl-gcc") {
-        cands = {"x86_64-linux-musl-g++", "g++"};
-    } else if (compiler == "gcc") {
-        cands = {"g++"};
-    } else if (compiler == "clang" || compiler == "llvm") {
-        cands = {"clang++"};
-    } else if (compiler == "msvc") {
-        cands = {"cl.exe"};
-    } else {
-        // Unknown xpkg — try each in priority order.
-        cands = {"g++", "clang++", "x86_64-linux-musl-g++", "cl.exe"};
-    }
-    for (auto& c : cands) {
-        auto p = binDir / c;
-        if (std::filesystem::exists(p)) return p;
-    }
-    return {};
 }
 
 // Stateless adapter from `mcpp::config::BootstrapProgress` (xlings
@@ -1087,33 +1060,13 @@ prepare_build(bool print_fingerprint,
     if (overrides.force_static) m->buildConfig.linkage = "static";
 
     if (tcSpec.has_value() && *tcSpec != "system") {
-        // Parse "<pkg>@<version>" with an optional "-musl" libc suffix on
-        // the version: "gcc@15.1.0" or "gcc@15.1.0-musl".
-        auto at = tcSpec->find('@');
-        if (at == std::string::npos) {
+        auto spec = mcpp::toolchain::parse_toolchain_spec(*tcSpec);
+        if (!spec || spec->version.empty()) {
             return std::unexpected(std::format(
                 "[toolchain].{} = '{}' is invalid; expected '<pkg>@<version>'",
                 kCurrentPlatform, *tcSpec));
         }
-        auto compiler = tcSpec->substr(0, at);
-        auto version  = tcSpec->substr(at + 1);
-        // Strip xim: prefix if user wrote it explicitly
-        std::string indexedCompiler = compiler;
-        if (auto colon = compiler.find(':'); colon != std::string::npos)
-            indexedCompiler = compiler.substr(colon + 1);
-        std::string ximCompiler = (indexedCompiler == "clang") ? "llvm" : indexedCompiler;
-
-        // libc suffix: `gcc@15.1.0-musl` → xim package `xim:musl-gcc@15.1.0`,
-        // binary at `<root>/bin/x86_64-linux-musl-g++`.
-        bool isMusl = endswith(version, "-musl");
-        std::string ximName = ximCompiler;
-        std::string ximVersion = version;
-        if (isMusl) {
-            ximVersion = version.substr(0, version.size() - 5); // drop "-musl"
-            ximName    = "musl-" + ximCompiler;                 // gcc → musl-gcc
-        }
-
-        std::string target = std::format("xim:{}@{}", ximName, ximVersion);
+        auto pkg = mcpp::toolchain::to_xim_package(*spec);
 
         auto cfg = get_cfg();
         if (!cfg) return std::unexpected(cfg.error());
@@ -1121,24 +1074,17 @@ prepare_build(bool print_fingerprint,
 
         mcpp::ui::info("Resolving", "toolchain");
         CliInstallProgress progress;
-        auto payload = fetcher.resolve_xpkg_path(target, /*autoInstall=*/true, &progress);
+        auto payload = fetcher.resolve_xpkg_path(pkg.target(), /*autoInstall=*/true, &progress);
         if (!payload) {
             return std::unexpected(std::format(
                 "toolchain '{}': {}", *tcSpec, payload.error().message));
         }
 
-        std::string binary_name = "g++";
-        if      (indexedCompiler == "llvm" || indexedCompiler == "clang") binary_name = "clang++";
-        else if (indexedCompiler == "msvc")                                binary_name = "cl.exe";
-        if (isMusl) {
-            // musl-gcc xpkg ships only the triple-prefixed frontends.
-            binary_name = "x86_64-linux-musl-g++";
-        }
-        explicit_compiler = payload->binDir / binary_name;
+        explicit_compiler = mcpp::toolchain::toolchain_frontend(payload->binDir, pkg);
         if (!std::filesystem::exists(explicit_compiler)) {
             return std::unexpected(std::format(
-                "toolchain payload '{}' has no '{}' (looked at {})",
-                target, binary_name, explicit_compiler.string()));
+                "toolchain payload '{}' has no known C++ frontend in {}",
+                pkg.target(), payload->binDir.string()));
         }
         mcpp::ui::info("Resolved",
             std::format("{} → {}", *tcSpec,
@@ -1164,6 +1110,8 @@ prepare_build(bool print_fingerprint,
         // pin it as the global default so the next invocation is silent.
         // Users can switch any time via `mcpp toolchain default <spec>`.
         std::string defaultSpec = "gcc@15.1.0-musl";
+        auto defaultParsed = mcpp::toolchain::parse_toolchain_spec(defaultSpec);
+        auto defaultPkg = mcpp::toolchain::to_xim_package(*defaultParsed);
 
         mcpp::ui::info("First run",
             std::format("no toolchain configured — installing {} (musl, static) as default",
@@ -1173,14 +1121,8 @@ prepare_build(bool print_fingerprint,
         if (!cfg) return std::unexpected(cfg.error());
         mcpp::fetcher::Fetcher fetcher(**cfg);
 
-        // gcc@15.1.0-musl → xim:musl-gcc@15.1.0; binary at
-        // <root>/bin/x86_64-linux-musl-g++. (Same translation `cmd_toolchain`
-        // and the build path apply.)
-        std::string ximTarget    = "xim:musl-gcc@15.1.0";
-        std::string ximBinaryRel = "x86_64-linux-musl-g++";
-
         CliInstallProgress progress;
-        auto payload = fetcher.resolve_xpkg_path(ximTarget,
+        auto payload = fetcher.resolve_xpkg_path(defaultPkg.target(),
                             /*autoInstall=*/true, &progress);
         if (!payload) {
             return std::unexpected(std::format(
@@ -1189,11 +1131,11 @@ prepare_build(bool print_fingerprint,
                 "         mcpp toolchain install gcc 15.1.0-musl",
                 defaultSpec, payload.error().message));
         }
-        explicit_compiler = payload->binDir / ximBinaryRel;
+        explicit_compiler = mcpp::toolchain::toolchain_frontend(payload->binDir, defaultPkg);
         if (!std::filesystem::exists(explicit_compiler)) {
             return std::unexpected(std::format(
-                "default toolchain payload {} has no {} at {}",
-                ximTarget, ximBinaryRel, explicit_compiler.string()));
+                "default toolchain payload {} has no known C++ frontend in {}",
+                defaultPkg.target(), payload->binDir.string()));
         }
 
         // Persist the default so we don't ask again next time.
@@ -2975,28 +2917,6 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
     auto xlEnv = mcpp::config::make_xlings_env(*cfg);
 
     if (subname == "list") {
-        // `gcc 15.1.0-musl` and `musl-gcc@15.1.0` describe the same xpkg
-        // (xim-x-musl-gcc/15.1.0) — match either user-form against the
-        // currently-configured default for the `*` marker.
-        auto matches_default = [&](std::string_view compiler,
-                                   std::string_view version) {
-            const auto& d = cfg->defaultToolchain;
-            if (d == std::format("{}@{}", compiler, version)) return true;
-            if (compiler == "musl-gcc"
-                && d == std::format("gcc@{}-musl", version)) return true;
-            return false;
-        };
-
-        // User-facing label for an xpkg row: `gcc 15.1.0-musl` reads more
-        // naturally than `musl-gcc 15.1.0` and matches the toolchain spec
-        // the rest of the CLI accepts.
-        auto display_label = [](std::string_view compiler,
-                                std::string_view version) {
-            if (compiler == "musl-gcc")
-                return std::format("gcc {}-musl", version);
-            return std::format("{} {}", compiler, version);
-        };
-
         auto pathCtx = make_path_ctx(&*cfg);
         struct Row {
             std::string compiler;
@@ -3014,13 +2934,15 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
                 if (auto sep = name.find("-x-"); sep != std::string::npos)
                     compiler = name.substr(sep + 3);
                 for (auto& vEntry : std::filesystem::directory_iterator(entry.path(), ec)) {
-                    auto bin = toolchain_frontend(vEntry.path() / "bin", compiler);
+                    auto bin = mcpp::toolchain::toolchain_frontend(
+                        vEntry.path() / "bin", compiler);
                     if (bin.empty()) continue;
                     Row r;
                     r.compiler  = compiler;
                     r.version   = vEntry.path().filename().string();
                     r.bin       = bin;
-                    r.isDefault = matches_default(r.compiler, r.version);
+                    r.isDefault = mcpp::toolchain::matches_default_toolchain(
+                        cfg->defaultToolchain, r.compiler, r.version);
                     installed.push_back(std::move(r));
                 }
             }
@@ -3035,7 +2957,7 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
             for (auto& r : installed) {
                 std::println("  {:<3}{:<22}  {}",
                     r.isDefault ? "*" : "",
-                    display_label(r.compiler, r.version),
+                    mcpp::toolchain::display_label(r.compiler, r.version),
                     mcpp::ui::shorten_path(r.bin, pathCtx));
             }
         }
@@ -3060,9 +2982,8 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
                 if (!already) avail.push_back({std::string(compiler), v});
             }
         };
-        add_avail("gcc",      "gcc");
-        add_avail("musl-gcc", "musl-gcc");
-        add_avail("llvm",     "llvm");
+        for (auto& [ximName, compiler] : mcpp::toolchain::available_toolchain_indexes())
+            add_avail(ximName, compiler);
 
         if (!avail.empty()) {
             // Newest first. Lexicographic-on-strings is good enough for
@@ -3077,7 +2998,8 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
             std::println("Available (run `mcpp toolchain install <compiler> <version>`):");
             std::println("  {:<3}{}", "", "TOOLCHAIN");
             for (auto& a : avail) {
-                std::println("  {:<3}{}", "", display_label(a.compiler, a.version));
+                std::println("  {:<3}{}", "",
+                    mcpp::toolchain::display_label(a.compiler, a.version));
             }
         }
         return 0;
@@ -3088,66 +3010,42 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
         //   mcpp toolchain install gcc 16.1.0      → ("gcc", "16.1.0")
         //   mcpp toolchain install gcc@16.1.0      → ("gcc", "16.1.0")
         //   mcpp toolchain install gcc 15          → ("gcc", "15")  partial
-        std::string compiler = sub_parsed.positional(0);
-        std::string version  = sub_parsed.positional(1);
-        if (auto at = compiler.find('@'); at != std::string::npos) {
-            if (version.empty()) version = compiler.substr(at + 1);
-            compiler = compiler.substr(0, at);
-        }
-        if (compiler.empty()) {
+        auto spec = mcpp::toolchain::parse_toolchain_spec(
+            sub_parsed.positional(0), sub_parsed.positional(1));
+        if (!spec || spec->compiler.empty()) {
             mcpp::ui::error("missing compiler name; e.g. `mcpp toolchain install gcc 16.1.0`");
             return 2;
         }
-
-        // Accept both spelling forms for the musl flavor:
-        //   mcpp toolchain install musl-gcc 15.1.0
-        //   mcpp toolchain install gcc      15.1.0-musl
-        // and translate either into the underlying xim package.
-        bool isMusl = (compiler == "musl-gcc")
-                   || (version.size() > 5
-                       && version.compare(version.size() - 5, 5, "-musl") == 0);
-        std::string ximName    = (compiler == "clang") ? "llvm" : compiler;
-        std::string ximVersion = version;
-        if (isMusl) {
-            if (compiler != "musl-gcc") ximName = "musl-" + ximName;   // gcc → musl-gcc
-            if (ximVersion.size() > 5
-                && ximVersion.compare(ximVersion.size() - 5, 5, "-musl") == 0)
-                ximVersion.resize(ximVersion.size() - 5);
-        }
+        auto pkg = mcpp::toolchain::to_xim_package(*spec);
 
         // Partial-version resolution: `gcc 15` → highest available 15.x.y in
         // the synced index. Empty version → latest of any major.
         if (auto picked = resolve_version_match(
-                ximVersion, list_available_xpkg_versions(*cfg, ximName))) {
-            if (*picked != ximVersion) {
+                pkg.ximVersion, list_available_xpkg_versions(*cfg, pkg.ximName))) {
+            if (*picked != pkg.ximVersion) {
                 mcpp::ui::info("Resolved",
-                    std::format("{}@{} → {}@{}", compiler, version, compiler, *picked));
+                    std::format("{}@{} → {}@{}", spec->compiler, spec->version,
+                                spec->compiler, *picked));
             }
-            ximVersion = *picked;
-            // Reflect the concrete version back into the user-facing label
-            // so the "Installed gcc@<ver>" line shows the real version.
-            version = ximVersion + (isMusl ? "-musl" : "");
+            spec = mcpp::toolchain::with_resolved_xim_version(*spec, *picked);
+            pkg = mcpp::toolchain::to_xim_package(*spec);
         }
 
-        std::string spec = std::format("xim:{}@{}", ximName, ximVersion);
-
-        mcpp::ui::info("Installing", std::format("{} {} via mcpp's xlings", compiler, version));
+        mcpp::ui::info("Installing",
+            std::format("{} {} via mcpp's xlings", spec->compiler, spec->version));
         mcpp::fetcher::Fetcher fetcher(*cfg);
         CliInstallProgress progress;
-        auto payload = fetcher.resolve_xpkg_path(spec, /*autoInstall=*/true, &progress);
+        auto payload = fetcher.resolve_xpkg_path(pkg.target(), /*autoInstall=*/true, &progress);
         if (!payload) {
             mcpp::ui::error(std::format("install failed: {}", payload.error().message));
             return 1;
         }
 
-        std::string bn = "g++";
-        if      (compiler == "llvm" || compiler == "clang") bn = "clang++";
-        else if (compiler == "msvc")                         bn = "cl.exe";
-        if (isMusl) bn = "x86_64-linux-musl-g++";
-        auto bin = payload->binDir / bn;
+        auto bin = mcpp::toolchain::toolchain_frontend(payload->binDir, pkg);
         if (!std::filesystem::exists(bin)) {
             mcpp::ui::error(std::format(
-                "installed package has no '{}' at '{}'", bn, bin.string()));
+                "installed package has no known C++ frontend in '{}'",
+                payload->binDir.string()));
             return 1;
         }
 
@@ -3161,7 +3059,7 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
         // musl-gcc ships its own self-contained sysroot at
         // `<root>/x86_64-linux-musl/{include,lib}` and doesn't link against
         // xim:glibc, so this fixup is both unnecessary and harmful for it.
-        if (compiler == "gcc" && !isMusl) {
+        if (pkg.needsGccPostInstallFixup) {
             auto glibcRoot = mcpp::xlings::paths::xim_tool_root(xlEnv, "glibc");
             std::filesystem::path glibcLibDir;
             if (std::filesystem::exists(glibcRoot)) {
@@ -3202,11 +3100,12 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
             }
         }
 
-        mcpp::ui::status("Installed", std::format("{}@{} → {}", compiler, version, bin.string()));
+        mcpp::ui::status("Installed",
+            std::format("{} → {}", pkg.display_spec(), bin.string()));
         if (cfg->defaultToolchain.empty()) {
             std::println("");
             std::println("Tip: `mcpp toolchain default {}@{}` to make this the default.",
-                         compiler, version);
+                         spec->compiler, spec->version);
         }
         return 0;
     }
@@ -3216,69 +3115,52 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
         //   mcpp toolchain default gcc@16.1.0
         //   mcpp toolchain default gcc 16.1.0
         //   mcpp toolchain default gcc 15        ← partial; picks highest 15.x.y
-        std::string compiler = sub_parsed.positional(0);
-        std::string version  = sub_parsed.positional(1);
-        if (auto at = compiler.find('@'); at != std::string::npos) {
-            if (version.empty()) version = compiler.substr(at + 1);
-            compiler = compiler.substr(0, at);
-        }
-        if (compiler.empty()) {
+        auto spec = mcpp::toolchain::parse_toolchain_spec(
+            sub_parsed.positional(0), sub_parsed.positional(1));
+        if (!spec || spec->compiler.empty()) {
             mcpp::ui::error("missing spec; e.g. `mcpp toolchain default gcc@16.1.0`");
             return 2;
         }
-
-        std::string ximName    = (compiler == "clang") ? "llvm" : compiler;
-        std::string ximVersion = version;
-        bool isMusl = (compiler == "musl-gcc")
-                   || (version.size() > 5
-                       && version.compare(version.size() - 5, 5, "-musl") == 0);
-        if (isMusl) {
-            if (compiler != "musl-gcc") ximName = "musl-" + ximName;
-            if (ximVersion.size() > 5
-                && ximVersion.compare(ximVersion.size() - 5, 5, "-musl") == 0)
-                ximVersion.resize(ximVersion.size() - 5);
-        }
+        auto pkg = mcpp::toolchain::to_xim_package(*spec);
 
         // Partial-version resolution against installed payloads.
         if (auto picked = resolve_version_match(
-                ximVersion, list_installed_versions(pkgsDir, ximName))) {
-            ximVersion = *picked;
+                pkg.ximVersion, list_installed_versions(pkgsDir, pkg.ximName))) {
+            spec = mcpp::toolchain::with_resolved_xim_version(*spec, *picked);
+            pkg = mcpp::toolchain::to_xim_package(*spec);
         }
 
         // Reconstruct the user-visible spec for messages / config.toml.
-        std::string spec = isMusl
-            ? std::format("{}@{}-musl",
-                  compiler == "musl-gcc" ? "musl-gcc" : compiler, ximVersion)
-            : std::format("{}@{}", compiler, ximVersion);
+        std::string displaySpec = pkg.display_spec();
 
-        auto installDir = mcpp::xlings::paths::xim_tool(xlEnv, ximName, ximVersion);
+        auto installDir = mcpp::xlings::paths::xim_tool(xlEnv, pkg.ximName, pkg.ximVersion);
         if (!std::filesystem::exists(installDir)) {
             mcpp::ui::error(std::format(
                 "{} is not installed. Run `mcpp toolchain install {} {}` first.",
-                spec, compiler, version.empty() ? ximVersion : version));
+                displaySpec, spec->compiler,
+                spec->version.empty() ? pkg.ximVersion : spec->version));
             return 1;
         }
-        auto wr = mcpp::config::write_default_toolchain(*cfg, spec);
+        auto wr = mcpp::config::write_default_toolchain(*cfg, displaySpec);
         if (!wr) {
             mcpp::ui::error(wr.error().message);
             return 1;
         }
         mcpp::ui::status("Default", std::format(
-            "set to {} (was: {})", spec,
+            "set to {} (was: {})", displaySpec,
             cfg->defaultToolchain.empty() ? "<none>" : cfg->defaultToolchain));
         return 0;
     }
 
     if (subname == "remove") {
-        std::string spec = sub_parsed.positional(0);
-        auto at = spec.find('@');
-        if (at == std::string::npos) {
-            mcpp::ui::error(std::format("invalid spec '{}'", spec));
+        auto parsedSpec = mcpp::toolchain::parse_toolchain_spec(sub_parsed.positional(0));
+        if (!parsedSpec || parsedSpec->version.empty()) {
+            mcpp::ui::error(std::format("invalid spec '{}'", sub_parsed.positional(0)));
             return 2;
         }
-        std::string compiler = spec.substr(0, at);
-        std::string version  = spec.substr(at + 1);
-        auto installDir = mcpp::xlings::paths::xim_tool(xlEnv, compiler, version);
+        auto pkg = mcpp::toolchain::to_xim_package(*parsedSpec);
+        auto spec = pkg.display_spec();
+        auto installDir = mcpp::xlings::paths::xim_tool(xlEnv, pkg.ximName, pkg.ximVersion);
         std::error_code ec;
         if (!std::filesystem::exists(installDir, ec)) {
             mcpp::ui::error(std::format("{} is not installed", spec));

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -592,6 +592,66 @@ std::string canonical_compile_flags(const mcpp::manifest::Manifest& m) {
     return s;
 }
 
+bool is_std_module(std::string_view name) {
+    return name == "std" || name == "std.compat";
+}
+
+std::string trim_copy(std::string s) {
+    while (!s.empty() && std::isspace(static_cast<unsigned char>(s.front())))
+        s.erase(0, 1);
+    while (!s.empty() && std::isspace(static_cast<unsigned char>(s.back())))
+        s.pop_back();
+    return s;
+}
+
+bool source_file_imports_std(const std::filesystem::path& path) {
+    std::ifstream is(path);
+    if (!is) return false;
+
+    std::string line;
+    while (std::getline(is, line)) {
+        line = trim_copy(std::move(line));
+        std::size_t i = std::string::npos;
+        if (line.starts_with("import ")) {
+            i = 7;
+        } else if (line.starts_with("export import ")) {
+            i = 14;
+        }
+        if (i == std::string::npos) continue;
+        while (i < line.size() && std::isspace(static_cast<unsigned char>(line[i])))
+            ++i;
+
+        std::string name;
+        while (i < line.size()
+            && (std::isalnum(static_cast<unsigned char>(line[i]))
+                || line[i] == '_' || line[i] == '.' || line[i] == ':')) {
+            name.push_back(line[i]);
+            ++i;
+        }
+        if (is_std_module(name)) return true;
+    }
+    return false;
+}
+
+bool graph_or_targets_import_std(const mcpp::modgraph::Graph& graph,
+                                 const mcpp::manifest::Manifest& manifest,
+                                 const std::filesystem::path& projectRoot) {
+    for (auto& u : graph.units) {
+        for (auto& req : u.requires_) {
+            if (is_std_module(req.logicalName))
+                return true;
+        }
+    }
+
+    // Some target entry files can be added to the plan after the package scan.
+    // Check them here so std BMI setup matches what make_plan will compile.
+    for (auto& t : manifest.targets) {
+        if (!t.main.empty() && source_file_imports_std(projectRoot / t.main))
+            return true;
+    }
+    return false;
+}
+
 // Run patchelf on every dynamic ELF in `dir` (recursively):
 //   - Set PT_INTERP to `loader` (the sandbox-local glibc loader).
 //   - Set RUNPATH to `rpath` (colon-separated list of sandbox lib dirs).
@@ -1039,15 +1099,16 @@ prepare_build(bool print_fingerprint,
         std::string indexedCompiler = compiler;
         if (auto colon = compiler.find(':'); colon != std::string::npos)
             indexedCompiler = compiler.substr(colon + 1);
+        std::string ximCompiler = (indexedCompiler == "clang") ? "llvm" : indexedCompiler;
 
         // libc suffix: `gcc@15.1.0-musl` → xim package `xim:musl-gcc@15.1.0`,
         // binary at `<root>/bin/x86_64-linux-musl-g++`.
         bool isMusl = endswith(version, "-musl");
-        std::string ximName = indexedCompiler;
+        std::string ximName = ximCompiler;
         std::string ximVersion = version;
         if (isMusl) {
             ximVersion = version.substr(0, version.size() - 5); // drop "-musl"
-            ximName    = "musl-" + indexedCompiler;             // gcc → musl-gcc
+            ximName    = "musl-" + ximCompiler;                 // gcc → musl-gcc
         }
 
         std::string target = std::format("xim:{}@{}", ximName, ximVersion);
@@ -1172,12 +1233,6 @@ prepare_build(bool print_fingerprint,
                 tc->sysroot = mcppSubos;
             }
         }
-    }
-
-    if (m->language.importStd && !tc->hasImportStd) {
-        return std::unexpected(std::format(
-            "manifest requires import_std but toolchain '{}' provides no std module source",
-            tc->label()));
     }
 
     // Resolve dependencies: walk the **transitive** graph from the main
@@ -1934,6 +1989,13 @@ prepare_build(bool print_fingerprint,
         return std::unexpected(msg);
     }
 
+    bool needsStdModule = graph_or_targets_import_std(scan.graph, *m, *root);
+    if (needsStdModule && !tc->hasImportStd) {
+        return std::unexpected(std::format(
+            "source imports std but toolchain '{}' provides no std module source",
+            tc->label()));
+    }
+
     // Compute fingerprint (no lockfile in M1 → empty hash)
     mcpp::toolchain::FingerprintInputs fpi;
     fpi.toolchain            = *tc;
@@ -1943,9 +2005,15 @@ prepare_build(bool print_fingerprint,
     fpi.stdBmiHash         = "";    // updated after stdmod build (chicken/egg ok for M1)
     auto fp = mcpp::toolchain::compute_fingerprint(fpi);
 
-    // Pre-build std module
-    auto sm = mcpp::toolchain::ensure_built(*tc, fp.hex);
-    if (!sm) return std::unexpected(sm.error().message);
+    // Pre-build std module only when the source graph actually imports it.
+    std::filesystem::path stdBmiPath;
+    std::filesystem::path stdObjectPath;
+    if (needsStdModule) {
+        auto sm = mcpp::toolchain::ensure_built(*tc, fp.hex);
+        if (!sm) return std::unexpected(sm.error().message);
+        stdBmiPath = sm->bmiPath;
+        stdObjectPath = sm->objectPath;
+    }
 
     if (print_fingerprint) {
         std::println("Toolchain: {}", tc->label());
@@ -1961,10 +2029,10 @@ prepare_build(bool print_fingerprint,
     ctx.fp          = fp;
     ctx.projectRoot= *root;
     ctx.outputDir  = target_dir(*tc, fp, *root);
-    ctx.stdBmi     = sm->bmiPath;
-    ctx.stdObject  = sm->objectPath;
+    ctx.stdBmi     = stdBmiPath;
+    ctx.stdObject  = stdObjectPath;
     ctx.plan        = mcpp::build::make_plan(*m, *tc, fp, scan.graph, report.topoOrder,
-                                             *root, ctx.outputDir, sm->bmiPath, sm->objectPath);
+                                             *root, ctx.outputDir, stdBmiPath, stdObjectPath);
 
     // ─── M3.2: BMI cache stage / populate-task collection ─────────────
     // For each version-based dep package (i.e. fetched from a registry,
@@ -2979,6 +3047,7 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
         };
         add_avail("gcc",      "gcc");
         add_avail("musl-gcc", "musl-gcc");
+        add_avail("llvm",     "llvm");
 
         if (!avail.empty()) {
             // Newest first. Lexicographic-on-strings is good enough for
@@ -3022,10 +3091,10 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
         bool isMusl = (compiler == "musl-gcc")
                    || (version.size() > 5
                        && version.compare(version.size() - 5, 5, "-musl") == 0);
-        std::string ximName    = compiler;
+        std::string ximName    = (compiler == "clang") ? "llvm" : compiler;
         std::string ximVersion = version;
         if (isMusl) {
-            if (compiler != "musl-gcc") ximName = "musl-" + compiler;   // gcc → musl-gcc
+            if (compiler != "musl-gcc") ximName = "musl-" + ximName;   // gcc → musl-gcc
             if (ximVersion.size() > 5
                 && ximVersion.compare(ximVersion.size() - 5, 5, "-musl") == 0)
                 ximVersion.resize(ximVersion.size() - 5);
@@ -3143,13 +3212,13 @@ int cmd_toolchain(const mcpplibs::cmdline::ParsedArgs& parsed) {
             return 2;
         }
 
-        std::string ximName    = compiler;
+        std::string ximName    = (compiler == "clang") ? "llvm" : compiler;
         std::string ximVersion = version;
         bool isMusl = (compiler == "musl-gcc")
                    || (version.size() > 5
                        && version.compare(version.size() - 5, 5, "-musl") == 0);
         if (isMusl) {
-            if (compiler != "musl-gcc") ximName = "musl-" + compiler;
+            if (compiler != "musl-gcc") ximName = "musl-" + ximName;
             if (ximVersion.size() > 5
                 && ximVersion.compare(ximVersion.size() - 5, 5, "-musl") == 0)
                 ximVersion.resize(ximVersion.size() - 5);

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -90,6 +90,7 @@ void print_usage() {
     std::println("About mcpp itself:");
     std::println("  mcpp self doctor                     Diagnose mcpp environment health");
     std::println("  mcpp self env                        Print mcpp paths and toolchain");
+    std::println("  mcpp self config [--mirror CN|GLOBAL] Show or modify mcpp's xlings config");
     std::println("  mcpp self version                    Show mcpp version");
     std::println("  mcpp self explain <CODE>             Show extended description for an error code");
     std::println("  mcpp --help / --version              Help / version");
@@ -3610,6 +3611,43 @@ int cmd_self_version(const mcpplibs::cmdline::ParsedArgs& /*parsed*/) {
     return 0;
 }
 
+std::string upper_ascii(std::string s) {
+    for (char& ch : s) {
+        if (ch >= 'a' && ch <= 'z') ch = static_cast<char>(ch - 'a' + 'A');
+    }
+    return s;
+}
+
+int cmd_self_config(const mcpplibs::cmdline::ParsedArgs& parsed) {
+    auto cfg = mcpp::config::load_or_init(/*quiet=*/false, make_bootstrap_progress_callback());
+    if (!cfg) {
+        mcpp::ui::error(cfg.error().message);
+        return 4;
+    }
+
+    auto env = mcpp::config::make_xlings_env(*cfg);
+    auto mirror = parsed.option_or_empty("mirror").value();
+    if (mirror.empty()) {
+        auto rc = mcpp::xlings::config_show(env);
+        return rc == 0 ? 0 : 1;
+    }
+
+    mirror = upper_ascii(std::move(mirror));
+    if (mirror != "CN" && mirror != "GLOBAL") {
+        mcpp::ui::error(std::format(
+            "invalid mirror '{}'; expected CN or GLOBAL", mirror));
+        return 2;
+    }
+
+    auto rc = mcpp::xlings::config_set_mirror(env, mirror, /*quiet=*/true);
+    if (rc != 0) {
+        mcpp::ui::error(std::format("failed to set xlings mirror to {}", mirror));
+        return 1;
+    }
+    mcpp::ui::status("Configured", std::format("xlings mirror = {}", mirror));
+    return 0;
+}
+
 // Used both by `mcpp explain <CODE>` (top-level) and `mcpp self explain
 // <CODE>` (legacy alias).
 int cmd_explain_action(const mcpplibs::cmdline::ParsedArgs& parsed) {
@@ -3925,6 +3963,10 @@ int run(int argc, char** argv) {
                 .description("Diagnose mcpp environment health"))
             .subcommand(cl::App("env")
                 .description("Print mcpp paths and configuration"))
+            .subcommand(cl::App("config")
+                .description("Show or modify mcpp's private xlings configuration")
+                .option(cl::Option("mirror").takes_value().value_name("CN|GLOBAL")
+                    .help("Set xlings mirror for mcpp's private registry")))
             .subcommand(cl::App("version")
                 .description("Show mcpp version"))
             .subcommand(cl::App("explain")
@@ -3934,6 +3976,7 @@ int run(int argc, char** argv) {
                 return dispatch_sub("self", p, {
                     {"doctor",  cmd_doctor},
                     {"env",     cmd_env},
+                    {"config",  cmd_self_config},
                     {"version", cmd_self_version},
                     {"explain", cmd_explain_action},
                 });

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -35,6 +35,7 @@ import mcpp.pm.resolver;   // PR-R4: extracted from cli.cppm
 import mcpp.pm.commands;   // PR-R5: cmd_add / cmd_remove / cmd_update live here now
 import mcpp.pm.mangle;     // Level 1 multi-version fallback (cross-major coexistence)
 import mcpp.pm.compat;     // 0.0.6: namespace field + dotted-name compat shims
+import mcpp.pm.dep_spec;
 import mcpp.ui;
 import mcpp.bmi_cache;
 import mcpp.dyndep;
@@ -1348,9 +1349,22 @@ prepare_build(bool print_fingerprint,
             auto fqname = ns.empty() ? shortName
                 : std::format("{}.{}", ns, shortName);
             mcpp::ui::info("Downloading", std::format("{} v{}", fqname, version));
-            std::vector<std::string> targets{ std::format("{}@{}", fqname, version) };
-            CliInstallProgress progress;
-            auto r = fetcher.install(targets, &progress);
+            auto install_one = [&](std::string target) {
+                std::vector<std::string> targets{ std::move(target) };
+                CliInstallProgress progress;
+                return fetcher.install(targets, &progress);
+            };
+            auto target = std::format("{}@{}", fqname, version);
+            auto r = install_one(target);
+            if (r && r->exitCode != 0 &&
+                (ns.empty() || ns == mcpp::pm::kDefaultNamespace)) {
+                auto compatTarget = std::format("compat.{}@{}", shortName, version);
+                if (compatTarget != target) {
+                    mcpp::ui::info("Downloading", std::format("{} v{}",
+                                     std::format("compat.{}", shortName), version));
+                    r = install_one(compatTarget);
+                }
+            }
             if (!r) return std::unexpected(std::format(
                 "fetch '{}@{}': {}", depName, version, r.error().message));
             if (r->exitCode != 0) {

--- a/src/config.cppm
+++ b/src/config.cppm
@@ -46,6 +46,7 @@ struct GlobalConfig {
     // From config.toml [xlings]
     std::string                     xlingsBinaryMode;    // "bundled" | "system" | absolute path
     std::filesystem::path           xlingsHomeOverride;  // empty = use registryDir
+    std::string                     xlingsMirror = "CN"; // "CN" | "GLOBAL" | empty = xlings default
 
     // From config.toml [index]
     std::string                     defaultIndex;        // "mcpplibs"
@@ -174,6 +175,30 @@ void write_file(const std::filesystem::path& p, std::string_view content) {
     os << content;
 }
 
+std::string normalize_xlings_mirror(std::string mirror) {
+    for (char& ch : mirror) {
+        if (ch >= 'a' && ch <= 'z') ch = static_cast<char>(ch - 'a' + 'A');
+    }
+    return mirror;
+}
+
+std::optional<std::string> read_xlings_json_mirror(const std::filesystem::path& path) {
+    std::ifstream is(path);
+    if (!is) return std::nullopt;
+    std::stringstream ss;
+    ss << is.rdbuf();
+    auto content = ss.str();
+    auto key = content.find("\"mirror\"");
+    if (key == std::string::npos) return std::nullopt;
+    auto colon = content.find(':', key);
+    if (colon == std::string::npos) return std::nullopt;
+    auto first = content.find('"', colon + 1);
+    if (first == std::string::npos) return std::nullopt;
+    auto second = content.find('"', first + 1);
+    if (second == std::string::npos) return std::nullopt;
+    return content.substr(first + 1, second - first - 1);
+}
+
 bool write_default_config_toml(const std::filesystem::path& path) {
     constexpr auto tmpl = R"(# mcpp global config — auto-generated; safe to edit.
 
@@ -182,6 +207,8 @@ bool write_default_config_toml(const std::filesystem::path& path) {
 binary = "bundled"
 # home:   empty = use $MCPP_HOME/registry; can override
 home   = ""
+# mirror: "CN" | "GLOBAL" | "" (defer to xlings)
+mirror = "CN"
 
 [index]
 default = "mcpplibs"
@@ -202,7 +229,8 @@ default_backend = "ninja"
 }
 
 bool write_default_xlings_json(const std::filesystem::path& path,
-                               const std::vector<IndexRepo>& repos)
+                               const std::vector<IndexRepo>& repos,
+                               std::string_view mirror)
 {
     // Delegate to xlings module. Convert IndexRepo vec to pair span.
     std::vector<std::pair<std::string,std::string>> pairs;
@@ -212,7 +240,7 @@ bool write_default_xlings_json(const std::filesystem::path& path,
     // construct a temporary Env with home = path.parent_path().
     mcpp::xlings::Env env;
     env.home = path.parent_path();
-    mcpp::xlings::seed_xlings_json(env, pairs);
+    mcpp::xlings::seed_xlings_json(env, pairs, mirror);
     return std::filesystem::exists(path);
 }
 
@@ -356,6 +384,15 @@ std::expected<GlobalConfig, ConfigError> load_or_init(
     cfg.xlingsBinaryMode = doc->get_string("xlings.binary").value_or("bundled");
     if (auto h = doc->get_string("xlings.home"); h && !h->empty())
         cfg.xlingsHomeOverride = *h;
+    cfg.xlingsMirror = normalize_xlings_mirror(
+        doc->get_string("xlings.mirror").value_or("CN"));
+    if (!cfg.xlingsMirror.empty() &&
+        cfg.xlingsMirror != "CN" &&
+        cfg.xlingsMirror != "GLOBAL") {
+        return std::unexpected(ConfigError{
+            std::format("invalid xlings.mirror '{}': expected CN, GLOBAL, or empty",
+                        cfg.xlingsMirror)});
+    }
     cfg.defaultIndex   = doc->get_string("index.default").value_or("mcpplibs");
     cfg.searchTtlSeconds = doc->get_int("cache.search_ttl_seconds").value_or(3600);
     cfg.defaultJobs    = doc->get_int("build.default_jobs").value_or(0);
@@ -387,7 +424,7 @@ std::expected<GlobalConfig, ConfigError> load_or_init(
     // 5. Seed registry/.xlings.json if missing
     auto xjson = cfg.xlingsHome() / ".xlings.json";
     if (!std::filesystem::exists(xjson)) {
-        write_default_xlings_json(xjson, cfg.indexRepos);
+        write_default_xlings_json(xjson, cfg.indexRepos, cfg.xlingsMirror);
     }
 
     // 6. Acquire xlings binary if needed
@@ -406,6 +443,15 @@ std::expected<GlobalConfig, ConfigError> load_or_init(
         if (!std::filesystem::exists(cfg.xlingsBinary))
             return std::unexpected(ConfigError{std::format(
                 "configured xlings binary not found: {}", cfg.xlingsBinary.string())});
+    }
+
+    if (!cfg.xlingsMirror.empty() &&
+        read_xlings_json_mirror(xjson).value_or("") != cfg.xlingsMirror) {
+        auto rc = mcpp::xlings::set_mirror(make_xlings_env(cfg), cfg.xlingsMirror, true);
+        if (rc != 0 && !quiet) {
+            std::println(stderr,
+                "warning: failed to set xlings mirror to '{}'", cfg.xlingsMirror);
+        }
     }
 
     // 7. Sandbox bootstrap (mcpp self-contained xlings environment).
@@ -429,6 +475,8 @@ void print_env(const GlobalConfig& cfg) {
     std::println("MCPP_HOME           = {}", cfg.mcppHome.string());
     std::println("xlings binary       = {}", cfg.xlingsBinary.string());
     std::println("xlings home         = {}", cfg.xlingsHome().string());
+    std::println("xlings mirror       = {}",
+                 cfg.xlingsMirror.empty() ? "(xlings default)" : cfg.xlingsMirror);
     std::println("config              = {}", cfg.configFile.string());
     std::println("BMI cache           = {}", cfg.bmiCacheDir.string());
     std::println("meta cache          = {}", cfg.metaCacheDir.string());

--- a/src/config.cppm
+++ b/src/config.cppm
@@ -216,6 +216,75 @@ bool write_default_xlings_json(const std::filesystem::path& path,
     return std::filesystem::exists(path);
 }
 
+bool replace_all(std::string& text, std::string_view from, std::string_view to) {
+    bool changed = false;
+    for (std::size_t pos = 0;
+         (pos = text.find(from, pos)) != std::string::npos;) {
+        text.replace(pos, from.size(), to);
+        pos += to.size();
+        changed = true;
+    }
+    return changed;
+}
+
+bool write_text_if_changed(const std::filesystem::path& path,
+                           const std::string& original,
+                           const std::string& updated) {
+    if (updated == original) return false;
+    write_file(path, updated);
+    return true;
+}
+
+bool migrate_legacy_config_toml_index_names(const std::filesystem::path& path) {
+    std::ifstream is(path);
+    if (!is) return false;
+    std::stringstream ss;
+    ss << is.rdbuf();
+    auto original = ss.str();
+    auto updated = original;
+
+    replace_all(updated, "default = \"mcpp-index\"", "default = \"mcpplibs\"");
+    replace_all(updated, "[index.repos.\"mcpp-index\"]", "[index.repos.\"mcpplibs\"]");
+
+    return write_text_if_changed(path, original, updated);
+}
+
+bool migrate_legacy_xlings_json_index_names(const std::filesystem::path& path) {
+    std::ifstream is(path);
+    if (!is) return false;
+    std::stringstream ss;
+    ss << is.rdbuf();
+    auto original = ss.str();
+    auto updated = original;
+
+    // Older mcpp sandboxes seeded the package index under the repository
+    // name. Keep the URL and all xlings state intact; only rename the index
+    // key so xlings config/list output matches mcpp's default namespace.
+    replace_all(updated, "\"name\": \"mcpp-index\"", "\"name\": \"mcpplibs\"");
+    replace_all(updated, "\"name\":\"mcpp-index\"", "\"name\":\"mcpplibs\"");
+
+    return write_text_if_changed(path, original, updated);
+}
+
+void canonicalize_legacy_index_names(GlobalConfig& cfg) {
+    if (cfg.defaultIndex == "mcpp-index")
+        cfg.defaultIndex = "mcpplibs";
+
+    std::vector<IndexRepo> normalized;
+    for (auto r : cfg.indexRepos) {
+        if (r.name == "mcpp-index"
+            && r.url == "https://github.com/mcpp-community/mcpp-index.git") {
+            r.name = "mcpplibs";
+        }
+        bool duplicate = std::any_of(normalized.begin(), normalized.end(),
+            [&](const IndexRepo& existing) {
+                return existing.name == r.name && existing.url == r.url;
+            });
+        if (!duplicate) normalized.push_back(std::move(r));
+    }
+    cfg.indexRepos = std::move(normalized);
+}
+
 // Try to acquire xlings binary. Returns the path if successful.
 std::expected<std::filesystem::path, std::string>
 acquire_xlings_binary(const std::filesystem::path& destBin, bool quiet)
@@ -345,6 +414,7 @@ std::expected<GlobalConfig, ConfigError> load_or_init(
     // 3. Seed config.toml if missing
     bool fresh_config = !std::filesystem::exists(cfg.configFile);
     if (fresh_config) write_default_config_toml(cfg.configFile);
+    else migrate_legacy_config_toml_index_names(cfg.configFile);
 
     // 4. Load config.toml
     auto doc = t::parse_file(cfg.configFile);
@@ -383,11 +453,16 @@ std::expected<GlobalConfig, ConfigError> load_or_init(
         cfg.indexRepos.push_back({ std::string(name), std::string(url) });
     };
     add_default("mcpplibs", "https://github.com/mcpp-community/mcpp-index.git");
+    canonicalize_legacy_index_names(cfg);
 
-    // 5. Seed registry/.xlings.json if missing
+    // 5. Seed registry/.xlings.json if missing; migrate legacy cached
+    // sandboxes in place so CI/user caches move from mcpp-index to mcpplibs
+    // without losing xlings' active subos or version bindings.
     auto xjson = cfg.xlingsHome() / ".xlings.json";
     if (!std::filesystem::exists(xjson)) {
         write_default_xlings_json(xjson, cfg.indexRepos);
+    } else {
+        migrate_legacy_xlings_json_index_names(xjson);
     }
 
     // 6. Acquire xlings binary if needed

--- a/src/config.cppm
+++ b/src/config.cppm
@@ -46,7 +46,6 @@ struct GlobalConfig {
     // From config.toml [xlings]
     std::string                     xlingsBinaryMode;    // "bundled" | "system" | absolute path
     std::filesystem::path           xlingsHomeOverride;  // empty = use registryDir
-    std::string                     xlingsMirror = "CN"; // "CN" | "GLOBAL" | empty = xlings default
 
     // From config.toml [index]
     std::string                     defaultIndex;        // "mcpplibs"
@@ -175,30 +174,6 @@ void write_file(const std::filesystem::path& p, std::string_view content) {
     os << content;
 }
 
-std::string normalize_xlings_mirror(std::string mirror) {
-    for (char& ch : mirror) {
-        if (ch >= 'a' && ch <= 'z') ch = static_cast<char>(ch - 'a' + 'A');
-    }
-    return mirror;
-}
-
-std::optional<std::string> read_xlings_json_mirror(const std::filesystem::path& path) {
-    std::ifstream is(path);
-    if (!is) return std::nullopt;
-    std::stringstream ss;
-    ss << is.rdbuf();
-    auto content = ss.str();
-    auto key = content.find("\"mirror\"");
-    if (key == std::string::npos) return std::nullopt;
-    auto colon = content.find(':', key);
-    if (colon == std::string::npos) return std::nullopt;
-    auto first = content.find('"', colon + 1);
-    if (first == std::string::npos) return std::nullopt;
-    auto second = content.find('"', first + 1);
-    if (second == std::string::npos) return std::nullopt;
-    return content.substr(first + 1, second - first - 1);
-}
-
 bool write_default_config_toml(const std::filesystem::path& path) {
     constexpr auto tmpl = R"(# mcpp global config — auto-generated; safe to edit.
 
@@ -207,8 +182,6 @@ bool write_default_config_toml(const std::filesystem::path& path) {
 binary = "bundled"
 # home:   empty = use $MCPP_HOME/registry; can override
 home   = ""
-# mirror: "CN" | "GLOBAL" | "" (defer to xlings)
-mirror = "CN"
 
 [index]
 default = "mcpplibs"
@@ -229,8 +202,7 @@ default_backend = "ninja"
 }
 
 bool write_default_xlings_json(const std::filesystem::path& path,
-                               const std::vector<IndexRepo>& repos,
-                               std::string_view mirror)
+                               const std::vector<IndexRepo>& repos)
 {
     // Delegate to xlings module. Convert IndexRepo vec to pair span.
     std::vector<std::pair<std::string,std::string>> pairs;
@@ -240,7 +212,7 @@ bool write_default_xlings_json(const std::filesystem::path& path,
     // construct a temporary Env with home = path.parent_path().
     mcpp::xlings::Env env;
     env.home = path.parent_path();
-    mcpp::xlings::seed_xlings_json(env, pairs, mirror);
+    mcpp::xlings::seed_xlings_json(env, pairs);
     return std::filesystem::exists(path);
 }
 
@@ -384,15 +356,6 @@ std::expected<GlobalConfig, ConfigError> load_or_init(
     cfg.xlingsBinaryMode = doc->get_string("xlings.binary").value_or("bundled");
     if (auto h = doc->get_string("xlings.home"); h && !h->empty())
         cfg.xlingsHomeOverride = *h;
-    cfg.xlingsMirror = normalize_xlings_mirror(
-        doc->get_string("xlings.mirror").value_or("CN"));
-    if (!cfg.xlingsMirror.empty() &&
-        cfg.xlingsMirror != "CN" &&
-        cfg.xlingsMirror != "GLOBAL") {
-        return std::unexpected(ConfigError{
-            std::format("invalid xlings.mirror '{}': expected CN, GLOBAL, or empty",
-                        cfg.xlingsMirror)});
-    }
     cfg.defaultIndex   = doc->get_string("index.default").value_or("mcpplibs");
     cfg.searchTtlSeconds = doc->get_int("cache.search_ttl_seconds").value_or(3600);
     cfg.defaultJobs    = doc->get_int("build.default_jobs").value_or(0);
@@ -424,7 +387,7 @@ std::expected<GlobalConfig, ConfigError> load_or_init(
     // 5. Seed registry/.xlings.json if missing
     auto xjson = cfg.xlingsHome() / ".xlings.json";
     if (!std::filesystem::exists(xjson)) {
-        write_default_xlings_json(xjson, cfg.indexRepos, cfg.xlingsMirror);
+        write_default_xlings_json(xjson, cfg.indexRepos);
     }
 
     // 6. Acquire xlings binary if needed
@@ -443,15 +406,6 @@ std::expected<GlobalConfig, ConfigError> load_or_init(
         if (!std::filesystem::exists(cfg.xlingsBinary))
             return std::unexpected(ConfigError{std::format(
                 "configured xlings binary not found: {}", cfg.xlingsBinary.string())});
-    }
-
-    if (!cfg.xlingsMirror.empty() &&
-        read_xlings_json_mirror(xjson).value_or("") != cfg.xlingsMirror) {
-        auto rc = mcpp::xlings::set_mirror(make_xlings_env(cfg), cfg.xlingsMirror, true);
-        if (rc != 0 && !quiet) {
-            std::println(stderr,
-                "warning: failed to set xlings mirror to '{}'", cfg.xlingsMirror);
-        }
     }
 
     // 7. Sandbox bootstrap (mcpp self-contained xlings environment).
@@ -475,8 +429,6 @@ void print_env(const GlobalConfig& cfg) {
     std::println("MCPP_HOME           = {}", cfg.mcppHome.string());
     std::println("xlings binary       = {}", cfg.xlingsBinary.string());
     std::println("xlings home         = {}", cfg.xlingsHome().string());
-    std::println("xlings mirror       = {}",
-                 cfg.xlingsMirror.empty() ? "(xlings default)" : cfg.xlingsMirror);
     std::println("config              = {}", cfg.configFile.string());
     std::println("BMI cache           = {}", cfg.bmiCacheDir.string());
     std::println("meta cache          = {}", cfg.metaCacheDir.string());

--- a/src/pm/compat.cppm
+++ b/src/pm/compat.cppm
@@ -189,6 +189,12 @@ inline std::vector<std::string> install_dir_candidates(std::string_view ns,
     // Old index-prefixed layout: <index>-x-<ns>.<shortName>
     candidates.push_back(std::format("{}-x-{}", indexName, fqname));
 
+    // Fallback: compat.<shortName> packages serving default-namespace deps
+    // such as bare `gtest = "1.15.2"`.
+    if (ns.empty() || ns == mcpp::pm::kDefaultNamespace) {
+        candidates.push_back(std::format("compat-x-compat.{}", shortName));
+    }
+
     // Bare short name variants
     if (!ns.empty()) {
         candidates.push_back(std::format("{}-x-{}", ns, shortName));

--- a/src/toolchain/clang.cppm
+++ b/src/toolchain/clang.cppm
@@ -1,0 +1,167 @@
+// mcpp.toolchain.clang - Clang/libc++ compiler behavior.
+
+export module mcpp.toolchain.clang;
+
+import std;
+import mcpp.toolchain.model;
+import mcpp.toolchain.probe;
+import mcpp.xlings;
+
+export namespace mcpp::toolchain::clang {
+
+bool matches_version_output(std::string_view firstLineLower,
+                            std::string_view fullOutputLower);
+
+std::optional<std::filesystem::path> find_libcxx_std_module_source(
+    const std::filesystem::path& cxx_binary,
+    const std::string& envPrefix);
+
+void enrich_toolchain(Toolchain& tc, const std::string& envPrefix);
+
+std::filesystem::path std_bmi_path(const std::filesystem::path& cacheDir);
+std::filesystem::path staged_std_bmi_path(const std::filesystem::path& outputDir);
+
+std::vector<std::string> std_module_build_commands(const Toolchain& tc,
+                                                   const std::filesystem::path& cacheDir,
+                                                   const std::filesystem::path& bmiPath,
+                                                   std::string_view sysrootFlag);
+
+std::filesystem::path archive_tool(const Toolchain& tc);
+
+} // namespace mcpp::toolchain::clang
+
+namespace mcpp::toolchain::clang {
+
+namespace {
+
+std::optional<std::string>
+json_string_value_after(std::string_view body, std::size_t start, std::string_view key) {
+    auto keyToken = std::string{"\""} + std::string(key) + "\"";
+    auto keyPos = body.find(keyToken, start);
+    if (keyPos == std::string_view::npos) return std::nullopt;
+
+    auto colon = body.find(':', keyPos + keyToken.size());
+    if (colon == std::string_view::npos) return std::nullopt;
+
+    auto quote = body.find('"', colon + 1);
+    if (quote == std::string_view::npos) return std::nullopt;
+
+    std::string out;
+    for (std::size_t i = quote + 1; i < body.size(); ++i) {
+        char c = body[i];
+        if (c == '"') return out;
+        if (c == '\\' && i + 1 < body.size()) {
+            out.push_back(body[++i]);
+        } else {
+            out.push_back(c);
+        }
+    }
+    return std::nullopt;
+}
+
+} // namespace
+
+bool matches_version_output(std::string_view firstLineLower,
+                            std::string_view fullOutputLower) {
+    return firstLineLower.find("clang version") != std::string::npos
+        || firstLineLower.find("apple clang version") != std::string::npos
+        || fullOutputLower.find("clang") != std::string::npos;
+}
+
+std::optional<std::filesystem::path> find_libcxx_std_module_source(
+    const std::filesystem::path& cxx_binary,
+    const std::string& envPrefix)
+{
+    auto manifest_r = mcpp::toolchain::run_capture(std::format(
+        "{}{} -print-library-module-manifest-path 2>/dev/null",
+        envPrefix,
+        mcpp::xlings::shq(cxx_binary.string())));
+    if (manifest_r) {
+        auto manifestPath = std::filesystem::path(
+            mcpp::toolchain::trim_line(*manifest_r));
+        if (!manifestPath.empty() && std::filesystem::exists(manifestPath)) {
+            std::ifstream is(manifestPath);
+            std::stringstream ss;
+            ss << is.rdbuf();
+            auto body = ss.str();
+
+            std::size_t cursor = 0;
+            while (true) {
+                auto logical = body.find("\"logical-name\"", cursor);
+                if (logical == std::string::npos) break;
+                auto name = json_string_value_after(body, logical, "logical-name");
+                if (name && *name == "std") {
+                    auto src = json_string_value_after(body, logical, "source-path");
+                    if (src) {
+                        std::filesystem::path p = *src;
+                        if (p.is_relative())
+                            p = manifestPath.parent_path() / p;
+                        std::error_code ec;
+                        auto canon = std::filesystem::weakly_canonical(p, ec);
+                        if (!ec) p = canon;
+                        if (std::filesystem::exists(p)) return p;
+                    }
+                }
+                cursor = logical + 1;
+            }
+        }
+    }
+
+    auto root = cxx_binary.parent_path().parent_path();
+    auto fallback = root / "share" / "libc++" / "v1" / "std.cppm";
+    if (std::filesystem::exists(fallback)) return fallback;
+    return std::nullopt;
+}
+
+void enrich_toolchain(Toolchain& tc, const std::string& envPrefix) {
+    tc.stdlibId      = "libc++";
+    tc.stdlibVersion = tc.version.empty() ? "unknown" : tc.version;
+    tc.linkRuntimeDirs = mcpp::toolchain::discover_link_runtime_dirs(
+        tc.binaryPath, tc.targetTriple);
+    if (auto p = find_libcxx_std_module_source(tc.binaryPath, envPrefix)) {
+        tc.stdModuleSource = *p;
+        tc.hasImportStd    = true;
+    }
+}
+
+std::filesystem::path std_bmi_path(const std::filesystem::path& cacheDir) {
+    return cacheDir / "pcm.cache" / "std.pcm";
+}
+
+std::filesystem::path staged_std_bmi_path(const std::filesystem::path& outputDir) {
+    return outputDir / "pcm.cache" / "std.pcm";
+}
+
+std::vector<std::string> std_module_build_commands(const Toolchain& tc,
+                                                   const std::filesystem::path& cacheDir,
+                                                   const std::filesystem::path& bmiPath,
+                                                   std::string_view sysrootFlag) {
+    auto relBmi = std::filesystem::relative(bmiPath, cacheDir).string();
+    return {
+        std::format(
+            "cd {} && {}{} -std=c++23 -Wno-reserved-module-identifier{} "
+            "--precompile {} -o {} 2>&1",
+            mcpp::xlings::shq(cacheDir.string()),
+            mcpp::toolchain::compiler_env_prefix(tc),
+            mcpp::xlings::shq(tc.binaryPath.string()),
+            sysrootFlag,
+            mcpp::xlings::shq(tc.stdModuleSource.string()),
+            mcpp::xlings::shq(relBmi)),
+        std::format(
+            "cd {} && {}{} -std=c++23 -Wno-reserved-module-identifier{} "
+            "{} -c -o std.o 2>&1",
+            mcpp::xlings::shq(cacheDir.string()),
+            mcpp::toolchain::compiler_env_prefix(tc),
+            mcpp::xlings::shq(tc.binaryPath.string()),
+            sysrootFlag,
+            mcpp::xlings::shq(relBmi))
+    };
+}
+
+std::filesystem::path archive_tool(const Toolchain& tc) {
+    auto llvmAr = tc.binaryPath.parent_path() / "llvm-ar";
+    if (std::filesystem::exists(llvmAr)) return llvmAr;
+    return {};
+}
+
+} // namespace mcpp::toolchain::clang

--- a/src/toolchain/detect.cppm
+++ b/src/toolchain/detect.cppm
@@ -179,6 +179,39 @@ std::string lower_copy(std::string_view s) {
     return out;
 }
 
+std::string trim_line(std::string s) {
+    while (!s.empty() && (s.back() == '\n' || s.back() == '\r' || s.back() == ' '))
+        s.pop_back();
+    while (!s.empty() && (s.front() == '\n' || s.front() == '\r' || s.front() == ' '))
+        s.erase(s.begin());
+    return s;
+}
+
+std::optional<std::string>
+json_string_value_after(std::string_view body, std::size_t start, std::string_view key) {
+    auto keyToken = std::string{"\""} + std::string(key) + "\"";
+    auto keyPos = body.find(keyToken, start);
+    if (keyPos == std::string_view::npos) return std::nullopt;
+
+    auto colon = body.find(':', keyPos + keyToken.size());
+    if (colon == std::string_view::npos) return std::nullopt;
+
+    auto quote = body.find('"', colon + 1);
+    if (quote == std::string_view::npos) return std::nullopt;
+
+    std::string out;
+    for (std::size_t i = quote + 1; i < body.size(); ++i) {
+        char c = body[i];
+        if (c == '"') return out;
+        if (c == '\\' && i + 1 < body.size()) {
+            out.push_back(body[++i]);
+        } else {
+            out.push_back(c);
+        }
+    }
+    return std::nullopt;
+}
+
 } // namespace
 
 std::string compiler_env_prefix(const Toolchain& tc) {
@@ -209,6 +242,47 @@ std::optional<std::filesystem::path> find_std_module_source(
             if (std::filesystem::exists(p2)) return p2;
         }
     }
+    return std::nullopt;
+}
+
+std::optional<std::filesystem::path> find_libcxx_std_module_source(
+    const std::filesystem::path& cxx_binary, const std::string& envPrefix) {
+    auto manifest_r = run_capture(std::format("{}{} -print-library-module-manifest-path 2>/dev/null",
+                                              envPrefix,
+                                              mcpp::xlings::shq(cxx_binary.string())));
+    if (manifest_r) {
+        auto manifestPath = std::filesystem::path(trim_line(*manifest_r));
+        if (!manifestPath.empty() && std::filesystem::exists(manifestPath)) {
+            std::ifstream is(manifestPath);
+            std::stringstream ss;
+            ss << is.rdbuf();
+            auto body = ss.str();
+
+            std::size_t cursor = 0;
+            while (true) {
+                auto logical = body.find("\"logical-name\"", cursor);
+                if (logical == std::string::npos) break;
+                auto name = json_string_value_after(body, logical, "logical-name");
+                if (name && *name == "std") {
+                    auto src = json_string_value_after(body, logical, "source-path");
+                    if (src) {
+                        std::filesystem::path p = *src;
+                        if (p.is_relative())
+                            p = manifestPath.parent_path() / p;
+                        std::error_code ec;
+                        auto canon = std::filesystem::weakly_canonical(p, ec);
+                        if (!ec) p = canon;
+                        if (std::filesystem::exists(p)) return p;
+                    }
+                }
+                cursor = logical + 1;
+            }
+        }
+    }
+
+    auto root = cxx_binary.parent_path().parent_path();
+    auto fallback = root / "share" / "libc++" / "v1" / "std.cppm";
+    if (std::filesystem::exists(fallback)) return fallback;
     return std::nullopt;
 }
 
@@ -304,6 +378,10 @@ detect(const std::filesystem::path& explicit_compiler) {
         tc.stdlibId      = "libc++";
         tc.stdlibVersion = tc.version.empty() ? "unknown" : tc.version;
         tc.linkRuntimeDirs = discover_link_runtime_dirs(tc.binaryPath, tc.targetTriple);
+        if (auto p = find_libcxx_std_module_source(tc.binaryPath, envPrefix)) {
+            tc.stdModuleSource = *p;
+            tc.hasImportStd    = true;
+        }
     }
 
     // std module source

--- a/src/toolchain/detect.cppm
+++ b/src/toolchain/detect.cppm
@@ -1,58 +1,24 @@
-// mcpp.toolchain.detect — discover the C++ compiler and its capabilities
-
-module;
-#include <cstdio>      // popen, pclose, fgets, FILE
-#include <cstdlib>     // getenv
+// mcpp.toolchain.detect - compiler discovery facade.
 
 export module mcpp.toolchain.detect;
 
+export import mcpp.toolchain.model;
+export import mcpp.toolchain.probe;
+
 import std;
+import mcpp.toolchain.clang;
+import mcpp.toolchain.gcc;
 import mcpp.xlings;
 
 export namespace mcpp::toolchain {
 
-enum class CompilerId { Unknown, GCC, Clang, MSVC };
-
-struct Toolchain {
-    CompilerId                          compiler        = CompilerId::Unknown;
-    std::string                         version;            // "15.1.0"
-    std::filesystem::path               binaryPath;
-    std::string                         targetTriple;      // "x86_64-linux-gnu"
-    std::string                         stdlibId;          // "libstdc++"
-    std::string                         stdlibVersion;
-    std::filesystem::path               stdModuleSource;  // bits/std.cc
-    std::filesystem::path               sysroot;           // M5.5: -print-sysroot output (or empty)
-    std::vector<std::filesystem::path>   compilerRuntimeDirs; // LD_LIBRARY_PATH for private tools
-    std::vector<std::filesystem::path>   linkRuntimeDirs;     // -L/-rpath dirs for produced binaries
-    bool                                hasImportStd = false;
-
-    std::string label() const {
-        return std::format("{} {} ({})", compiler_name(), version, targetTriple);
-    }
-
-    std::string_view compiler_name() const {
-        switch (compiler) {
-            case CompilerId::GCC:   return "gcc";
-            case CompilerId::Clang: return "clang";
-            case CompilerId::MSVC:  return "msvc";
-            default:                return "unknown";
-        }
-    }
-};
-
-struct DetectError { std::string message; };
-
 // Detect toolchain. If explicit_compiler is given, use that binary path
-// directly (skipping auto-discovery). Otherwise fall back to $CXX env
-// variable, and finally PATH (with implicit warning expected from caller).
+// directly. Otherwise fall back to $CXX, then PATH g++.
 std::expected<Toolchain, DetectError>
 detect(const std::filesystem::path& explicit_compiler = {});
 
-// Shell prefix used when invoking private toolchain executables that have
-// runtime .so dependencies outside the system loader's default search path.
-std::string compiler_env_prefix(const Toolchain& tc);
-
-// Helper: find std module source for a given GCC binary
+// Compatibility helper for older call sites/tests: GCC std module lookup now
+// lives in the GCC provider.
 std::optional<std::filesystem::path> find_std_module_source(
     const std::filesystem::path& cxx_binary, std::string_view version);
 
@@ -60,352 +26,55 @@ std::optional<std::filesystem::path> find_std_module_source(
 
 namespace mcpp::toolchain {
 
-namespace {
-
-void append_existing_unique(std::vector<std::filesystem::path>& out,
-                            const std::filesystem::path& p) {
-    std::error_code ec;
-    if (p.empty() || !std::filesystem::exists(p, ec)) return;
-    auto abs = std::filesystem::absolute(p, ec);
-    if (ec) abs = p;
-    if (std::find(out.begin(), out.end(), abs) == out.end())
-        out.push_back(abs);
-}
-
-std::string join_colon_paths(const std::vector<std::filesystem::path>& dirs) {
-    std::string joined;
-    for (auto& d : dirs) {
-        if (!joined.empty()) joined += ':';
-        joined += d.string();
-    }
-    return joined;
-}
-
-std::string env_prefix_for_dirs(const std::vector<std::filesystem::path>& dirs) {
-    if (dirs.empty()) return "";
-    auto joined = join_colon_paths(dirs);
-    return std::format("env LD_LIBRARY_PATH={}${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}} ",
-                       mcpp::xlings::shq(joined));
-}
-
-std::vector<std::filesystem::path>
-discover_compiler_runtime_dirs(const std::filesystem::path& compilerBin) {
-    std::vector<std::filesystem::path> dirs;
-    auto root = compilerBin.parent_path().parent_path();
-
-    // xlings LLVM currently ships clang++ linked to host libz, while the
-    // compiler config and libc++ live inside the package root. Keep this
-    // local to tool invocation; these host dirs are not embedded into output.
-    auto rootStr = root.string();
-    auto exe = compilerBin.filename().string();
-    bool looksLikeLlvm = rootStr.find("xim-x-llvm") != std::string::npos
-                      || exe.find("clang") != std::string::npos;
-    if (looksLikeLlvm) {
-        append_existing_unique(dirs, root / "lib");
-        append_existing_unique(dirs, root / "lib" / "x86_64-unknown-linux-gnu");
-        append_existing_unique(dirs, "/lib/x86_64-linux-gnu");
-        append_existing_unique(dirs, "/usr/lib/x86_64-linux-gnu");
-        append_existing_unique(dirs, "/usr/lib64");
-    }
-
-    if (auto rt = mcpp::xlings::paths::find_sibling_tool(compilerBin, "gcc-runtime")) {
-        append_existing_unique(dirs, *rt / "lib64");
-        append_existing_unique(dirs, *rt / "lib");
-    }
-    return dirs;
-}
-
-std::vector<std::filesystem::path>
-discover_link_runtime_dirs(const std::filesystem::path& compilerBin,
-                           std::string_view targetTriple) {
-    std::vector<std::filesystem::path> dirs;
-    auto root = compilerBin.parent_path().parent_path();
-    if (!targetTriple.empty())
-        append_existing_unique(dirs, root / "lib" / std::string(targetTriple));
-    append_existing_unique(dirs, root / "lib" / "x86_64-unknown-linux-gnu");
-    append_existing_unique(dirs, root / "lib");
-
-    if (auto rt = mcpp::xlings::paths::find_sibling_tool(compilerBin, "gcc-runtime")) {
-        append_existing_unique(dirs, *rt / "lib64");
-        append_existing_unique(dirs, *rt / "lib");
-    }
-    return dirs;
-}
-
-std::expected<std::string, DetectError> run_capture(const std::string& cmd) {
-    std::array<char, 4096> buf{};
-    std::string out;
-    std::FILE* fp = ::popen(cmd.c_str(), "r");
-    if (!fp) {
-        return std::unexpected(DetectError{std::format("failed to execute: {}", cmd)});
-    }
-    while (std::fgets(buf.data(), buf.size(), fp) != nullptr) out += buf.data();
-    int rc = ::pclose(fp);
-    if (rc != 0) {
-        return std::unexpected(DetectError{
-            std::format("'{}' exited with status {}", cmd, rc)});
-    }
-    return out;
-}
-
-// Match the leading version triple "X.Y.Z" out of a string.
-std::string extract_version(std::string_view s) {
-    std::string out;
-    bool seen_digit = false;
-    int dots = 0;
-    for (char c : s) {
-        if (std::isdigit(static_cast<unsigned char>(c))) {
-            out.push_back(c);
-            seen_digit = true;
-        } else if (c == '.' && seen_digit && dots < 2) {
-            out.push_back('.'); ++dots;
-        } else if (seen_digit) {
-            break;
-        }
-    }
-    return out;
-}
-
-std::string first_line_of(std::string_view s) {
-    auto end = s.find('\n');
-    return std::string(s.substr(0, end));
-}
-
-std::string lower_copy(std::string_view s) {
-    std::string out(s);
-    std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c) {
-        return static_cast<char>(std::tolower(c));
-    });
-    return out;
-}
-
-std::string trim_line(std::string s) {
-    while (!s.empty() && (s.back() == '\n' || s.back() == '\r' || s.back() == ' '))
-        s.pop_back();
-    while (!s.empty() && (s.front() == '\n' || s.front() == '\r' || s.front() == ' '))
-        s.erase(s.begin());
-    return s;
-}
-
-std::optional<std::string>
-json_string_value_after(std::string_view body, std::size_t start, std::string_view key) {
-    auto keyToken = std::string{"\""} + std::string(key) + "\"";
-    auto keyPos = body.find(keyToken, start);
-    if (keyPos == std::string_view::npos) return std::nullopt;
-
-    auto colon = body.find(':', keyPos + keyToken.size());
-    if (colon == std::string_view::npos) return std::nullopt;
-
-    auto quote = body.find('"', colon + 1);
-    if (quote == std::string_view::npos) return std::nullopt;
-
-    std::string out;
-    for (std::size_t i = quote + 1; i < body.size(); ++i) {
-        char c = body[i];
-        if (c == '"') return out;
-        if (c == '\\' && i + 1 < body.size()) {
-            out.push_back(body[++i]);
-        } else {
-            out.push_back(c);
-        }
-    }
-    return std::nullopt;
-}
-
-} // namespace
-
-std::string compiler_env_prefix(const Toolchain& tc) {
-    return env_prefix_for_dirs(tc.compilerRuntimeDirs);
-}
-
 std::optional<std::filesystem::path> find_std_module_source(
     const std::filesystem::path& cxx_binary, std::string_view version) {
-    // Strategy: starting from CXX binary, derive GCC root and look for
-    //   <root>/include/c++/<version>/bits/std.cc
-    // Path layout (xlings GCC):
-    //   ~/.xlings/data/xpkgs/xim-x-gcc/15.1.0/bin/g++
-    //                                    /include/c++/15.1.0/bits/std.cc
-    auto root = cxx_binary.parent_path().parent_path();
-    auto p = root / "include" / "c++" / std::string(version) / "bits" / "std.cc";
-    if (std::filesystem::exists(p)) return p;
-
-    // Try: ask the compiler.
-    auto cmd = std::format("'{}' -print-file-name=libstdc++.so 2>/dev/null", cxx_binary.string());
-    auto r = run_capture(cmd);
-    if (r) {
-        std::string trimmed = *r;
-        while (!trimmed.empty() && (trimmed.back() == '\n' || trimmed.back() == '\r')) trimmed.pop_back();
-        if (!trimmed.empty()) {
-            std::filesystem::path libpath = trimmed;
-            auto root2 = libpath.parent_path().parent_path();
-            auto p2 = root2 / "include" / "c++" / std::string(version) / "bits" / "std.cc";
-            if (std::filesystem::exists(p2)) return p2;
-        }
-    }
-    return std::nullopt;
-}
-
-std::optional<std::filesystem::path> find_libcxx_std_module_source(
-    const std::filesystem::path& cxx_binary, const std::string& envPrefix) {
-    auto manifest_r = run_capture(std::format("{}{} -print-library-module-manifest-path 2>/dev/null",
-                                              envPrefix,
-                                              mcpp::xlings::shq(cxx_binary.string())));
-    if (manifest_r) {
-        auto manifestPath = std::filesystem::path(trim_line(*manifest_r));
-        if (!manifestPath.empty() && std::filesystem::exists(manifestPath)) {
-            std::ifstream is(manifestPath);
-            std::stringstream ss;
-            ss << is.rdbuf();
-            auto body = ss.str();
-
-            std::size_t cursor = 0;
-            while (true) {
-                auto logical = body.find("\"logical-name\"", cursor);
-                if (logical == std::string::npos) break;
-                auto name = json_string_value_after(body, logical, "logical-name");
-                if (name && *name == "std") {
-                    auto src = json_string_value_after(body, logical, "source-path");
-                    if (src) {
-                        std::filesystem::path p = *src;
-                        if (p.is_relative())
-                            p = manifestPath.parent_path() / p;
-                        std::error_code ec;
-                        auto canon = std::filesystem::weakly_canonical(p, ec);
-                        if (!ec) p = canon;
-                        if (std::filesystem::exists(p)) return p;
-                    }
-                }
-                cursor = logical + 1;
-            }
-        }
-    }
-
-    auto root = cxx_binary.parent_path().parent_path();
-    auto fallback = root / "share" / "libc++" / "v1" / "std.cppm";
-    if (std::filesystem::exists(fallback)) return fallback;
-    return std::nullopt;
+    return mcpp::toolchain::gcc::find_std_module_source(cxx_binary, version);
 }
 
 std::expected<Toolchain, DetectError>
 detect(const std::filesystem::path& explicit_compiler) {
-    Toolchain tc;
+    auto bin_r = probe_compiler_binary(explicit_compiler);
+    if (!bin_r) return std::unexpected(bin_r.error());
 
-    // Determine compiler binary:
-    //   1. explicit_compiler argument (caller resolved via [toolchain] / sandbox subos)
-    //   2. $CXX env
-    //   3. g++ in PATH (last resort; caller should warn)
-    std::string bin;
-    if (!explicit_compiler.empty()) {
-        if (!std::filesystem::exists(explicit_compiler)) {
-            return std::unexpected(DetectError{std::format(
-                "explicit compiler path does not exist: {}",
-                explicit_compiler.string())});
-        }
-        bin = explicit_compiler.string();
-    } else {
-        std::string cxx;
-        if (auto* e = std::getenv("CXX"); e && *e) {
-            cxx = e;
-        } else {
-            cxx = "g++"; // M1: GCC only
-        }
-        auto bin_path_r = run_capture(std::format("command -v '{}' 2>/dev/null", cxx));
-        if (!bin_path_r) {
-            return std::unexpected(DetectError{std::format("compiler '{}' not found in PATH", cxx)});
-        }
-        bin = *bin_path_r;
-        while (!bin.empty() && (bin.back() == '\n' || bin.back() == '\r')) bin.pop_back();
-        if (bin.empty()) {
-            return std::unexpected(DetectError{std::format("compiler '{}' not found", cxx)});
-        }
-    }
-    tc.binaryPath = bin;
+    Toolchain tc;
+    tc.binaryPath = *bin_r;
     tc.compilerRuntimeDirs = discover_compiler_runtime_dirs(tc.binaryPath);
     auto envPrefix = compiler_env_prefix(tc);
 
-    // Version probe
     auto ver_r = run_capture(std::format("{}{} --version 2>&1",
                                          envPrefix,
-                                         mcpp::xlings::shq(bin)));
+                                         mcpp::xlings::shq(tc.binaryPath.string())));
     if (!ver_r) return std::unexpected(ver_r.error());
-    const std::string& vstr = *ver_r;
 
+    const auto& vstr = *ver_r;
     auto head = first_line_of(vstr);
     auto headLower = lower_copy(head);
-    if (headLower.find("clang version") != std::string::npos
-        || headLower.find("apple clang version") != std::string::npos) {
+    auto fullLower = lower_copy(vstr);
+
+    if (mcpp::toolchain::clang::matches_version_output(headLower, fullLower)) {
         tc.compiler = CompilerId::Clang;
-        tc.version  = extract_version(head);
-    } else if (headLower.find("g++") != std::string::npos
-            || headLower.find("gcc") != std::string::npos) {
+        tc.version  = extract_version(head.empty()
+            ? std::string_view(vstr)
+            : std::string_view(head));
+    } else if (mcpp::toolchain::gcc::matches_version_output(headLower)) {
         tc.compiler = CompilerId::GCC;
-        // Extract version after the parenthesized package label, if any.
-        // E.g. "g++ (XPKG: ...) 15.1.0"
-        // Find rightmost number sequence on first line.
-        auto rpos = head.find_last_of("0123456789");
-        if (rpos != std::string::npos) {
-            // Walk left to find start of "X.Y.Z"
-            std::size_t lpos = rpos;
-            while (lpos > 0 && (std::isdigit(static_cast<unsigned char>(head[lpos-1])) || head[lpos-1] == '.')) {
-                --lpos;
-            }
-            tc.version = head.substr(lpos, rpos - lpos + 1);
-        }
-        if (tc.version.empty()) tc.version = extract_version(head);
-    } else if (lower_copy(vstr).find("clang") != std::string::npos) {
-        tc.compiler = CompilerId::Clang;
-        tc.version  = extract_version(head.empty() ? std::string_view(vstr) : std::string_view(head));
+        tc.version  = mcpp::toolchain::gcc::parse_version(head);
     } else {
         return std::unexpected(DetectError{
             std::format("unrecognized compiler output:\n{}", vstr)});
     }
 
-    // Target triple
-    auto triple_r = run_capture(std::format("{}{} -dumpmachine 2>/dev/null",
-                                            envPrefix,
-                                            mcpp::xlings::shq(bin)));
-    if (triple_r) {
-        std::string t = *triple_r;
-        while (!t.empty() && (t.back() == '\n' || t.back() == '\r')) t.pop_back();
-        tc.targetTriple = t;
+    if (auto triple = probe_target_triple(tc.binaryPath, envPrefix)) {
+        tc.targetTriple = *triple;
     }
 
-    // Stdlib identification (GCC → libstdc++)
     if (tc.compiler == CompilerId::GCC) {
-        tc.stdlibId      = "libstdc++";
-        tc.stdlibVersion = tc.version; // libstdc++ ships with GCC; same version
+        mcpp::toolchain::gcc::enrich_toolchain(tc);
     } else if (tc.compiler == CompilerId::Clang) {
-        tc.stdlibId      = "libc++";
-        tc.stdlibVersion = tc.version.empty() ? "unknown" : tc.version;
-        tc.linkRuntimeDirs = discover_link_runtime_dirs(tc.binaryPath, tc.targetTriple);
-        if (auto p = find_libcxx_std_module_source(tc.binaryPath, envPrefix)) {
-            tc.stdModuleSource = *p;
-            tc.hasImportStd    = true;
-        }
+        mcpp::toolchain::clang::enrich_toolchain(tc, envPrefix);
     }
 
-    // std module source
-    if (tc.compiler == CompilerId::GCC) {
-        if (auto p = find_std_module_source(tc.binaryPath, tc.version)) {
-            tc.stdModuleSource = *p;
-            tc.hasImportStd    = true;
-        }
-    }
-
-    // M5.5: probe sysroot — needed when bypassing xlings wrapper.
-    {
-        auto cmd = std::format("{}{} -print-sysroot 2>/dev/null",
-                               envPrefix,
-                               mcpp::xlings::shq(tc.binaryPath.string()));
-        auto r = run_capture(cmd);
-        if (r) {
-            std::string s = *r;
-            while (!s.empty() && (s.back() == '\n' || s.back() == '\r' || s.back() == ' ')) s.pop_back();
-            if (!s.empty() && std::filesystem::exists(s)) {
-                tc.sysroot = s;
-            }
-        }
-    }
+    tc.sysroot = probe_sysroot(tc.binaryPath, envPrefix);
 
     return tc;
 }

--- a/src/toolchain/detect.cppm
+++ b/src/toolchain/detect.cppm
@@ -7,6 +7,7 @@ module;
 export module mcpp.toolchain.detect;
 
 import std;
+import mcpp.xlings;
 
 export namespace mcpp::toolchain {
 
@@ -21,6 +22,8 @@ struct Toolchain {
     std::string                         stdlibVersion;
     std::filesystem::path               stdModuleSource;  // bits/std.cc
     std::filesystem::path               sysroot;           // M5.5: -print-sysroot output (or empty)
+    std::vector<std::filesystem::path>   compilerRuntimeDirs; // LD_LIBRARY_PATH for private tools
+    std::vector<std::filesystem::path>   linkRuntimeDirs;     // -L/-rpath dirs for produced binaries
     bool                                hasImportStd = false;
 
     std::string label() const {
@@ -45,6 +48,10 @@ struct DetectError { std::string message; };
 std::expected<Toolchain, DetectError>
 detect(const std::filesystem::path& explicit_compiler = {});
 
+// Shell prefix used when invoking private toolchain executables that have
+// runtime .so dependencies outside the system loader's default search path.
+std::string compiler_env_prefix(const Toolchain& tc);
+
 // Helper: find std module source for a given GCC binary
 std::optional<std::filesystem::path> find_std_module_source(
     const std::filesystem::path& cxx_binary, std::string_view version);
@@ -54,6 +61,76 @@ std::optional<std::filesystem::path> find_std_module_source(
 namespace mcpp::toolchain {
 
 namespace {
+
+void append_existing_unique(std::vector<std::filesystem::path>& out,
+                            const std::filesystem::path& p) {
+    std::error_code ec;
+    if (p.empty() || !std::filesystem::exists(p, ec)) return;
+    auto abs = std::filesystem::absolute(p, ec);
+    if (ec) abs = p;
+    if (std::find(out.begin(), out.end(), abs) == out.end())
+        out.push_back(abs);
+}
+
+std::string join_colon_paths(const std::vector<std::filesystem::path>& dirs) {
+    std::string joined;
+    for (auto& d : dirs) {
+        if (!joined.empty()) joined += ':';
+        joined += d.string();
+    }
+    return joined;
+}
+
+std::string env_prefix_for_dirs(const std::vector<std::filesystem::path>& dirs) {
+    if (dirs.empty()) return "";
+    auto joined = join_colon_paths(dirs);
+    return std::format("env LD_LIBRARY_PATH={}${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}} ",
+                       mcpp::xlings::shq(joined));
+}
+
+std::vector<std::filesystem::path>
+discover_compiler_runtime_dirs(const std::filesystem::path& compilerBin) {
+    std::vector<std::filesystem::path> dirs;
+    auto root = compilerBin.parent_path().parent_path();
+
+    // xlings LLVM currently ships clang++ linked to host libz, while the
+    // compiler config and libc++ live inside the package root. Keep this
+    // local to tool invocation; these host dirs are not embedded into output.
+    auto rootStr = root.string();
+    auto exe = compilerBin.filename().string();
+    bool looksLikeLlvm = rootStr.find("xim-x-llvm") != std::string::npos
+                      || exe.find("clang") != std::string::npos;
+    if (looksLikeLlvm) {
+        append_existing_unique(dirs, root / "lib");
+        append_existing_unique(dirs, root / "lib" / "x86_64-unknown-linux-gnu");
+        append_existing_unique(dirs, "/lib/x86_64-linux-gnu");
+        append_existing_unique(dirs, "/usr/lib/x86_64-linux-gnu");
+        append_existing_unique(dirs, "/usr/lib64");
+    }
+
+    if (auto rt = mcpp::xlings::paths::find_sibling_tool(compilerBin, "gcc-runtime")) {
+        append_existing_unique(dirs, *rt / "lib64");
+        append_existing_unique(dirs, *rt / "lib");
+    }
+    return dirs;
+}
+
+std::vector<std::filesystem::path>
+discover_link_runtime_dirs(const std::filesystem::path& compilerBin,
+                           std::string_view targetTriple) {
+    std::vector<std::filesystem::path> dirs;
+    auto root = compilerBin.parent_path().parent_path();
+    if (!targetTriple.empty())
+        append_existing_unique(dirs, root / "lib" / std::string(targetTriple));
+    append_existing_unique(dirs, root / "lib" / "x86_64-unknown-linux-gnu");
+    append_existing_unique(dirs, root / "lib");
+
+    if (auto rt = mcpp::xlings::paths::find_sibling_tool(compilerBin, "gcc-runtime")) {
+        append_existing_unique(dirs, *rt / "lib64");
+        append_existing_unique(dirs, *rt / "lib");
+    }
+    return dirs;
+}
 
 std::expected<std::string, DetectError> run_capture(const std::string& cmd) {
     std::array<char, 4096> buf{};
@@ -89,7 +166,24 @@ std::string extract_version(std::string_view s) {
     return out;
 }
 
+std::string first_line_of(std::string_view s) {
+    auto end = s.find('\n');
+    return std::string(s.substr(0, end));
+}
+
+std::string lower_copy(std::string_view s) {
+    std::string out(s);
+    std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return out;
+}
+
 } // namespace
+
+std::string compiler_env_prefix(const Toolchain& tc) {
+    return env_prefix_for_dirs(tc.compilerRuntimeDirs);
+}
 
 std::optional<std::filesystem::path> find_std_module_source(
     const std::filesystem::path& cxx_binary, std::string_view version) {
@@ -152,20 +246,27 @@ detect(const std::filesystem::path& explicit_compiler) {
         }
     }
     tc.binaryPath = bin;
+    tc.compilerRuntimeDirs = discover_compiler_runtime_dirs(tc.binaryPath);
+    auto envPrefix = compiler_env_prefix(tc);
 
     // Version probe
-    auto ver_r = run_capture(std::format("'{}' --version 2>&1", bin));
+    auto ver_r = run_capture(std::format("{}{} --version 2>&1",
+                                         envPrefix,
+                                         mcpp::xlings::shq(bin)));
     if (!ver_r) return std::unexpected(ver_r.error());
     const std::string& vstr = *ver_r;
 
-    if (vstr.find("g++") != std::string::npos || vstr.find("GCC") != std::string::npos
-        || vstr.find("gcc") != std::string::npos)
-    {
+    auto head = first_line_of(vstr);
+    auto headLower = lower_copy(head);
+    if (headLower.find("clang version") != std::string::npos
+        || headLower.find("apple clang version") != std::string::npos) {
+        tc.compiler = CompilerId::Clang;
+        tc.version  = extract_version(head);
+    } else if (headLower.find("g++") != std::string::npos
+            || headLower.find("gcc") != std::string::npos) {
         tc.compiler = CompilerId::GCC;
         // Extract version after the parenthesized package label, if any.
         // E.g. "g++ (XPKG: ...) 15.1.0"
-        auto first_line_end = vstr.find('\n');
-        std::string head = vstr.substr(0, first_line_end);
         // Find rightmost number sequence on first line.
         auto rpos = head.find_last_of("0123456789");
         if (rpos != std::string::npos) {
@@ -177,16 +278,18 @@ detect(const std::filesystem::path& explicit_compiler) {
             tc.version = head.substr(lpos, rpos - lpos + 1);
         }
         if (tc.version.empty()) tc.version = extract_version(head);
-    } else if (vstr.find("clang") != std::string::npos) {
+    } else if (lower_copy(vstr).find("clang") != std::string::npos) {
         tc.compiler = CompilerId::Clang;
-        tc.version  = extract_version(vstr);
+        tc.version  = extract_version(head.empty() ? std::string_view(vstr) : std::string_view(head));
     } else {
         return std::unexpected(DetectError{
             std::format("unrecognized compiler output:\n{}", vstr)});
     }
 
     // Target triple
-    auto triple_r = run_capture(std::format("'{}' -dumpmachine 2>/dev/null", bin));
+    auto triple_r = run_capture(std::format("{}{} -dumpmachine 2>/dev/null",
+                                            envPrefix,
+                                            mcpp::xlings::shq(bin)));
     if (triple_r) {
         std::string t = *triple_r;
         while (!t.empty() && (t.back() == '\n' || t.back() == '\r')) t.pop_back();
@@ -199,7 +302,8 @@ detect(const std::filesystem::path& explicit_compiler) {
         tc.stdlibVersion = tc.version; // libstdc++ ships with GCC; same version
     } else if (tc.compiler == CompilerId::Clang) {
         tc.stdlibId      = "libc++";
-        tc.stdlibVersion = "unknown";
+        tc.stdlibVersion = tc.version.empty() ? "unknown" : tc.version;
+        tc.linkRuntimeDirs = discover_link_runtime_dirs(tc.binaryPath, tc.targetTriple);
     }
 
     // std module source
@@ -212,7 +316,9 @@ detect(const std::filesystem::path& explicit_compiler) {
 
     // M5.5: probe sysroot — needed when bypassing xlings wrapper.
     {
-        auto cmd = std::format("'{}' -print-sysroot 2>/dev/null", tc.binaryPath.string());
+        auto cmd = std::format("{}{} -print-sysroot 2>/dev/null",
+                               envPrefix,
+                               mcpp::xlings::shq(tc.binaryPath.string()));
         auto r = run_capture(cmd);
         if (r) {
             std::string s = *r;

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.13";
+inline constexpr std::string_view MCPP_VERSION = "0.0.14";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;

--- a/src/toolchain/gcc.cppm
+++ b/src/toolchain/gcc.cppm
@@ -1,0 +1,123 @@
+// mcpp.toolchain.gcc - GCC-family compiler behavior.
+
+export module mcpp.toolchain.gcc;
+
+import std;
+import mcpp.toolchain.model;
+import mcpp.toolchain.probe;
+import mcpp.xlings;
+
+export namespace mcpp::toolchain::gcc {
+
+bool matches_version_output(std::string_view firstLineLower);
+std::string parse_version(std::string_view firstLine);
+
+std::optional<std::filesystem::path> find_std_module_source(
+    const std::filesystem::path& cxx_binary,
+    std::string_view version);
+
+void enrich_toolchain(Toolchain& tc);
+
+std::optional<std::filesystem::path>
+find_binutils_bin(const std::filesystem::path& compilerBin);
+
+std::filesystem::path std_bmi_path(const std::filesystem::path& cacheDir);
+std::filesystem::path staged_std_bmi_path(const std::filesystem::path& outputDir);
+
+std::string std_module_build_command(const Toolchain& tc,
+                                     const std::filesystem::path& cacheDir,
+                                     std::string_view sysrootFlag);
+
+} // namespace mcpp::toolchain::gcc
+
+namespace mcpp::toolchain::gcc {
+
+bool matches_version_output(std::string_view firstLineLower) {
+    return firstLineLower.find("g++") != std::string::npos
+        || firstLineLower.find("gcc") != std::string::npos;
+}
+
+std::string parse_version(std::string_view firstLine) {
+    std::string head(firstLine);
+    auto rpos = head.find_last_of("0123456789");
+    if (rpos != std::string::npos) {
+        std::size_t lpos = rpos;
+        while (lpos > 0
+            && (std::isdigit(static_cast<unsigned char>(head[lpos - 1]))
+                || head[lpos - 1] == '.')) {
+            --lpos;
+        }
+        auto version = head.substr(lpos, rpos - lpos + 1);
+        if (!version.empty()) return version;
+    }
+    return mcpp::toolchain::extract_version(firstLine);
+}
+
+std::optional<std::filesystem::path> find_std_module_source(
+    const std::filesystem::path& cxx_binary,
+    std::string_view version)
+{
+    auto root = cxx_binary.parent_path().parent_path();
+    auto p = root / "include" / "c++" / std::string(version) / "bits" / "std.cc";
+    if (std::filesystem::exists(p)) return p;
+
+    auto cmd = std::format("'{}' -print-file-name=libstdc++.so 2>/dev/null",
+                           cxx_binary.string());
+    auto r = mcpp::toolchain::run_capture(cmd);
+    if (r) {
+        auto trimmed = mcpp::toolchain::trim_line(*r);
+        if (!trimmed.empty()) {
+            std::filesystem::path libpath = trimmed;
+            auto root2 = libpath.parent_path().parent_path();
+            auto p2 = root2 / "include" / "c++" / std::string(version) / "bits" / "std.cc";
+            if (std::filesystem::exists(p2)) return p2;
+        }
+    }
+    return std::nullopt;
+}
+
+void enrich_toolchain(Toolchain& tc) {
+    tc.stdlibId      = "libstdc++";
+    tc.stdlibVersion = tc.version;
+    if (auto p = find_std_module_source(tc.binaryPath, tc.version)) {
+        tc.stdModuleSource = *p;
+        tc.hasImportStd    = true;
+    }
+}
+
+std::optional<std::filesystem::path>
+find_binutils_bin(const std::filesystem::path& compilerBin) {
+    if (auto as = mcpp::xlings::paths::find_sibling_binary(
+            compilerBin, "binutils", "bin/as")) {
+        return as->parent_path();
+    }
+    return std::nullopt;
+}
+
+std::filesystem::path std_bmi_path(const std::filesystem::path& cacheDir) {
+    return cacheDir / "gcm.cache" / "std.gcm";
+}
+
+std::filesystem::path staged_std_bmi_path(const std::filesystem::path& outputDir) {
+    return outputDir / "gcm.cache" / "std.gcm";
+}
+
+std::string std_module_build_command(const Toolchain& tc,
+                                     const std::filesystem::path& cacheDir,
+                                     std::string_view sysrootFlag) {
+    std::string bFlag;
+    if (auto binutilsBin = find_binutils_bin(tc.binaryPath)) {
+        bFlag = std::format(" -B'{}'", binutilsBin->string());
+    }
+
+    return std::format(
+        "cd {} && {}{} -std=c++23 -fmodules -O2{}{} -c {} -o std.o 2>&1",
+        mcpp::xlings::shq(cacheDir.string()),
+        mcpp::toolchain::compiler_env_prefix(tc),
+        mcpp::xlings::shq(tc.binaryPath.string()),
+        sysrootFlag,
+        bFlag,
+        mcpp::xlings::shq(tc.stdModuleSource.string()));
+}
+
+} // namespace mcpp::toolchain::gcc

--- a/src/toolchain/llvm.cppm
+++ b/src/toolchain/llvm.cppm
@@ -1,0 +1,34 @@
+// mcpp.toolchain.llvm - xlings LLVM package mapping.
+
+export module mcpp.toolchain.llvm;
+
+import std;
+
+export namespace mcpp::toolchain::llvm {
+
+bool is_alias(std::string_view compiler);
+std::string package_name();
+std::vector<std::string> frontend_candidates();
+std::vector<std::string> list_aliases();
+
+} // namespace mcpp::toolchain::llvm
+
+namespace mcpp::toolchain::llvm {
+
+bool is_alias(std::string_view compiler) {
+    return compiler == "llvm" || compiler == "clang";
+}
+
+std::string package_name() {
+    return "llvm";
+}
+
+std::vector<std::string> frontend_candidates() {
+    return {"clang++"};
+}
+
+std::vector<std::string> list_aliases() {
+    return {"llvm", "clang"};
+}
+
+} // namespace mcpp::toolchain::llvm

--- a/src/toolchain/model.cppm
+++ b/src/toolchain/model.cppm
@@ -1,0 +1,60 @@
+// mcpp.toolchain.model - stable toolchain data model.
+
+export module mcpp.toolchain.model;
+
+import std;
+
+export namespace mcpp::toolchain {
+
+enum class CompilerId { Unknown, GCC, Clang, MSVC };
+
+struct Toolchain {
+    CompilerId                          compiler        = CompilerId::Unknown;
+    std::string                         version;            // "15.1.0"
+    std::filesystem::path               binaryPath;
+    std::string                         targetTriple;       // "x86_64-linux-gnu"
+    std::string                         stdlibId;           // "libstdc++"
+    std::string                         stdlibVersion;
+    std::filesystem::path               stdModuleSource;    // bits/std.cc / std.cppm
+    std::filesystem::path               sysroot;            // -print-sysroot output (or empty)
+    std::vector<std::filesystem::path>   compilerRuntimeDirs; // LD_LIBRARY_PATH for private tools
+    std::vector<std::filesystem::path>   linkRuntimeDirs;     // -L/-rpath dirs for produced binaries
+    bool                                hasImportStd = false;
+
+    std::string label() const {
+        return std::format("{} {} ({})", compiler_name(), version, targetTriple);
+    }
+
+    std::string_view compiler_name() const {
+        switch (compiler) {
+            case CompilerId::GCC:   return "gcc";
+            case CompilerId::Clang: return "clang";
+            case CompilerId::MSVC:  return "msvc";
+            default:                return "unknown";
+        }
+    }
+};
+
+struct DetectError { std::string message; };
+
+bool is_gcc(const Toolchain& tc);
+bool is_clang(const Toolchain& tc);
+bool is_musl_target(const Toolchain& tc);
+
+} // namespace mcpp::toolchain
+
+namespace mcpp::toolchain {
+
+bool is_gcc(const Toolchain& tc) {
+    return tc.compiler == CompilerId::GCC;
+}
+
+bool is_clang(const Toolchain& tc) {
+    return tc.compiler == CompilerId::Clang;
+}
+
+bool is_musl_target(const Toolchain& tc) {
+    return tc.targetTriple.find("-musl") != std::string::npos;
+}
+
+} // namespace mcpp::toolchain

--- a/src/toolchain/probe.cppm
+++ b/src/toolchain/probe.cppm
@@ -1,0 +1,227 @@
+// mcpp.toolchain.probe - common compiler probing helpers.
+
+module;
+#include <cstdio>      // popen, pclose, fgets, FILE
+#include <cstdlib>     // getenv
+
+export module mcpp.toolchain.probe;
+
+import std;
+import mcpp.toolchain.model;
+import mcpp.xlings;
+
+export namespace mcpp::toolchain {
+
+std::expected<std::string, DetectError> run_capture(const std::string& cmd);
+
+std::string extract_version(std::string_view s);
+std::string first_line_of(std::string_view s);
+std::string lower_copy(std::string_view s);
+std::string trim_line(std::string s);
+
+std::vector<std::filesystem::path>
+discover_compiler_runtime_dirs(const std::filesystem::path& compilerBin);
+
+std::vector<std::filesystem::path>
+discover_link_runtime_dirs(const std::filesystem::path& compilerBin,
+                           std::string_view targetTriple);
+
+std::string compiler_env_prefix(const Toolchain& tc);
+
+std::expected<std::filesystem::path, DetectError>
+probe_compiler_binary(const std::filesystem::path& explicit_compiler = {});
+
+std::expected<std::string, DetectError>
+probe_target_triple(const std::filesystem::path& compilerBin,
+                    const std::string& envPrefix);
+
+std::filesystem::path
+probe_sysroot(const std::filesystem::path& compilerBin,
+              const std::string& envPrefix);
+
+} // namespace mcpp::toolchain
+
+namespace mcpp::toolchain {
+
+namespace {
+
+void append_existing_unique(std::vector<std::filesystem::path>& out,
+                            const std::filesystem::path& p) {
+    std::error_code ec;
+    if (p.empty() || !std::filesystem::exists(p, ec)) return;
+    auto abs = std::filesystem::absolute(p, ec);
+    if (ec) abs = p;
+    if (std::find(out.begin(), out.end(), abs) == out.end())
+        out.push_back(abs);
+}
+
+std::string join_colon_paths(const std::vector<std::filesystem::path>& dirs) {
+    std::string joined;
+    for (auto& d : dirs) {
+        if (!joined.empty()) joined += ':';
+        joined += d.string();
+    }
+    return joined;
+}
+
+std::string env_prefix_for_dirs(const std::vector<std::filesystem::path>& dirs) {
+    if (dirs.empty()) return "";
+    auto joined = join_colon_paths(dirs);
+    return std::format("env LD_LIBRARY_PATH={}${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}} ",
+                       mcpp::xlings::shq(joined));
+}
+
+} // namespace
+
+std::expected<std::string, DetectError> run_capture(const std::string& cmd) {
+    std::array<char, 4096> buf{};
+    std::string out;
+    std::FILE* fp = ::popen(cmd.c_str(), "r");
+    if (!fp) {
+        return std::unexpected(DetectError{std::format("failed to execute: {}", cmd)});
+    }
+    while (std::fgets(buf.data(), buf.size(), fp) != nullptr) out += buf.data();
+    int rc = ::pclose(fp);
+    if (rc != 0) {
+        return std::unexpected(DetectError{
+            std::format("'{}' exited with status {}", cmd, rc)});
+    }
+    return out;
+}
+
+std::string extract_version(std::string_view s) {
+    std::string out;
+    bool seen_digit = false;
+    int dots = 0;
+    for (char c : s) {
+        if (std::isdigit(static_cast<unsigned char>(c))) {
+            out.push_back(c);
+            seen_digit = true;
+        } else if (c == '.' && seen_digit && dots < 2) {
+            out.push_back('.');
+            ++dots;
+        } else if (seen_digit) {
+            break;
+        }
+    }
+    return out;
+}
+
+std::string first_line_of(std::string_view s) {
+    auto end = s.find('\n');
+    return std::string(s.substr(0, end));
+}
+
+std::string lower_copy(std::string_view s) {
+    std::string out(s);
+    std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return out;
+}
+
+std::string trim_line(std::string s) {
+    while (!s.empty() && (s.back() == '\n' || s.back() == '\r' || s.back() == ' '))
+        s.pop_back();
+    while (!s.empty() && (s.front() == '\n' || s.front() == '\r' || s.front() == ' '))
+        s.erase(s.begin());
+    return s;
+}
+
+std::vector<std::filesystem::path>
+discover_compiler_runtime_dirs(const std::filesystem::path& compilerBin) {
+    std::vector<std::filesystem::path> dirs;
+    auto root = compilerBin.parent_path().parent_path();
+
+    auto rootStr = root.string();
+    auto exe = compilerBin.filename().string();
+    bool looksLikeLlvm = rootStr.find("xim-x-llvm") != std::string::npos
+                      || exe.find("clang") != std::string::npos;
+    if (looksLikeLlvm) {
+        append_existing_unique(dirs, root / "lib");
+        append_existing_unique(dirs, root / "lib" / "x86_64-unknown-linux-gnu");
+        append_existing_unique(dirs, "/lib/x86_64-linux-gnu");
+        append_existing_unique(dirs, "/usr/lib/x86_64-linux-gnu");
+        append_existing_unique(dirs, "/usr/lib64");
+    }
+
+    if (auto rt = mcpp::xlings::paths::find_sibling_tool(compilerBin, "gcc-runtime")) {
+        append_existing_unique(dirs, *rt / "lib64");
+        append_existing_unique(dirs, *rt / "lib");
+    }
+    return dirs;
+}
+
+std::vector<std::filesystem::path>
+discover_link_runtime_dirs(const std::filesystem::path& compilerBin,
+                           std::string_view targetTriple) {
+    std::vector<std::filesystem::path> dirs;
+    auto root = compilerBin.parent_path().parent_path();
+    if (!targetTriple.empty())
+        append_existing_unique(dirs, root / "lib" / std::string(targetTriple));
+    append_existing_unique(dirs, root / "lib" / "x86_64-unknown-linux-gnu");
+    append_existing_unique(dirs, root / "lib");
+
+    if (auto rt = mcpp::xlings::paths::find_sibling_tool(compilerBin, "gcc-runtime")) {
+        append_existing_unique(dirs, *rt / "lib64");
+        append_existing_unique(dirs, *rt / "lib");
+    }
+    return dirs;
+}
+
+std::string compiler_env_prefix(const Toolchain& tc) {
+    return env_prefix_for_dirs(tc.compilerRuntimeDirs);
+}
+
+std::expected<std::filesystem::path, DetectError>
+probe_compiler_binary(const std::filesystem::path& explicit_compiler) {
+    if (!explicit_compiler.empty()) {
+        if (!std::filesystem::exists(explicit_compiler)) {
+            return std::unexpected(DetectError{std::format(
+                "explicit compiler path does not exist: {}",
+                explicit_compiler.string())});
+        }
+        return explicit_compiler;
+    }
+
+    std::string cxx;
+    if (auto* e = std::getenv("CXX"); e && *e) {
+        cxx = e;
+    } else {
+        cxx = "g++";
+    }
+
+    auto bin_path_r = run_capture(std::format("command -v '{}' 2>/dev/null", cxx));
+    if (!bin_path_r) {
+        return std::unexpected(DetectError{std::format("compiler '{}' not found in PATH", cxx)});
+    }
+    auto bin = trim_line(*bin_path_r);
+    if (bin.empty()) {
+        return std::unexpected(DetectError{std::format("compiler '{}' not found", cxx)});
+    }
+    return std::filesystem::path(bin);
+}
+
+std::expected<std::string, DetectError>
+probe_target_triple(const std::filesystem::path& compilerBin,
+                    const std::string& envPrefix) {
+    auto triple_r = run_capture(std::format("{}{} -dumpmachine 2>/dev/null",
+                                            envPrefix,
+                                            mcpp::xlings::shq(compilerBin.string())));
+    if (!triple_r) return std::unexpected(triple_r.error());
+    return trim_line(*triple_r);
+}
+
+std::filesystem::path
+probe_sysroot(const std::filesystem::path& compilerBin,
+              const std::string& envPrefix) {
+    auto r = run_capture(std::format("{}{} -print-sysroot 2>/dev/null",
+                                     envPrefix,
+                                     mcpp::xlings::shq(compilerBin.string())));
+    if (!r) return {};
+    auto s = trim_line(*r);
+    if (!s.empty() && std::filesystem::exists(s)) return s;
+    return {};
+}
+
+} // namespace mcpp::toolchain

--- a/src/toolchain/registry.cppm
+++ b/src/toolchain/registry.cppm
@@ -1,0 +1,232 @@
+// mcpp.toolchain.registry - user spec and package/provider mapping.
+
+export module mcpp.toolchain.registry;
+
+import std;
+import mcpp.toolchain.clang;
+import mcpp.toolchain.gcc;
+import mcpp.toolchain.llvm;
+import mcpp.toolchain.model;
+
+export namespace mcpp::toolchain {
+
+struct ToolchainSpec {
+    std::string compiler;    // user-facing compiler name, namespace-stripped
+    std::string version;     // user-facing version, may include -musl
+    bool        isMusl = false;
+};
+
+struct XimToolchainPackage {
+    std::string                     ximName;
+    std::string                     ximVersion;
+    std::string                     displayCompiler;
+    std::string                     displayVersion;
+    std::vector<std::string>        frontendCandidates;
+    bool                            needsGccPostInstallFixup = false;
+
+    std::string target() const {
+        return std::format("xim:{}@{}", ximName, ximVersion);
+    }
+
+    std::string display_spec() const {
+        return std::format("{}@{}", displayCompiler, displayVersion);
+    }
+};
+
+std::expected<ToolchainSpec, std::string>
+parse_toolchain_spec(std::string compilerArg,
+                     std::string versionArg = {},
+                     bool requireCompiler = true);
+
+XimToolchainPackage to_xim_package(const ToolchainSpec& spec);
+
+ToolchainSpec with_resolved_xim_version(const ToolchainSpec& spec,
+                                        std::string_view ximVersion);
+
+std::filesystem::path toolchain_frontend(const std::filesystem::path& binDir,
+                                         std::string_view compiler);
+
+std::filesystem::path toolchain_frontend(const std::filesystem::path& binDir,
+                                         const XimToolchainPackage& pkg);
+
+std::string display_label(std::string_view compiler, std::string_view version);
+bool matches_default_toolchain(std::string_view configuredDefault,
+                               std::string_view compiler,
+                               std::string_view version);
+
+std::vector<std::pair<std::string, std::string>> available_toolchain_indexes();
+
+std::filesystem::path derive_c_compiler(const Toolchain& tc);
+std::filesystem::path archive_tool(const Toolchain& tc);
+std::filesystem::path staged_std_bmi_path(const Toolchain& tc,
+                                          const std::filesystem::path& outputDir);
+
+} // namespace mcpp::toolchain
+
+namespace mcpp::toolchain {
+
+namespace {
+
+bool ends_with(std::string_view s, std::string_view suf) {
+    return s.size() >= suf.size()
+        && s.compare(s.size() - suf.size(), suf.size(), suf) == 0;
+}
+
+std::string strip_namespace(std::string compiler) {
+    if (auto colon = compiler.find(':'); colon != std::string::npos)
+        return compiler.substr(colon + 1);
+    return compiler;
+}
+
+std::vector<std::string> frontend_candidates_for(std::string_view ximName,
+                                                 bool isMusl) {
+    if (isMusl) return {"x86_64-linux-musl-g++", "g++"};
+    if (ximName == "gcc") return {"g++"};
+    if (ximName == "llvm") return mcpp::toolchain::llvm::frontend_candidates();
+    if (ximName == "msvc") return {"cl.exe"};
+    return {"g++", "clang++", "x86_64-linux-musl-g++", "cl.exe"};
+}
+
+std::filesystem::path derive_c_compiler_path(const std::filesystem::path& cxxPath) {
+    auto stem = cxxPath.stem().string();
+    auto parent = cxxPath.parent_path();
+    auto ext = cxxPath.extension();
+
+    std::string cc_stem;
+    if (stem.ends_with("++")) {
+        cc_stem = stem.substr(0, stem.size() - 2);
+        if (cc_stem == "g" || cc_stem.ends_with("-g"))
+            cc_stem += "cc";
+    } else {
+        cc_stem = stem;
+    }
+    return parent / (cc_stem + ext.string());
+}
+
+} // namespace
+
+std::expected<ToolchainSpec, std::string>
+parse_toolchain_spec(std::string compilerArg,
+                     std::string versionArg,
+                     bool requireCompiler) {
+    if (auto at = compilerArg.find('@'); at != std::string::npos) {
+        if (versionArg.empty()) versionArg = compilerArg.substr(at + 1);
+        compilerArg = compilerArg.substr(0, at);
+    }
+
+    compilerArg = strip_namespace(std::move(compilerArg));
+    if (compilerArg.empty() && requireCompiler) {
+        return std::unexpected("missing compiler name");
+    }
+
+    ToolchainSpec spec;
+    spec.compiler = std::move(compilerArg);
+    spec.version  = std::move(versionArg);
+    spec.isMusl   = spec.compiler == "musl-gcc" || ends_with(spec.version, "-musl");
+    return spec;
+}
+
+XimToolchainPackage to_xim_package(const ToolchainSpec& spec) {
+    XimToolchainPackage pkg;
+    pkg.displayCompiler = spec.compiler;
+    pkg.displayVersion  = spec.version;
+
+    std::string ximCompiler = spec.compiler;
+    if (mcpp::toolchain::llvm::is_alias(ximCompiler))
+        ximCompiler = mcpp::toolchain::llvm::package_name();
+
+    pkg.ximName = ximCompiler;
+    pkg.ximVersion = spec.version;
+
+    if (spec.isMusl) {
+        if (pkg.ximName != "musl-gcc")
+            pkg.ximName = "musl-" + pkg.ximName;
+        if (ends_with(pkg.ximVersion, "-musl"))
+            pkg.ximVersion.resize(pkg.ximVersion.size() - 5);
+    }
+
+    pkg.frontendCandidates = frontend_candidates_for(pkg.ximName, spec.isMusl);
+    pkg.needsGccPostInstallFixup = spec.compiler == "gcc" && !spec.isMusl;
+    return pkg;
+}
+
+ToolchainSpec with_resolved_xim_version(const ToolchainSpec& spec,
+                                        std::string_view ximVersion) {
+    ToolchainSpec out = spec;
+    out.version = std::string(ximVersion);
+    if (out.isMusl) out.version += "-musl";
+    return out;
+}
+
+std::filesystem::path toolchain_frontend(const std::filesystem::path& binDir,
+                                         std::string_view compiler) {
+    bool isMusl = compiler == "musl-gcc";
+    std::string ximName(compiler);
+    if (mcpp::toolchain::llvm::is_alias(ximName))
+        ximName = mcpp::toolchain::llvm::package_name();
+
+    for (auto& cand : frontend_candidates_for(ximName, isMusl)) {
+        auto p = binDir / cand;
+        if (std::filesystem::exists(p)) return p;
+    }
+    return {};
+}
+
+std::filesystem::path toolchain_frontend(const std::filesystem::path& binDir,
+                                         const XimToolchainPackage& pkg) {
+    for (auto& cand : pkg.frontendCandidates) {
+        auto p = binDir / cand;
+        if (std::filesystem::exists(p)) return p;
+    }
+    return {};
+}
+
+std::string display_label(std::string_view compiler, std::string_view version) {
+    if (compiler == "musl-gcc")
+        return std::format("gcc {}-musl", version);
+    return std::format("{} {}", compiler, version);
+}
+
+bool matches_default_toolchain(std::string_view configuredDefault,
+                               std::string_view compiler,
+                               std::string_view version) {
+    if (configuredDefault == std::format("{}@{}", compiler, version)) return true;
+    if (compiler == "musl-gcc"
+        && configuredDefault == std::format("gcc@{}-musl", version)) {
+        return true;
+    }
+    return false;
+}
+
+std::vector<std::pair<std::string, std::string>> available_toolchain_indexes() {
+    return {
+        {"gcc",      "gcc"},
+        {"musl-gcc", "musl-gcc"},
+        {mcpp::toolchain::llvm::package_name(), "llvm"},
+    };
+}
+
+std::filesystem::path derive_c_compiler(const Toolchain& tc) {
+    return derive_c_compiler_path(tc.binaryPath);
+}
+
+std::filesystem::path archive_tool(const Toolchain& tc) {
+    if (is_clang(tc)) return mcpp::toolchain::clang::archive_tool(tc);
+
+    if (!is_musl_target(tc)) {
+        if (auto binutilsBin = mcpp::toolchain::gcc::find_binutils_bin(tc.binaryPath))
+            return *binutilsBin / "ar";
+    }
+
+    auto muslAr = tc.binaryPath.parent_path() / "x86_64-linux-musl-ar";
+    if (std::filesystem::exists(muslAr)) return muslAr;
+    return {};
+}
+
+std::filesystem::path staged_std_bmi_path(const Toolchain& tc,
+                                          const std::filesystem::path& outputDir) {
+    if (is_clang(tc)) return mcpp::toolchain::clang::staged_std_bmi_path(outputDir);
+    return mcpp::toolchain::gcc::staged_std_bmi_path(outputDir);
+}
+
+} // namespace mcpp::toolchain

--- a/src/toolchain/stdmod.cppm
+++ b/src/toolchain/stdmod.cppm
@@ -8,14 +8,17 @@ module;
 //   g++ -std=c++23 -fmodules -Og -c <std.cc> -o std.o
 //     ⇒ produces gcm.cache/std.gcm + std.o
 //
+// Clang/libc++ flow:
+//   clang++ -std=c++23 --precompile <std.cppm> -o pcm.cache/std.pcm
+//   clang++ -std=c++23 pcm.cache/std.pcm -c -o std.o
+//
 // We invoke the compiler in a dedicated cache directory so the produced
-// gcm.cache/std.gcm is owned by mcpp and reused across all builds with the
-// same fingerprint.
+// BMI is owned by mcpp and reused across all builds with the same fingerprint.
 //
 // Output layout:
 //   <cache_root>/<fingerprint>/
-//      gcm.cache/std.gcm        ← BMI consumed via -fmodule-file=std=...
-//                                 (or simply -fprebuilt-module-path=...)
+//      gcm.cache/std.gcm        ← GCC BMI
+//      pcm.cache/std.pcm        ← Clang BMI
 //      std.o                    ← linked into final binaries
 
 export module mcpp.toolchain.stdmod;
@@ -46,6 +49,27 @@ std::expected<StdModule, StdModError> ensure_built(
 
 namespace mcpp::toolchain {
 
+namespace {
+
+std::expected<std::string, StdModError> run_capture_command(const std::string& cmd) {
+    std::array<char, 4096> buf{};
+    std::string out;
+    std::FILE* fp = ::popen(cmd.c_str(), "r");
+    if (!fp) {
+        return std::unexpected(StdModError{
+            std::format("failed to spawn compiler: {}", cmd)});
+    }
+    while (std::fgets(buf.data(), buf.size(), fp) != nullptr) out += buf.data();
+    int rc = ::pclose(fp);
+    if (rc != 0) {
+        return std::unexpected(StdModError{
+            std::format("std module precompile failed (rc={}):\n{}", rc, out)});
+    }
+    return out;
+}
+
+} // namespace
+
 std::filesystem::path default_cache_root() {
     if (auto* e = std::getenv("MCPP_HOME"); e && *e) {
         return std::filesystem::path(e) / "bmi";
@@ -66,9 +90,12 @@ std::expected<StdModule, StdModError> ensure_built(
             "toolchain has no std module source (import std unsupported on this compiler)"});
     }
 
+    const bool isClang = tc.compiler == CompilerId::Clang;
+
     StdModule sm;
     sm.cacheDir   = cache_root / std::string(fingerprint_hex);
-    sm.bmiPath    = sm.cacheDir / "gcm.cache" / "std.gcm";
+    sm.bmiPath    = sm.cacheDir / (isClang ? "pcm.cache" : "gcm.cache")
+                  / (isClang ? "std.pcm" : "std.gcm");
     sm.objectPath = sm.cacheDir / "std.o";
 
     if (std::filesystem::exists(sm.bmiPath) && std::filesystem::exists(sm.objectPath)) {
@@ -76,11 +103,10 @@ std::expected<StdModule, StdModError> ensure_built(
     }
 
     std::error_code ec;
-    std::filesystem::create_directories(sm.cacheDir, ec);
+    std::filesystem::create_directories(sm.bmiPath.parent_path(), ec);
     if (ec) return std::unexpected(StdModError{
-        std::format("cannot create '{}': {}", sm.cacheDir.string(), ec.message())});
+        std::format("cannot create '{}': {}", sm.bmiPath.parent_path().string(), ec.message())});
 
-    // Run: cd <cacheDir> && g++ -std=c++23 -fmodules -Og [--sysroot=...] -c <std.cc> -o std.o
     std::string sysroot_flag;
     if (!tc.sysroot.empty()) {
         sysroot_flag = std::format(" --sysroot='{}'", tc.sysroot.string());
@@ -90,33 +116,50 @@ std::expected<StdModule, StdModError> ensure_built(
     // -B<binutils-bin> so gcc finds `as`/`ld` directly via its internal
     // exec_prefix lookup — no PATH dependency, no xlings shim involvement.
     std::string b_flag;
-    if (auto as = mcpp::xlings::paths::find_sibling_binary(
-            tc.binaryPath, "binutils", "bin/as")) {
-        b_flag = std::format(" -B'{}'", as->parent_path().string());
+    if (!isClang) {
+        if (auto as = mcpp::xlings::paths::find_sibling_binary(
+                tc.binaryPath, "binutils", "bin/as")) {
+            b_flag = std::format(" -B'{}'", as->parent_path().string());
+        }
     }
 
     auto envPrefix = compiler_env_prefix(tc);
-    auto cmd = std::format(
-        "cd {} && {}{} -std=c++23 -fmodules -O2{}{} -c {} -o std.o 2>&1",
-        mcpp::xlings::shq(sm.cacheDir.string()),
-        envPrefix,
-        mcpp::xlings::shq(tc.binaryPath.string()),
-        sysroot_flag,
-        b_flag,
-        mcpp::xlings::shq(tc.stdModuleSource.string()));
-
-    std::array<char, 4096> buf{};
     std::string out;
-    std::FILE* fp = ::popen(cmd.c_str(), "r");
-    if (!fp) {
-        return std::unexpected(StdModError{
-            std::format("failed to spawn compiler: {}", cmd)});
-    }
-    while (std::fgets(buf.data(), buf.size(), fp) != nullptr) out += buf.data();
-    int rc = ::pclose(fp);
-    if (rc != 0) {
-        return std::unexpected(StdModError{
-            std::format("std module precompile failed (rc={}):\n{}", rc, out)});
+
+    if (isClang) {
+        auto precompile = std::format(
+            "cd {} && {}{} -std=c++23 -Wno-reserved-module-identifier{} "
+            "--precompile {} -o {} 2>&1",
+            mcpp::xlings::shq(sm.cacheDir.string()),
+            envPrefix,
+            mcpp::xlings::shq(tc.binaryPath.string()),
+            sysroot_flag,
+            mcpp::xlings::shq(tc.stdModuleSource.string()),
+            mcpp::xlings::shq(std::filesystem::relative(sm.bmiPath, sm.cacheDir).string()));
+        if (auto r = run_capture_command(precompile); !r) return std::unexpected(r.error());
+        else out += *r;
+
+        auto compile_object = std::format(
+            "cd {} && {}{} -std=c++23 -Wno-reserved-module-identifier{} "
+            "{} -c -o std.o 2>&1",
+            mcpp::xlings::shq(sm.cacheDir.string()),
+            envPrefix,
+            mcpp::xlings::shq(tc.binaryPath.string()),
+            sysroot_flag,
+            mcpp::xlings::shq(std::filesystem::relative(sm.bmiPath, sm.cacheDir).string()));
+        if (auto r = run_capture_command(compile_object); !r) return std::unexpected(r.error());
+        else out += *r;
+    } else {
+        auto cmd = std::format(
+            "cd {} && {}{} -std=c++23 -fmodules -O2{}{} -c {} -o std.o 2>&1",
+            mcpp::xlings::shq(sm.cacheDir.string()),
+            envPrefix,
+            mcpp::xlings::shq(tc.binaryPath.string()),
+            sysroot_flag,
+            b_flag,
+            mcpp::xlings::shq(tc.stdModuleSource.string()));
+        if (auto r = run_capture_command(cmd); !r) return std::unexpected(r.error());
+        else out += *r;
     }
 
     if (!std::filesystem::exists(sm.bmiPath)) {

--- a/src/toolchain/stdmod.cppm
+++ b/src/toolchain/stdmod.cppm
@@ -95,13 +95,15 @@ std::expected<StdModule, StdModError> ensure_built(
         b_flag = std::format(" -B'{}'", as->parent_path().string());
     }
 
+    auto envPrefix = compiler_env_prefix(tc);
     auto cmd = std::format(
-        "cd '{}' && '{}' -std=c++23 -fmodules -O2{}{} -c '{}' -o std.o 2>&1",
-        sm.cacheDir.string(),
-        tc.binaryPath.string(),
+        "cd {} && {}{} -std=c++23 -fmodules -O2{}{} -c {} -o std.o 2>&1",
+        mcpp::xlings::shq(sm.cacheDir.string()),
+        envPrefix,
+        mcpp::xlings::shq(tc.binaryPath.string()),
         sysroot_flag,
         b_flag,
-        tc.stdModuleSource.string());
+        mcpp::xlings::shq(tc.stdModuleSource.string()));
 
     std::array<char, 4096> buf{};
     std::string out;

--- a/src/toolchain/stdmod.cppm
+++ b/src/toolchain/stdmod.cppm
@@ -24,8 +24,9 @@ module;
 export module mcpp.toolchain.stdmod;
 
 import std;
+import mcpp.toolchain.clang;
 import mcpp.toolchain.detect;
-import mcpp.xlings;
+import mcpp.toolchain.gcc;
 
 export namespace mcpp::toolchain {
 
@@ -90,12 +91,11 @@ std::expected<StdModule, StdModError> ensure_built(
             "toolchain has no std module source (import std unsupported on this compiler)"});
     }
 
-    const bool isClang = tc.compiler == CompilerId::Clang;
-
     StdModule sm;
     sm.cacheDir   = cache_root / std::string(fingerprint_hex);
-    sm.bmiPath    = sm.cacheDir / (isClang ? "pcm.cache" : "gcm.cache")
-                  / (isClang ? "std.pcm" : "std.gcm");
+    sm.bmiPath    = is_clang(tc)
+                  ? mcpp::toolchain::clang::std_bmi_path(sm.cacheDir)
+                  : mcpp::toolchain::gcc::std_bmi_path(sm.cacheDir);
     sm.objectPath = sm.cacheDir / "std.o";
 
     if (std::filesystem::exists(sm.bmiPath) && std::filesystem::exists(sm.objectPath)) {
@@ -112,52 +112,17 @@ std::expected<StdModule, StdModError> ensure_built(
         sysroot_flag = std::format(" --sysroot='{}'", tc.sysroot.string());
     }
 
-    // When the compiler comes from mcpp's private sandbox, pass
-    // -B<binutils-bin> so gcc finds `as`/`ld` directly via its internal
-    // exec_prefix lookup — no PATH dependency, no xlings shim involvement.
-    std::string b_flag;
-    if (!isClang) {
-        if (auto as = mcpp::xlings::paths::find_sibling_binary(
-                tc.binaryPath, "binutils", "bin/as")) {
-            b_flag = std::format(" -B'{}'", as->parent_path().string());
-        }
-    }
-
-    auto envPrefix = compiler_env_prefix(tc);
     std::string out;
 
-    if (isClang) {
-        auto precompile = std::format(
-            "cd {} && {}{} -std=c++23 -Wno-reserved-module-identifier{} "
-            "--precompile {} -o {} 2>&1",
-            mcpp::xlings::shq(sm.cacheDir.string()),
-            envPrefix,
-            mcpp::xlings::shq(tc.binaryPath.string()),
-            sysroot_flag,
-            mcpp::xlings::shq(tc.stdModuleSource.string()),
-            mcpp::xlings::shq(std::filesystem::relative(sm.bmiPath, sm.cacheDir).string()));
-        if (auto r = run_capture_command(precompile); !r) return std::unexpected(r.error());
-        else out += *r;
-
-        auto compile_object = std::format(
-            "cd {} && {}{} -std=c++23 -Wno-reserved-module-identifier{} "
-            "{} -c -o std.o 2>&1",
-            mcpp::xlings::shq(sm.cacheDir.string()),
-            envPrefix,
-            mcpp::xlings::shq(tc.binaryPath.string()),
-            sysroot_flag,
-            mcpp::xlings::shq(std::filesystem::relative(sm.bmiPath, sm.cacheDir).string()));
-        if (auto r = run_capture_command(compile_object); !r) return std::unexpected(r.error());
-        else out += *r;
+    if (is_clang(tc)) {
+        for (auto& cmd : mcpp::toolchain::clang::std_module_build_commands(
+                 tc, sm.cacheDir, sm.bmiPath, sysroot_flag)) {
+            if (auto r = run_capture_command(cmd); !r) return std::unexpected(r.error());
+            else out += *r;
+        }
     } else {
-        auto cmd = std::format(
-            "cd {} && {}{} -std=c++23 -fmodules -O2{}{} -c {} -o std.o 2>&1",
-            mcpp::xlings::shq(sm.cacheDir.string()),
-            envPrefix,
-            mcpp::xlings::shq(tc.binaryPath.string()),
-            sysroot_flag,
-            b_flag,
-            mcpp::xlings::shq(tc.stdModuleSource.string()));
+        auto cmd = mcpp::toolchain::gcc::std_module_build_command(
+            tc, sm.cacheDir, sysroot_flag);
         if (auto r = run_capture_command(cmd); !r) return std::unexpected(r.error());
         else out += *r;
     }

--- a/src/xlings.cppm
+++ b/src/xlings.cppm
@@ -189,7 +189,11 @@ int install_with_progress(const Env& env, std::string_view target,
 
 // Write .xlings.json seed file.
 void seed_xlings_json(const Env& env,
-                      std::span<const std::pair<std::string,std::string>> repos);
+                      std::span<const std::pair<std::string,std::string>> repos,
+                      std::string_view mirror = "CN");
+
+// Persist the xlings mirror selection in .xlings.json via xlings itself.
+int set_mirror(const Env& env, std::string_view mirror, bool quiet = false);
 
 // Run xlings self init.
 void ensure_init(const Env& env, bool quiet);
@@ -685,7 +689,8 @@ int install_with_progress(const Env& env, std::string_view target,
 // ─── Sandbox lifecycle ──────────────────────────────────────────────
 
 void seed_xlings_json(const Env& env,
-                      std::span<const std::pair<std::string,std::string>> repos)
+                      std::span<const std::pair<std::string,std::string>> repos,
+                      std::string_view mirror)
 {
     auto path = env.home / ".xlings.json";
     std::string json = "{\n";
@@ -697,9 +702,21 @@ void seed_xlings_json(const Env& env,
     }
     json += "  ],\n";
     json += "  \"lang\": \"en\",\n";
-    json += "  \"mirror\": \"\"\n";
+    json += std::format("  \"mirror\": \"{}\"\n", mirror);
     json += "}\n";
     write_file(path, json);
+}
+
+int set_mirror(const Env& env, std::string_view mirror, bool quiet) {
+    if (mirror.empty()) return 0;
+    auto cmd = std::format(
+        "cd {} && env -u XLINGS_PROJECT_DIR XLINGS_HOME={} {} config --mirror {} {}",
+        shq(env.home.string()),
+        shq(env.home.string()),
+        shq(env.binary.string()),
+        shq(mirror),
+        quiet ? ">/dev/null 2>&1" : "");
+    return std::system(cmd.c_str());
 }
 
 void ensure_init(const Env& env, bool quiet) {

--- a/src/xlings.cppm
+++ b/src/xlings.cppm
@@ -193,7 +193,8 @@ void seed_xlings_json(const Env& env,
                       std::string_view mirror = "CN");
 
 // Persist the xlings mirror selection in .xlings.json via xlings itself.
-int set_mirror(const Env& env, std::string_view mirror, bool quiet = false);
+int config_show(const Env& env);
+int config_set_mirror(const Env& env, std::string_view mirror, bool quiet = false);
 
 // Run xlings self init.
 void ensure_init(const Env& env, bool quiet);
@@ -707,13 +708,16 @@ void seed_xlings_json(const Env& env,
     write_file(path, json);
 }
 
-int set_mirror(const Env& env, std::string_view mirror, bool quiet) {
+int config_show(const Env& env) {
+    auto cmd = std::format("{} config", build_command_prefix(env));
+    return std::system(cmd.c_str());
+}
+
+int config_set_mirror(const Env& env, std::string_view mirror, bool quiet) {
     if (mirror.empty()) return 0;
     auto cmd = std::format(
-        "cd {} && env -u XLINGS_PROJECT_DIR XLINGS_HOME={} {} config --mirror {} {}",
-        shq(env.home.string()),
-        shq(env.home.string()),
-        shq(env.binary.string()),
+        "{} config --mirror {} {}",
+        build_command_prefix(env),
         shq(mirror),
         quiet ? ">/dev/null 2>&1" : "");
     return std::system(cmd.c_str());

--- a/tests/e2e/26_toolchain_management.sh
+++ b/tests/e2e/26_toolchain_management.sh
@@ -36,6 +36,10 @@ out=$("$MCPP" build 2>&1) || rc=$?
 [[ "$out" == *"no toolchain configured"* ]] || { echo "FAIL: error not helpful: $out"; exit 1; }
 
 # 3) Install gcc 16.1.0
+if [[ -n "${MCPP_E2E_TOOLCHAIN_MIRROR:-}" ]]; then
+    "$MCPP" self config --mirror "$MCPP_E2E_TOOLCHAIN_MIRROR"
+    "$MCPP" self config
+fi
 rc=0
 "$MCPP" toolchain install gcc 16.1.0 > /tmp/_inst.log 2>&1 || rc=$?
 if [[ $rc -ne 0 ]]; then

--- a/tests/e2e/30_pack_modes.sh
+++ b/tests/e2e/30_pack_modes.sh
@@ -15,6 +15,13 @@ export MCPP_HOME=$HOME/.mcpp
 cd "$TMP"
 "$MCPP" new myapp > /dev/null
 cd myapp
+# Keep Mode C independent from whatever global default toolchain earlier
+# e2e tests wrote into ~/.mcpp/config.toml.
+cat >> mcpp.toml <<'EOF'
+
+[toolchain]
+linux = "gcc@16.1.0"
+EOF
 
 # ─── Mode C (default = bundle-project) ─────────────────────────────────
 "$MCPP" pack > "$TMP/pack-c.log" 2>&1 || {

--- a/tests/e2e/36_llvm_toolchain.sh
+++ b/tests/e2e/36_llvm_toolchain.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# 36_llvm_toolchain.sh — build a non-module C/C++ package with xlings LLVM.
+set -e
+
+LLVM_ROOT="${HOME}/.mcpp/registry/data/xpkgs/xim-x-llvm/20.1.7"
+if [[ ! -x "$LLVM_ROOT/bin/clang++" ]]; then
+    echo "SKIP: xlings llvm@20.1.7 is not installed"
+    exit 0
+fi
+
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+export MCPP_HOME="$TMP/mcpp-home"
+source "$(dirname "$0")/_inherit_toolchain.sh"
+
+mkdir -p "$TMP/proj/src"
+cd "$TMP/proj"
+
+cat > mcpp.toml <<'EOF'
+[package]
+name    = "hello_llvm"
+version = "0.1.0"
+
+[language]
+import_std = false
+
+[toolchain]
+linux = "llvm@20.1.7"
+EOF
+
+cat > src/main.cpp <<'EOF'
+#include <iostream>
+
+extern "C" int answer(void);
+
+int main() {
+    std::cout << "llvm " << answer() << "\n";
+    return 0;
+}
+EOF
+
+cat > src/answer.c <<'EOF'
+int answer(void) {
+    return 42;
+}
+EOF
+
+"$MCPP" toolchain list > "$TMP/list.log" 2>&1
+grep -q 'llvm 20.1.7' "$TMP/list.log" || {
+    cat "$TMP/list.log"
+    echo "FAIL: toolchain list did not show installed llvm 20.1.7"
+    exit 1
+}
+
+"$MCPP" build --no-cache > "$TMP/build.log" 2>&1 || {
+    cat "$TMP/build.log"
+    echo "FAIL: llvm build failed"
+    exit 1
+}
+grep -q 'Finished' "$TMP/build.log" || {
+    cat "$TMP/build.log"
+    echo "FAIL: build did not finish"
+    exit 1
+}
+
+binary=$(find target -type f -path '*/bin/hello_llvm' | head -1)
+[[ -n "$binary" && -x "$binary" ]] || {
+    find target -maxdepth 5 -type f
+    echo "FAIL: hello_llvm binary missing"
+    exit 1
+}
+
+out=$("$binary")
+[[ "$out" == "llvm 42" ]] || {
+    echo "FAIL: wrong runtime output: $out"
+    exit 1
+}
+
+echo "OK"

--- a/tests/e2e/37_llvm_import_std.sh
+++ b/tests/e2e/37_llvm_import_std.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# 37_llvm_import_std.sh — build an import-std package with xlings LLVM/libc++.
+set -e
+
+LLVM_ROOT="${HOME}/.mcpp/registry/data/xpkgs/xim-x-llvm/20.1.7"
+if [[ ! -x "$LLVM_ROOT/bin/clang++" ]]; then
+    echo "SKIP: xlings llvm@20.1.7 is not installed"
+    exit 0
+fi
+if [[ ! -f "$LLVM_ROOT/share/libc++/v1/std.cppm" ]]; then
+    echo "SKIP: xlings llvm@20.1.7 has no libc++ std.cppm"
+    exit 0
+fi
+
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+export MCPP_HOME="$TMP/mcpp-home"
+source "$(dirname "$0")/_inherit_toolchain.sh"
+
+mkdir -p "$TMP/proj/src"
+cd "$TMP/proj"
+
+cat > mcpp.toml <<'EOF'
+[package]
+name    = "hello_llvm_std"
+version = "0.1.0"
+
+[toolchain]
+linux = "llvm@20.1.7"
+EOF
+
+cat > src/main.cpp <<'EOF'
+import std;
+
+int main() {
+    std::println("llvm std {}", 23);
+    return 0;
+}
+EOF
+
+"$MCPP" build --no-cache > "$TMP/build.log" 2>&1 || {
+    cat "$TMP/build.log"
+    echo "FAIL: llvm import-std build failed"
+    exit 1
+}
+
+binary=$(find target -type f -path '*/bin/hello_llvm_std' | head -1)
+[[ -n "$binary" && -x "$binary" ]] || {
+    find target -maxdepth 5 -type f
+    echo "FAIL: hello_llvm_std binary missing"
+    exit 1
+}
+
+out=$("$binary")
+[[ "$out" == "llvm std 23" ]] || {
+    echo "FAIL: wrong runtime output: $out"
+    exit 1
+}
+
+echo "OK"

--- a/tests/e2e/38_self_config_mirror.sh
+++ b/tests/e2e/38_self_config_mirror.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# 38_self_config_mirror.sh — configure xlings mirror through mcpp self config.
+set -e
+
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+export MCPP_HOME="$TMP/mcpp-home"
+source "$(dirname "$0")/_inherit_toolchain.sh"
+
+"$MCPP" self env > "$TMP/env.log" 2>&1 || {
+    cat "$TMP/env.log"
+    echo "FAIL: self env failed"
+    exit 1
+}
+
+grep -q '"mirror": "CN"' "$MCPP_HOME/registry/.xlings.json" || {
+    cat "$MCPP_HOME/registry/.xlings.json"
+    echo "FAIL: default mirror should be CN"
+    exit 1
+}
+
+"$MCPP" self config --mirror GLOBAL > "$TMP/global.log" 2>&1 || {
+    cat "$TMP/global.log"
+    echo "FAIL: self config --mirror GLOBAL failed"
+    exit 1
+}
+grep -q '"mirror": "GLOBAL"' "$MCPP_HOME/registry/.xlings.json" || {
+    cat "$MCPP_HOME/registry/.xlings.json"
+    echo "FAIL: mirror should be GLOBAL"
+    exit 1
+}
+
+"$MCPP" self config --mirror cn > "$TMP/cn.log" 2>&1 || {
+    cat "$TMP/cn.log"
+    echo "FAIL: self config --mirror cn failed"
+    exit 1
+}
+grep -q '"mirror": "CN"' "$MCPP_HOME/registry/.xlings.json" || {
+    cat "$MCPP_HOME/registry/.xlings.json"
+    echo "FAIL: mirror should be CN"
+    exit 1
+}
+
+if "$MCPP" self config --mirror BAD > "$TMP/bad.log" 2>&1; then
+    cat "$TMP/bad.log"
+    echo "FAIL: invalid mirror unexpectedly succeeded"
+    exit 1
+fi
+grep -q "invalid mirror" "$TMP/bad.log" || {
+    cat "$TMP/bad.log"
+    echo "FAIL: invalid mirror diagnostic missing"
+    exit 1
+}
+
+echo "OK"

--- a/tests/e2e/39_xlings_index_migration.sh
+++ b/tests/e2e/39_xlings_index_migration.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# 39_xlings_index_migration.sh - legacy mcpp-index cache migrates to mcpplibs.
+set -e
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+export MCPP_HOME="$TMP/mcpp-home"
+
+if [[ -z "${MCPP_VENDORED_XLINGS:-}" && -x "$HOME/.mcpp/registry/bin/xlings" ]]; then
+    export MCPP_VENDORED_XLINGS="$HOME/.mcpp/registry/bin/xlings"
+fi
+
+source "$(dirname "$0")/_inherit_toolchain.sh"
+
+cat > "$MCPP_HOME/config.toml" <<'TOML'
+[xlings]
+binary = "bundled"
+home   = ""
+
+[index]
+default = "mcpp-index"
+
+[index.repos."mcpp-index"]
+url = "https://github.com/mcpp-community/mcpp-index.git"
+
+[cache]
+search_ttl_seconds = 3600
+
+[build]
+default_jobs    = 0
+default_backend = "ninja"
+TOML
+
+mkdir -p "$MCPP_HOME/registry"
+cat > "$MCPP_HOME/registry/.xlings.json" <<'JSON'
+{
+  "activeSubos": "default",
+  "index_repos": [
+    {
+      "name": "mcpp-index",
+      "url": "https://github.com/mcpp-community/mcpp-index.git"
+    }
+  ],
+  "lang": "en",
+  "mirror": "GLOBAL",
+  "subos": {
+    "default": {
+      "dir": ""
+    }
+  }
+}
+JSON
+
+"$MCPP" self env > "$TMP/env.log"
+
+grep -q 'default = "mcpplibs"' "$MCPP_HOME/config.toml" || {
+    cat "$MCPP_HOME/config.toml"; echo "config.toml default index was not migrated"; exit 1; }
+grep -q '\[index.repos."mcpplibs"\]' "$MCPP_HOME/config.toml" || {
+    cat "$MCPP_HOME/config.toml"; echo "config.toml repo table was not migrated"; exit 1; }
+if grep -q 'default = "mcpp-index"' "$MCPP_HOME/config.toml" \
+   || grep -q '\[index.repos."mcpp-index"\]' "$MCPP_HOME/config.toml"; then
+    cat "$MCPP_HOME/config.toml"; echo "config.toml still contains legacy index key"; exit 1
+fi
+
+grep -q '"name": "mcpplibs"' "$MCPP_HOME/registry/.xlings.json" || {
+    cat "$MCPP_HOME/registry/.xlings.json"; echo ".xlings.json repo name was not migrated"; exit 1; }
+if grep -q '"name": "mcpp-index"' "$MCPP_HOME/registry/.xlings.json"; then
+    cat "$MCPP_HOME/registry/.xlings.json"; echo ".xlings.json still contains legacy index name"; exit 1
+fi
+
+"$MCPP" self config > "$TMP/self-config.log"
+grep -q 'mcpplibs' "$TMP/self-config.log" || {
+    cat "$TMP/self-config.log"; echo "self config did not show mcpplibs"; exit 1; }
+if grep -q 'index-repo.*mcpp-index[[:space:]]*:' "$TMP/self-config.log"; then
+    cat "$TMP/self-config.log"; echo "self config still shows legacy index key"; exit 1
+fi
+
+echo "OK"

--- a/tests/unit/test_toolchain_detect.cpp
+++ b/tests/unit/test_toolchain_detect.cpp
@@ -1,0 +1,67 @@
+#include <gtest/gtest.h>
+
+import std;
+import mcpp.toolchain.detect;
+
+using namespace mcpp::toolchain;
+
+namespace {
+
+struct TempDirGuard {
+    std::filesystem::path root;
+
+    ~TempDirGuard() {
+        std::error_code ec;
+        std::filesystem::remove_all(root, ec);
+    }
+};
+
+std::filesystem::path make_fake_clang() {
+    auto dir = std::filesystem::temp_directory_path()
+             / std::format("mcpp_fake_clang_{}", std::random_device{}());
+    std::filesystem::create_directories(dir);
+    auto clang = dir / "clang++";
+
+    std::ofstream os(clang);
+    os << R"(#!/usr/bin/env bash
+case "$1" in
+  --version)
+    cat <<'OUT'
+clang version 20.1.7 (https://github.com/llvm/llvm-project 6146a88f60492b520a36f8f8f3231e15f3cc6082)
+Target: x86_64-unknown-linux-gnu
+Configuration file: /home/user/.mcpp/registry/data/xpkgs/xim-x-gcc-runtime/15.1.0/lib64
+OUT
+    ;;
+  -dumpmachine)
+    echo x86_64-unknown-linux-gnu
+    ;;
+  -print-sysroot)
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+)";
+    os.close();
+    std::filesystem::permissions(
+        clang,
+        std::filesystem::perms::owner_exec
+        | std::filesystem::perms::owner_read
+        | std::filesystem::perms::owner_write);
+    return clang;
+}
+
+} // namespace
+
+TEST(ToolchainDetect, ClangVersionOutputIsNotMisclassifiedByGccPaths) {
+    auto clang = make_fake_clang();
+    TempDirGuard cleanup{clang.parent_path()};
+
+    auto tc = detect(clang);
+    ASSERT_TRUE(tc.has_value()) << tc.error().message;
+    EXPECT_EQ(tc->compiler, CompilerId::Clang);
+    EXPECT_EQ(tc->version, "20.1.7");
+    EXPECT_EQ(tc->targetTriple, "x86_64-unknown-linux-gnu");
+    EXPECT_EQ(tc->stdlibId, "libc++");
+    EXPECT_FALSE(tc->hasImportStd);
+}

--- a/tests/unit/test_toolchain_registry.cpp
+++ b/tests/unit/test_toolchain_registry.cpp
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+
+import std;
+import mcpp.toolchain.registry;
+
+using namespace mcpp::toolchain;
+
+TEST(ToolchainRegistry, MapsGccSpecToGccPackage) {
+    auto spec = parse_toolchain_spec("gcc@16.1.0");
+    ASSERT_TRUE(spec.has_value()) << spec.error();
+
+    auto pkg = to_xim_package(*spec);
+    EXPECT_EQ(pkg.ximName, "gcc");
+    EXPECT_EQ(pkg.ximVersion, "16.1.0");
+    EXPECT_EQ(pkg.display_spec(), "gcc@16.1.0");
+    ASSERT_FALSE(pkg.frontendCandidates.empty());
+    EXPECT_EQ(pkg.frontendCandidates.front(), "g++");
+    EXPECT_TRUE(pkg.needsGccPostInstallFixup);
+}
+
+TEST(ToolchainRegistry, MapsGccMuslSuffixToMuslGccPackage) {
+    auto spec = parse_toolchain_spec("gcc@15.1.0-musl");
+    ASSERT_TRUE(spec.has_value()) << spec.error();
+
+    auto pkg = to_xim_package(*spec);
+    EXPECT_TRUE(spec->isMusl);
+    EXPECT_EQ(pkg.ximName, "musl-gcc");
+    EXPECT_EQ(pkg.ximVersion, "15.1.0");
+    EXPECT_EQ(pkg.display_spec(), "gcc@15.1.0-musl");
+    ASSERT_FALSE(pkg.frontendCandidates.empty());
+    EXPECT_EQ(pkg.frontendCandidates.front(), "x86_64-linux-musl-g++");
+    EXPECT_FALSE(pkg.needsGccPostInstallFixup);
+}
+
+TEST(ToolchainRegistry, MapsLlvmAndClangAliasesToLlvmPackage) {
+    auto llvmSpec = parse_toolchain_spec("llvm", "20.1.7");
+    auto clangSpec = parse_toolchain_spec("clang@20.1.7");
+    ASSERT_TRUE(llvmSpec.has_value()) << llvmSpec.error();
+    ASSERT_TRUE(clangSpec.has_value()) << clangSpec.error();
+
+    auto llvmPkg = to_xim_package(*llvmSpec);
+    auto clangPkg = to_xim_package(*clangSpec);
+
+    EXPECT_EQ(llvmPkg.ximName, "llvm");
+    EXPECT_EQ(clangPkg.ximName, "llvm");
+    EXPECT_EQ(llvmPkg.ximVersion, "20.1.7");
+    EXPECT_EQ(clangPkg.ximVersion, "20.1.7");
+    EXPECT_EQ(llvmPkg.display_spec(), "llvm@20.1.7");
+    EXPECT_EQ(clangPkg.display_spec(), "clang@20.1.7");
+    ASSERT_FALSE(clangPkg.frontendCandidates.empty());
+    EXPECT_EQ(clangPkg.frontendCandidates.front(), "clang++");
+}
+
+TEST(ToolchainRegistry, ResolvesPartialMuslVersionForDisplayAndPackage) {
+    auto spec = parse_toolchain_spec("gcc", "15-musl");
+    ASSERT_TRUE(spec.has_value()) << spec.error();
+
+    auto resolved = with_resolved_xim_version(*spec, "15.1.0");
+    auto pkg = to_xim_package(resolved);
+
+    EXPECT_EQ(resolved.version, "15.1.0-musl");
+    EXPECT_EQ(pkg.ximName, "musl-gcc");
+    EXPECT_EQ(pkg.ximVersion, "15.1.0");
+    EXPECT_EQ(pkg.display_spec(), "gcc@15.1.0-musl");
+}


### PR DESCRIPTION
## Summary

- Add Clang/libc++ `import std` support for the xlings `llvm@20.1.7` toolchain by discovering libc++'s module manifest, prebuilding `std.pcm`/`std.o`, staging the BMI in Ninja, and passing `-fmodule-file=std=...` to Clang consumers.
- Keep GCC and Clang std-module artifacts separate (`gcm.cache/std.gcm` vs `pcm.cache/std.pcm`) so the toolchain layer can support multiple compiler families cleanly.
- Initialize new MCPP private xlings registries with `mirror = CN` instead of an empty mirror.
- Add `mcpp self config` and `mcpp self config --mirror <CN|GLOBAL>`; the CLI maps through `mcpp.xlings` instead of editing `.xlings.json` directly.
- Add compat fallback for default-namespace dev dependencies such as bare `gtest = "1.15.2"` resolving to the current `compat.gtest` package layout.
- Keep GitHub-hosted CI on `GLOBAL` mirror for toolchain-management e2e downloads while preserving CN as the MCPP default.
- Add e2e coverage for LLVM `import std` and self mirror configuration.

## Validation

- `MCPP_HOME=/home/speak/.mcpp target/x86_64-linux-gnu/da10400fd300debb/bin/mcpp build --no-cache`
- `MCPP=$PWD/target/x86_64-linux-gnu/5b7e8018a8fa4c2a/bin/mcpp tests/e2e/38_self_config_mirror.sh` passed.
- `MCPP=$PWD/target/x86_64-linux-gnu/5b7e8018a8fa4c2a/bin/mcpp tests/e2e/37_llvm_import_std.sh` passed.
- `MCPP_HOME=/home/speak/.mcpp $PWD/target/x86_64-linux-gnu/5b7e8018a8fa4c2a/bin/mcpp self config --mirror CN` passed; `mcpp self config` reports `mirror CN`.
- `MCPP_HOME=/home/speak/.mcpp $PWD/target/x86_64-linux-gnu/5b7e8018a8fa4c2a/bin/mcpp test` passed: 11 test binaries, 0 failed.
- `bash -n tests/e2e/26_toolchain_management.sh && bash -n tests/e2e/run_all.sh` passed.