### PR TITLE
fix: align macOS install asset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## 为什么选择 mcpp
 
-mcpp 专门为 **C++23 模块化开发** 打造。如果你想在项目中使用 `import std`、模块接口单元（`.cppm`）、模块分区等现代 C++ 特性，mcpp 在 Linux 上能为你提供便捷且友好的开发体验：
+mcpp 专门为 **C++23 模块化开发** 打造。如果你想在项目中使用 `import std`、模块接口单元（`.cppm`）、模块分区等现代 C++ 特性，mcpp 在 Linux 和 macOS ARM64 上能为你提供便捷且友好的开发体验：
 
 - **默认模块化** — `mcpp new` 创建的项目模板直接使用 C++23 模块，`import std` 开箱即用
 - **文件级增量构建** — 基于 P1689 dyndep 的三层优化（前端脏检查 + 逐文件扫描 + BMI restat），只重编真正变化的模块
@@ -181,10 +181,10 @@ import mcpplibs.cmdline;
 <details>
 <summary><b>打包与发布</b></summary>
 
-- `mcpp pack`：三种模式 — static（musl全静态）/ bundle-project / bundle-all
-- musl 全静态二进制：单文件可分发，无 glibc 依赖
+- `mcpp pack`：三种 Linux 发布模式 — static（musl全静态）/ bundle-project / bundle-all
+- musl 全静态二进制：单文件可分发，无 glibc 依赖（Linux x86_64）
 - `mcpp publish`：生成 xpkg.lua + 发布到包索引
-- 自动 patchelf 修正 RPATH
+- 自动 patchelf 修正 RPATH（Linux）
 
 </details>
 
@@ -207,12 +207,14 @@ import mcpplibs.cmdline;
 |------------------|:-----------:|:----------:|:------------:|:----:|
 | Linux x86_64     | ✅ | ✅ *默认* | ✅ | — |
 | Linux aarch64    | 🔄 | 🔄 | 🔄 | — |
-| macOS            | — | — | 🔄 | — |
+| macOS arm64      | — | — | ✅ *默认* | — |
+| macOS x86_64     | — | — | 🔄 | — |
 | Windows          | — | — | 🔄 | 🔄 |
 
 ✅ 已支持 ｜ 🔄 计划中
 
-> *默认*：release 二进制走 musl 全静态，Linux x86_64 可直接运行，无 glibc 依赖。
+> *默认*：Linux 默认工具链为 musl-gcc,release 二进制走 musl 全静态；
+> macOS ARM64 默认工具链为 LLVM/Clang。
 
 ## 文档
 

--- a/docs/00-getting-started.md
+++ b/docs/00-getting-started.md
@@ -4,8 +4,9 @@
 
 ## 安装
 
-仅需 Linux x86_64 环境,无需预先安装 GCC、xlings 或其他依赖。
-mcpp 在首次运行时会将 musl-gcc 工具链安装至独立沙盒(`~/.mcpp/`)。
+仅需 Linux x86_64 或 macOS ARM64 环境,无需预先安装 GCC、xlings 或其他依赖。
+mcpp 在首次运行时会将默认工具链安装至独立沙盒(`~/.mcpp/`)。
+Linux 默认使用 musl-gcc,macOS 默认使用 LLVM/Clang。
 
 推荐通过 [xlings](https://xlings.d2learn.org) 进行安装,可与系统
 环境保持隔离:
@@ -74,8 +75,8 @@ mcpp run
 # Built with import std + std::println on modular C++23.
 ```
 
-首次构建需下载默认工具链(musl-gcc 15.1,约 800 MB),期间显示进度
-与速度。下载完成后,所有 mcpp 项目共用同一份沙盒。
+首次构建需下载默认工具链(Linux 为 musl-gcc 15.1,macOS 为 LLVM/Clang 20.1),
+期间显示进度与速度。下载完成后,所有 mcpp 项目共用同一份沙盒。
 
 ## 增量编译与测试
 

--- a/docs/03-toolchains.md
+++ b/docs/03-toolchains.md
@@ -12,14 +12,16 @@ C++23 模块对编译器版本较为敏感,不同版本的 GCC / Clang 在模块
 
 ## 自动安装
 
-首次运行 `mcpp build` 时,若尚未配置工具链,mcpp 会自动安装一份
-musl-gcc 15.1(适用于全静态构建)并将其设为全局默认:
+首次运行 `mcpp build` 时,若尚未配置工具链,mcpp 会自动安装当前平台
+的默认工具链并将其设为全局默认:
 
 ```
 First run no toolchain configured — installing gcc@15.1.0-musl (musl, static) as default
 Downloading xim:musl-gcc@15.1.0 [====>      ] 312 MB / 808 MB  3.7 MB/s
 Default set to gcc@15.1.0-musl
 ```
+
+Linux 默认使用 `gcc@15.1.0-musl`; macOS 默认使用 `llvm@20.1.7`。
 
 后续构建不再触发该流程。
 
@@ -34,6 +36,7 @@ Default set to gcc@15.1.0-musl
 mcpp toolchain install gcc 16.1.0           # GNU libc,适用于动态链接默认场景
 mcpp toolchain install gcc 15.1.0-musl      # musl libc,适用于全静态构建
 mcpp toolchain install musl-gcc 15.1.0      # 等价于上一条
+mcpp toolchain install llvm 20.1.7          # LLVM/Clang,macOS 默认工具链
 ```
 
 版本号支持部分匹配:

--- a/install.sh
+++ b/install.sh
@@ -27,11 +27,10 @@ uname_s=$(uname -s)
 uname_m=$(uname -m)
 case "${uname_s}-${uname_m}" in
     Linux-x86_64)   PLAT="linux-x86_64" ;;
-    Darwin-arm64)   PLAT="darwin-arm64" ;;
-    Darwin-x86_64)  PLAT="darwin-x86_64" ;;
+    Darwin-arm64)   PLAT="macosx-arm64" ;;
     *)
         echo "error: unsupported platform ${uname_s}-${uname_m}." >&2
-        echo "       Currently supported: linux-x86_64, darwin-arm64, darwin-x86_64." >&2
+        echo "       Currently supported: linux-x86_64, macosx-arm64." >&2
         echo "       Build from source instead:" >&2
         echo "       https://github.com/${REPO}#从源码构建开发者" >&2
         exit 1

--- a/tests/e2e/45_install_platform_mapping.sh
+++ b/tests/e2e/45_install_platform_mapping.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# 45_install_platform_mapping.sh — install.sh platform IDs must match release assets.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+INSTALL_SH="$ROOT/install.sh"
+RELEASE_YML="$ROOT/.github/workflows/release.yml"
+
+grep -q 'Darwin-arm64).*PLAT="macosx-arm64"' "$INSTALL_SH" || {
+    echo "FAIL: Darwin-arm64 must map to the released macosx-arm64 asset"
+    exit 1
+}
+
+! grep -q 'Darwin-x86_64).*PLAT=' "$INSTALL_SH" || {
+    echo "FAIL: install.sh advertises Darwin-x86_64, but release CI publishes no macOS x86_64 asset"
+    exit 1
+}
+
+grep -q 'Currently supported: linux-x86_64, macosx-arm64' "$INSTALL_SH" || {
+    echo "FAIL: supported platform message must match published install assets"
+    exit 1
+}
+
+grep -q 'mcpp-macosx-arm64.tar.gz' "$RELEASE_YML" || {
+    echo "FAIL: release workflow must publish the macosx-arm64 alias used by install.sh"
+    exit 1
+}


### PR DESCRIPTION
## Summary
- Align install.sh macOS ARM64 platform mapping with the published `macosx-arm64` release asset.
- Stop advertising macOS x86_64 in the installer until release CI publishes that asset.
- Update README and getting-started/toolchain docs to describe current macOS ARM64 LLVM support.
- Add an e2e regression check for installer platform mapping.

Closes #50

## Test plan
- `bash -n install.sh`
- `bash -n tests/e2e/45_install_platform_mapping.sh`
- `bash tests/e2e/45_install_platform_mapping.sh`
- `git diff --check HEAD~1 HEAD`
