### PR TITLE
ci: add fresh-install workflow for first-time user experience

### DIFF
--- a/.github/workflows/ci-fresh-install.yml
+++ b/.github/workflows/ci-fresh-install.yml
@@ -1,0 +1,114 @@
+name: ci-fresh-install
+
+# Fresh install CI — tests the released mcpp via xlings on clean machines.
+# Validates: xlings install mcpp → mcpp build (self) → mcpp new → mcpp run
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-fresh-install-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux-fresh:
+    name: Linux fresh install
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install xlings + mcpp
+        env:
+          XLINGS_NON_INTERACTIVE: '1'
+        run: |
+          curl -fsSL https://github.com/d2learn/xlings/releases/download/v0.4.30/xlings-0.4.30-linux-x86_64.tar.gz | tar -xzf - -C /tmp
+          /tmp/xlings-0.4.30-linux-x86_64/subos/default/bin/xlings self install
+          export PATH="$HOME/.xlings/subos/default/bin:$PATH"
+          xlings install mcpp -y
+          echo "$HOME/.xlings/subos/default/bin" >> "$GITHUB_PATH"
+
+      - name: mcpp build (self-host)
+        run: mcpp build
+
+      - name: mcpp new hello → mcpp run
+        run: |
+          cd "$(mktemp -d)"
+          mcpp new hello
+          cd hello
+          mcpp run
+
+      - name: install LLVM → mcpp new → mcpp run
+        continue-on-error: true
+        run: |
+          mcpp self config --mirror GLOBAL
+          mcpp toolchain install llvm 20.1.7
+          mcpp toolchain default llvm@20.1.7
+          cd "$(mktemp -d)"
+          mcpp new hello_llvm
+          cd hello_llvm
+          mcpp run
+
+  macos-fresh:
+    name: macOS fresh install
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install xlings + mcpp
+        env:
+          XLINGS_NON_INTERACTIVE: '1'
+        run: |
+          curl -fsSL https://github.com/d2learn/xlings/releases/download/v0.4.30/xlings-0.4.30-macosx-arm64.tar.gz | tar -xzf - -C /tmp
+          /tmp/xlings-0.4.30-macosx-arm64/subos/default/bin/xlings self install
+          export PATH="$HOME/.xlings/subos/default/bin:$PATH"
+          xlings install mcpp -y
+          echo "$HOME/.xlings/subos/default/bin" >> "$GITHUB_PATH"
+
+      - name: mcpp build (self-host)
+        run: mcpp build
+
+      - name: mcpp new hello → mcpp run
+        run: |
+          cd "$(mktemp -d)"
+          mcpp new hello
+          cd hello
+          mcpp run
+
+  windows-fresh:
+    name: Windows fresh install
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install xlings + mcpp
+        shell: pwsh
+        env:
+          XLINGS_NON_INTERACTIVE: '1'
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/d2learn/xlings/releases/download/v0.4.30/xlings-0.4.30-windows-x86_64.zip" -OutFile "$env:TEMP\xlings.zip"
+          Expand-Archive -Path "$env:TEMP\xlings.zip" -DestinationPath "$env:TEMP\xlings-extract" -Force
+          & "$env:TEMP\xlings-extract\xlings-0.4.30-windows-x86_64\subos\default\bin\xlings.exe" self install
+          $xlingsbin = "$env:USERPROFILE\.xlings\subos\default\bin"
+          $env:PATH = "$xlingsbin;$env:PATH"
+          xlings install mcpp -y
+          $xlingsbin | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
+      - name: mcpp build (self-host)
+        shell: pwsh
+        run: mcpp build
+
+      - name: mcpp new hello → mcpp run
+        shell: pwsh
+        run: |
+          $tmp = New-TemporaryFile | ForEach-Object { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
+          Set-Location $tmp
+          mcpp new hello
+          Set-Location hello
+          mcpp run

--- a/.github/workflows/ci-fresh-install.yml
+++ b/.github/workflows/ci-fresh-install.yml
@@ -7,13 +7,12 @@ name: ci-fresh-install
 #   1. mcpp new hello → mcpp run (basic project)
 #   2. mcpp build (build mcpp itself from source)
 #
-# This workflow does NOT run on PRs — it tests released mcpp, not PR code.
-# Triggered manually or on a schedule to catch regressions after releases.
+# This workflow tests released mcpp, not PR code.
+# It does NOT run on PRs — only on push to main, manual trigger, and daily schedule.
+# Failures here mean the released mcpp has issues, not that the PR is broken.
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
     branches: [ main ]
   workflow_dispatch:
   schedule:
@@ -48,7 +47,6 @@ jobs:
 
       - name: "GCC: mcpp new → run"
         run: |
-          mcpp toolchain default gcc
           cd "$(mktemp -d)"
           mcpp new hello_gcc
           cd hello_gcc
@@ -56,7 +54,6 @@ jobs:
 
       - name: "GCC: build mcpp"
         run: |
-          mcpp toolchain default gcc
           mcpp clean
           mcpp build
 

--- a/.github/workflows/ci-fresh-install.yml
+++ b/.github/workflows/ci-fresh-install.yml
@@ -1,24 +1,33 @@
 name: ci-fresh-install
 
-# Fresh install CI — tests the released mcpp via xlings on clean machines.
-# Validates: xlings install mcpp → mcpp build (self) → mcpp new → mcpp run
+# Fresh install CI — validates the released mcpp binary via xlings.
+# Simulates a real first-time user on a clean machine (no caches).
+#
+# For each platform, tests every supported toolchain:
+#   1. mcpp new hello → mcpp run (basic project)
+#   2. mcpp build (build mcpp itself from source)
+#
+# This workflow does NOT run on PRs — it tests released mcpp, not PR code.
+# Triggered manually or on a schedule to catch regressions after releases.
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:
+  schedule:
+    # Run daily at 06:00 UTC to catch issues from xlings/runner updates
+    - cron: '0 6 * * *'
 
 concurrency:
-  group: ci-fresh-install-${{ github.ref }}
+  group: ci-fresh-install
   cancel-in-progress: true
 
 jobs:
+  # ──────────────────────────────────────────────────────────────────
+  # Linux: gcc@16.1.0, musl-gcc@15.1.0, llvm@20.1.7
+  # ──────────────────────────────────────────────────────────────────
   linux-fresh:
     name: Linux fresh install
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
@@ -31,19 +40,38 @@ jobs:
           export PATH="$HOME/.xlings/subos/default/bin:$PATH"
           xlings install mcpp -y
           echo "$HOME/.xlings/subos/default/bin" >> "$GITHUB_PATH"
+          mcpp --version
 
-      - name: mcpp build (self-host)
-        run: mcpp build
-
-      - name: mcpp new hello → mcpp run
+      - name: "GCC: mcpp new → run"
         run: |
+          mcpp toolchain default gcc
           cd "$(mktemp -d)"
-          mcpp new hello
-          cd hello
+          mcpp new hello_gcc
+          cd hello_gcc
           mcpp run
 
-      - name: install LLVM → mcpp new → mcpp run
-        continue-on-error: true
+      - name: "GCC: build mcpp"
+        run: |
+          mcpp toolchain default gcc
+          mcpp clean
+          mcpp build
+
+      - name: "musl-gcc: mcpp new → run"
+        run: |
+          mcpp toolchain install gcc 15.1.0-musl
+          mcpp toolchain default gcc@15.1.0-musl
+          cd "$(mktemp -d)"
+          mcpp new hello_musl
+          cd hello_musl
+          mcpp run
+
+      - name: "musl-gcc: build mcpp"
+        run: |
+          mcpp toolchain default gcc@15.1.0-musl
+          mcpp clean
+          mcpp build
+
+      - name: "LLVM: mcpp new → run"
         run: |
           mcpp self config --mirror GLOBAL
           mcpp toolchain install llvm 20.1.7
@@ -53,6 +81,15 @@ jobs:
           cd hello_llvm
           mcpp run
 
+      - name: "LLVM: build mcpp"
+        run: |
+          mcpp toolchain default llvm@20.1.7
+          mcpp clean
+          mcpp build
+
+  # ──────────────────────────────────────────────────────────────────
+  # macOS: llvm@20.1.7
+  # ──────────────────────────────────────────────────────────────────
   macos-fresh:
     name: macOS fresh install
     runs-on: macos-15
@@ -69,17 +106,23 @@ jobs:
           export PATH="$HOME/.xlings/subos/default/bin:$PATH"
           xlings install mcpp -y
           echo "$HOME/.xlings/subos/default/bin" >> "$GITHUB_PATH"
+          mcpp --version
 
-      - name: mcpp build (self-host)
-        run: mcpp build
-
-      - name: mcpp new hello → mcpp run
+      - name: "LLVM: mcpp new → run"
         run: |
           cd "$(mktemp -d)"
-          mcpp new hello
-          cd hello
+          mcpp new hello_mac
+          cd hello_mac
           mcpp run
 
+      - name: "LLVM: build mcpp"
+        run: |
+          mcpp clean
+          mcpp build
+
+  # ──────────────────────────────────────────────────────────────────
+  # Windows: llvm@20.1.7 + MSVC STL
+  # ──────────────────────────────────────────────────────────────────
   windows-fresh:
     name: Windows fresh install
     runs-on: windows-latest
@@ -99,16 +142,19 @@ jobs:
           $env:PATH = "$xlingsbin;$env:PATH"
           xlings install mcpp -y
           $xlingsbin | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          mcpp --version
 
-      - name: mcpp build (self-host)
-        shell: pwsh
-        run: mcpp build
-
-      - name: mcpp new hello → mcpp run
+      - name: "LLVM: mcpp new → run"
         shell: pwsh
         run: |
           $tmp = New-TemporaryFile | ForEach-Object { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
           Set-Location $tmp
-          mcpp new hello
-          Set-Location hello
+          mcpp new hello_win
+          Set-Location hello_win
           mcpp run
+
+      - name: "LLVM: build mcpp"
+        shell: pwsh
+        run: |
+          mcpp clean
+          mcpp build

--- a/.github/workflows/ci-fresh-install.yml
+++ b/.github/workflows/ci-fresh-install.yml
@@ -11,6 +11,10 @@ name: ci-fresh-install
 # Triggered manually or on a schedule to catch regressions after releases.
 
 on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
   schedule:
     # Run daily at 06:00 UTC to catch issues from xlings/runner updates

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -311,6 +311,8 @@ jobs:
           MCPP=$(find target -path "*/bin/mcpp" | head -1)
           MCPP=$(cd "$(dirname "$MCPP")" && pwd)/$(basename "$MCPP")
           test -x "$MCPP"
+          cp "$MCPP" /tmp/mcpp-fresh
+          MCPP=/tmp/mcpp-fresh
           "$MCPP" toolchain default llvm@20.1.7
           "$MCPP" clean
           "$MCPP" build

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -306,14 +306,12 @@ jobs:
           "$MCPP" toolchain default llvm@20.1.7
           bash tests/e2e/run_all.sh
 
-      - name: Self-host smoke (freshly-built mcpp builds itself again)
+      - name: "Toolchain: LLVM — build mcpp (self-host)"
         run: |
           MCPP=$(find target -path "*/bin/mcpp" | head -1)
           MCPP=$(cd "$(dirname "$MCPP")" && pwd)/$(basename "$MCPP")
           test -x "$MCPP"
-          export PATH="$(dirname "$MCPP"):$PATH"
+          "$MCPP" toolchain default llvm@20.1.7
+          "$MCPP" clean
           "$MCPP" build
           "$MCPP" --version
-          echo ":: Self-host smoke PASS"
-
-      # Fresh user experience test moved to ci-fresh-install.yml (PR #63)

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -108,7 +108,16 @@ jobs:
           "$MCPP_SELF" --version
           echo ":: Self-host smoke PASS"
 
-      # Fresh user experience test moved to ci-fresh-install.yml (PR #63)
+      - name: "Toolchain: LLVM — mcpp new → build → run"
+        shell: bash
+        run: |
+          export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
+          "$MCPP_SELF" toolchain default llvm@20.1.7
+          TMP=$(mktemp -d)
+          cd "$TMP"
+          "$MCPP_SELF" new hello_llvm
+          cd hello_llvm
+          "$MCPP_SELF" run
 
       - name: Package Windows release zip
         id: package

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -100,21 +100,14 @@ jobs:
           "$MCPP_SELF" toolchain default llvm@20.1.7 2>/dev/null || true
           bash tests/e2e/run_all.sh
 
-      - name: Self-host smoke (freshly-built mcpp builds itself again)
-        shell: bash
-        run: |
-          export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
-          "$MCPP_SELF" build
-          "$MCPP_SELF" --version
-          echo ":: Self-host smoke PASS"
-
-      - name: "Toolchain: LLVM — build mcpp"
+      - name: "Toolchain: LLVM — build mcpp (self-host)"
         shell: bash
         run: |
           export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
           "$MCPP_SELF" toolchain default llvm@20.1.7
           "$MCPP_SELF" clean
           "$MCPP_SELF" build
+          "$MCPP_SELF" --version
 
       - name: Package Windows release zip
         id: package

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -108,16 +108,13 @@ jobs:
           "$MCPP_SELF" --version
           echo ":: Self-host smoke PASS"
 
-      - name: "Toolchain: LLVM — mcpp new → build → run"
+      - name: "Toolchain: LLVM — build mcpp"
         shell: bash
         run: |
           export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
           "$MCPP_SELF" toolchain default llvm@20.1.7
-          TMP=$(mktemp -d)
-          cd "$TMP"
-          "$MCPP_SELF" new hello_llvm
-          cd hello_llvm
-          "$MCPP_SELF" run
+          "$MCPP_SELF" clean
+          "$MCPP_SELF" build
 
       - name: Package Windows release zip
         id: package

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -119,9 +119,12 @@ jobs:
           WRAPPER="mcpp-${VERSION}-windows-x86_64"
           ZIPNAME="${WRAPPER}.zip"
 
+          MCPP_BIN=$(find target -name "mcpp.exe" -path "*/bin/*" | head -1)
+          test -n "$MCPP_BIN" || { echo "FAIL: no mcpp.exe in target/"; exit 1; }
+
           STAGING=$(mktemp -d)
           mkdir -p "$STAGING/$WRAPPER/bin" "$STAGING/$WRAPPER/registry/bin"
-          cp "$MCPP_SELF" "$STAGING/$WRAPPER/bin/mcpp.exe"
+          cp "$MCPP_BIN" "$STAGING/$WRAPPER/bin/mcpp.exe"
           printf '@echo off\r\n"%%~dp0bin\\mcpp.exe" %%*\r\n' > "$STAGING/$WRAPPER/mcpp.bat"
           cp README.md "$STAGING/$WRAPPER/" 2>/dev/null || true
           cp LICENSE "$STAGING/$WRAPPER/" 2>/dev/null || true

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -96,9 +96,19 @@ jobs:
           export MCPP="$MCPP_SELF"
           export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
           export MCPP_E2E_TOOLCHAIN_MIRROR=GLOBAL
-          "$MCPP_SELF" self config --mirror GLOBAL 2>/dev/null || true
-          "$MCPP_SELF" toolchain default llvm@20.1.7 2>/dev/null || true
+          "$MCPP_SELF" self config --mirror GLOBAL
+          "$MCPP_SELF" toolchain default llvm@20.1.7
           bash tests/e2e/run_all.sh
+
+      - name: "Toolchain: LLVM — mcpp new → run"
+        shell: bash
+        run: |
+          export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
+          TMP=$(mktemp -d)
+          cd "$TMP"
+          "$MCPP_SELF" new hello_win
+          cd hello_win
+          "$MCPP_SELF" run
 
       - name: "Toolchain: LLVM — build mcpp (self-host)"
         shell: bash
@@ -108,8 +118,7 @@ jobs:
           MCPP=/tmp/mcpp-fresh.exe
           "$MCPP" toolchain default llvm@20.1.7
           "$MCPP" clean --bmi-cache
-          "$MCPP" build
-          "$MCPP" --version
+          "$MCPP" build 2>&1 | tee /dev/stderr | grep -q "Resolved llvm@20.1.7"
 
       - name: Package Windows release zip
         id: package

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -118,7 +118,7 @@ jobs:
           MCPP=/tmp/mcpp-fresh.exe
           "$MCPP" toolchain default llvm@20.1.7
           "$MCPP" clean --bmi-cache
-          "$MCPP" build 2>&1 | tee /dev/stderr | grep -q "Resolved llvm@20.1.7"
+          "$MCPP" build 2>&1 | tee build.log; grep -q "Resolved llvm@20.1.7" build.log
 
       - name: Package Windows release zip
         id: package

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -104,10 +104,12 @@ jobs:
         shell: bash
         run: |
           export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
-          "$MCPP_SELF" toolchain default llvm@20.1.7
-          "$MCPP_SELF" clean
-          "$MCPP_SELF" build
-          "$MCPP_SELF" --version
+          cp "$MCPP_SELF" /tmp/mcpp-fresh.exe
+          MCPP=/tmp/mcpp-fresh.exe
+          "$MCPP" toolchain default llvm@20.1.7
+          "$MCPP" clean --bmi-cache
+          "$MCPP" build
+          "$MCPP" --version
 
       - name: Package Windows release zip
         id: package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,18 +128,13 @@ jobs:
           "$MCPP" toolchain default gcc@16.1.0
           bash tests/e2e/run_all.sh
 
-      - name: Self-host smoke (freshly-built mcpp builds itself again)
-        run: |
-          MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
-          "$MCPP" build
-          "$MCPP" test
-
-      - name: "Toolchain: GCC — build mcpp"
+      - name: "Toolchain: GCC — build mcpp + test"
         run: |
           MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
           "$MCPP" toolchain default gcc@16.1.0
           "$MCPP" clean
           "$MCPP" build
+          "$MCPP" test
 
       - name: "Toolchain: musl-gcc — build mcpp"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,9 +128,14 @@ jobs:
           "$MCPP" toolchain default gcc@16.1.0
           bash tests/e2e/run_all.sh
 
-      - name: "Toolchain: GCC — build mcpp + test"
+      - name: Save freshly-built mcpp for toolchain tests
         run: |
           MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
+          cp "$MCPP" /tmp/mcpp-fresh
+          echo "MCPP=/tmp/mcpp-fresh" >> "$GITHUB_ENV"
+
+      - name: "Toolchain: GCC — build mcpp + test"
+        run: |
           "$MCPP" toolchain default gcc@16.1.0
           "$MCPP" clean
           "$MCPP" build
@@ -138,7 +143,6 @@ jobs:
 
       - name: "Toolchain: musl-gcc — build mcpp"
         run: |
-          MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
           "$MCPP" toolchain install gcc 15.1.0-musl
           "$MCPP" toolchain default gcc@15.1.0-musl
           "$MCPP" clean
@@ -146,7 +150,6 @@ jobs:
 
       - name: "Toolchain: LLVM — build mcpp"
         run: |
-          MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
           "$MCPP" toolchain install llvm 20.1.7
           "$MCPP" toolchain default llvm@20.1.7
           "$MCPP" clean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
       - name: "Toolchain: musl-gcc — mcpp new → build → run"
         run: |
           MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
+          "$MCPP" toolchain install gcc 15.1.0-musl
           "$MCPP" toolchain default gcc@15.1.0-musl
           TMP=$(mktemp -d)
           cd "$TMP"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,13 +137,13 @@ jobs:
       - name: "Toolchain: GCC — build mcpp + test"
         run: |
           "$MCPP" clean
-          "$MCPP" build 2>&1 | tee /dev/stderr | grep -q "Resolved gcc@16.1.0"
+          "$MCPP" build 2>&1 | tee build.log; grep -q "Resolved gcc@16.1.0" build.log
           "$MCPP" test
 
       - name: "Toolchain: musl-gcc — build mcpp (--target)"
         run: |
           "$MCPP" clean
-          "$MCPP" build --target x86_64-linux-musl 2>&1 | tee /dev/stderr | grep -q "musl"
+          "$MCPP" build --target x86_64-linux-musl 2>&1 | tee build.log; grep -q "Resolved gcc@15.1.0-musl" build.log
 
       - name: "Toolchain: LLVM — build mcpp"
         run: |
@@ -151,6 +151,6 @@ jobs:
           # Override project toolchain to use LLVM for this build
           sed -i 's/^default = "gcc@16.1.0"/default = "llvm@20.1.7"/' mcpp.toml
           "$MCPP" clean
-          "$MCPP" build 2>&1 | tee /dev/stderr | grep -q "Resolved llvm@20.1.7"
+          "$MCPP" build 2>&1 | tee build.log; grep -q "Resolved llvm@20.1.7" build.log
           # Restore
           sed -i 's/^default = "llvm@20.1.7"/default = "gcc@16.1.0"/' mcpp.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,21 +136,21 @@ jobs:
 
       - name: "Toolchain: GCC — build mcpp + test"
         run: |
-          "$MCPP" toolchain default gcc@16.1.0
           "$MCPP" clean
-          "$MCPP" build
+          "$MCPP" build 2>&1 | tee /dev/stderr | grep -q "Resolved gcc@16.1.0"
           "$MCPP" test
 
-      - name: "Toolchain: musl-gcc — build mcpp"
+      - name: "Toolchain: musl-gcc — build mcpp (--target)"
         run: |
-          "$MCPP" toolchain install gcc 15.1.0-musl
-          "$MCPP" toolchain default gcc@15.1.0-musl
           "$MCPP" clean
-          "$MCPP" build
+          "$MCPP" build --target x86_64-linux-musl 2>&1 | tee /dev/stderr | grep -q "musl"
 
       - name: "Toolchain: LLVM — build mcpp"
         run: |
           "$MCPP" toolchain install llvm 20.1.7
-          "$MCPP" toolchain default llvm@20.1.7
+          # Override project toolchain to use LLVM for this build
+          sed -i 's/^default = "gcc@16.1.0"/default = "llvm@20.1.7"/' mcpp.toml
           "$MCPP" clean
-          "$MCPP" build
+          "$MCPP" build 2>&1 | tee /dev/stderr | grep -q "Resolved llvm@20.1.7"
+          # Restore
+          sed -i 's/^default = "llvm@20.1.7"/default = "gcc@16.1.0"/' mcpp.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,34 +134,25 @@ jobs:
           "$MCPP" build
           "$MCPP" test
 
-      - name: "Toolchain: GCC — mcpp new → build → run"
+      - name: "Toolchain: GCC — build mcpp"
         run: |
           MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
           "$MCPP" toolchain default gcc@16.1.0
-          TMP=$(mktemp -d)
-          cd "$TMP"
-          "$MCPP" new hello_gcc
-          cd hello_gcc
-          "$MCPP" run
+          "$MCPP" clean
+          "$MCPP" build
 
-      - name: "Toolchain: musl-gcc — mcpp new → build → run"
+      - name: "Toolchain: musl-gcc — build mcpp"
         run: |
           MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
           "$MCPP" toolchain install gcc 15.1.0-musl
           "$MCPP" toolchain default gcc@15.1.0-musl
-          TMP=$(mktemp -d)
-          cd "$TMP"
-          "$MCPP" new hello_musl
-          cd hello_musl
-          "$MCPP" run
+          "$MCPP" clean
+          "$MCPP" build
 
-      - name: "Toolchain: LLVM — install + mcpp new → build → run"
+      - name: "Toolchain: LLVM — build mcpp"
         run: |
           MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
           "$MCPP" toolchain install llvm 20.1.7
           "$MCPP" toolchain default llvm@20.1.7
-          TMP=$(mktemp -d)
-          cd "$TMP"
-          "$MCPP" new hello_llvm
-          cd hello_llvm
-          "$MCPP" run
+          "$MCPP" clean
+          "$MCPP" build


### PR DESCRIPTION
## Summary

- New `ci-fresh-install.yml` workflow that validates the released mcpp binary on clean machines
- Tests the exact first-time user experience: `xlings install mcpp → mcpp build → mcpp new hello → mcpp run`
- All 3 platforms: Linux (GCC + LLVM), macOS (LLVM), Windows (LLVM + MSVC STL)
- No caches — catches issues that cached CI misses

## Related

Split from #62 to keep that PR focused on the sysroot fix.