### PR TITLE
fix: CI — install musl-gcc before setting default + add ci-fresh-install workflow

### DIFF
--- a/.github/workflows/ci-fresh-install.yml
+++ b/.github/workflows/ci-fresh-install.yml
@@ -1,0 +1,114 @@
+name: ci-fresh-install
+
+# Fresh install CI — tests the released mcpp via xlings on clean machines.
+# Validates: xlings install mcpp → mcpp build (self) → mcpp new → mcpp run
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-fresh-install-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux-fresh:
+    name: Linux fresh install
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install xlings + mcpp
+        env:
+          XLINGS_NON_INTERACTIVE: '1'
+        run: |
+          curl -fsSL https://github.com/d2learn/xlings/releases/download/v0.4.30/xlings-0.4.30-linux-x86_64.tar.gz | tar -xzf - -C /tmp
+          /tmp/xlings-0.4.30-linux-x86_64/subos/default/bin/xlings self install
+          export PATH="$HOME/.xlings/subos/default/bin:$PATH"
+          xlings install mcpp -y
+          echo "$HOME/.xlings/subos/default/bin" >> "$GITHUB_PATH"
+
+      - name: mcpp build (self-host)
+        run: mcpp build
+
+      - name: mcpp new hello → mcpp run
+        run: |
+          cd "$(mktemp -d)"
+          mcpp new hello
+          cd hello
+          mcpp run
+
+      - name: install LLVM → mcpp new → mcpp run
+        continue-on-error: true
+        run: |
+          mcpp self config --mirror GLOBAL
+          mcpp toolchain install llvm 20.1.7
+          mcpp toolchain default llvm@20.1.7
+          cd "$(mktemp -d)"
+          mcpp new hello_llvm
+          cd hello_llvm
+          mcpp run
+
+  macos-fresh:
+    name: macOS fresh install
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install xlings + mcpp
+        env:
+          XLINGS_NON_INTERACTIVE: '1'
+        run: |
+          curl -fsSL https://github.com/d2learn/xlings/releases/download/v0.4.30/xlings-0.4.30-macosx-arm64.tar.gz | tar -xzf - -C /tmp
+          /tmp/xlings-0.4.30-macosx-arm64/subos/default/bin/xlings self install
+          export PATH="$HOME/.xlings/subos/default/bin:$PATH"
+          xlings install mcpp -y
+          echo "$HOME/.xlings/subos/default/bin" >> "$GITHUB_PATH"
+
+      - name: mcpp build (self-host)
+        run: mcpp build
+
+      - name: mcpp new hello → mcpp run
+        run: |
+          cd "$(mktemp -d)"
+          mcpp new hello
+          cd hello
+          mcpp run
+
+  windows-fresh:
+    name: Windows fresh install
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install xlings + mcpp
+        shell: pwsh
+        env:
+          XLINGS_NON_INTERACTIVE: '1'
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/d2learn/xlings/releases/download/v0.4.30/xlings-0.4.30-windows-x86_64.zip" -OutFile "$env:TEMP\xlings.zip"
+          Expand-Archive -Path "$env:TEMP\xlings.zip" -DestinationPath "$env:TEMP\xlings-extract" -Force
+          & "$env:TEMP\xlings-extract\xlings-0.4.30-windows-x86_64\subos\default\bin\xlings.exe" self install
+          $xlingsbin = "$env:USERPROFILE\.xlings\subos\default\bin"
+          $env:PATH = "$xlingsbin;$env:PATH"
+          xlings install mcpp -y
+          $xlingsbin | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
+      - name: mcpp build (self-host)
+        shell: pwsh
+        run: mcpp build
+
+      - name: mcpp new hello → mcpp run
+        shell: pwsh
+        run: |
+          $tmp = New-TemporaryFile | ForEach-Object { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
+          Set-Location $tmp
+          mcpp new hello
+          Set-Location hello
+          mcpp run

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -108,7 +108,13 @@ jobs:
           "$MCPP_SELF" --version
           echo ":: Self-host smoke PASS"
 
-      # Fresh user experience test moved to ci-fresh-install.yml (PR #63)
+      - name: "Toolchain: LLVM — build mcpp"
+        shell: bash
+        run: |
+          export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
+          "$MCPP_SELF" toolchain default llvm@20.1.7
+          "$MCPP_SELF" clean
+          "$MCPP_SELF" build
 
       - name: Package Windows release zip
         id: package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,34 +134,24 @@ jobs:
           "$MCPP" build
           "$MCPP" test
 
-      - name: "Toolchain: GCC — mcpp new → build → run"
+      - name: "Toolchain: GCC — build mcpp"
         run: |
           MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
           "$MCPP" toolchain default gcc@16.1.0
-          TMP=$(mktemp -d)
-          cd "$TMP"
-          "$MCPP" new hello_gcc
-          cd hello_gcc
-          "$MCPP" run
+          "$MCPP" clean
+          "$MCPP" build
 
-      - name: "Toolchain: musl-gcc — mcpp new → build → run"
+      - name: "Toolchain: musl-gcc — build mcpp"
         run: |
           MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
-          "$MCPP" toolchain install gcc 15.1.0-musl
           "$MCPP" toolchain default gcc@15.1.0-musl
-          TMP=$(mktemp -d)
-          cd "$TMP"
-          "$MCPP" new hello_musl
-          cd hello_musl
-          "$MCPP" run
+          "$MCPP" clean
+          "$MCPP" build
 
-      - name: "Toolchain: LLVM — install + mcpp new → build → run"
+      - name: "Toolchain: LLVM — build mcpp"
         run: |
           MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
           "$MCPP" toolchain install llvm 20.1.7
           "$MCPP" toolchain default llvm@20.1.7
-          TMP=$(mktemp -d)
-          cd "$TMP"
-          "$MCPP" new hello_llvm
-          cd hello_llvm
-          "$MCPP" run
+          "$MCPP" clean
+          "$MCPP" build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
       - name: "Toolchain: musl-gcc — mcpp new → build → run"
         run: |
           MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
+          "$MCPP" toolchain install gcc 15.1.0-musl
           "$MCPP" toolchain default gcc@15.1.0-musl
           TMP=$(mktemp -d)
           cd "$TMP"


### PR DESCRIPTION
## Summary

- ci.yml: add `mcpp toolchain install gcc 15.1.0-musl` before `toolchain default` — the musl-gcc test assumed the toolchain was cached, fails after cache clears
- Add ci-fresh-install.yml: validates released mcpp on clean machines (xlings install mcpp → mcpp build → mcpp new → mcpp run)

Follow-up to PR #62.