### PR TITLE
chore: bump version to 0.0.24, trigger ci-fresh-install on release

### DIFF
--- a/.github/workflows/ci-fresh-install.yml
+++ b/.github/workflows/ci-fresh-install.yml
@@ -8,12 +8,11 @@ name: ci-fresh-install
 #   2. mcpp build (build mcpp itself from source)
 #
 # This workflow tests released mcpp, not PR code.
-# It does NOT run on PRs — only on push to main, manual trigger, and daily schedule.
-# Failures here mean the released mcpp has issues, not that the PR is broken.
+# It runs on release publish, manual trigger, and daily schedule.
 
 on:
-  push:
-    branches: [ main ]
+  release:
+    types: [ published ]
   workflow_dispatch:
   schedule:
     # Run daily at 06:00 UTC to catch issues from xlings/runner updates
@@ -21,7 +20,7 @@ on:
 
 concurrency:
   group: ci-fresh-install
-  cancel-in-progress: true
+  cancel-in-progress: false # use false to test in PRs, true to only test released mcpp
 
 jobs:
   # ──────────────────────────────────────────────────────────────────
@@ -38,24 +37,30 @@ jobs:
         env:
           XLINGS_NON_INTERACTIVE: '1'
         run: |
-          curl -fsSL https://github.com/d2learn/xlings/releases/download/v0.4.30/xlings-0.4.30-linux-x86_64.tar.gz | tar -xzf - -C /tmp
-          /tmp/xlings-0.4.30-linux-x86_64/subos/default/bin/xlings self install
-          export PATH="$HOME/.xlings/subos/default/bin:$PATH"
-          xlings install mcpp -y
-          echo "$HOME/.xlings/subos/default/bin" >> "$GITHUB_PATH"
-          mcpp --version
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash -s v0.4.38
+          echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
 
-      - name: "GCC: mcpp new → run"
+      - name: Install mcpp and config mirror
+        run: |
+          xlings install mcpp -y -g  # install to global
+          mcpp --version
+          mcpp self config --mirror GLOBAL
+
+          echo "mcpp debug info:"
+          which mcpp
+          cat $HOME/.xlings/.xlings.json
+
+      - name: "Default: mcpp new → run"
         run: |
           cd "$(mktemp -d)"
           mcpp new hello_gcc
           cd hello_gcc
           mcpp run
 
-      - name: "GCC: build mcpp"
+      - name: "Default: build mcpp"
         run: |
           mcpp clean
-          mcpp build
+          mcpp run
 
       - name: "musl-gcc: mcpp new → run"
         run: |
@@ -70,11 +75,25 @@ jobs:
         run: |
           mcpp toolchain default gcc@15.1.0-musl
           mcpp clean
-          mcpp build
+          mcpp run
+
+      - name: "gcc 16: mcpp new → run"
+        run: |
+          mcpp toolchain install gcc 16.1.0
+          mcpp toolchain default gcc@16.1.0
+          cd "$(mktemp -d)"
+          mcpp new hello_gcc16
+          cd hello_gcc16
+          mcpp run
+
+      - name: "gcc 16: build mcpp"
+        run: |
+          mcpp toolchain default gcc@16.1.0
+          mcpp clean
+          mcpp run
 
       - name: "LLVM: mcpp new → run"
         run: |
-          mcpp self config --mirror GLOBAL
           mcpp toolchain install llvm 20.1.7
           mcpp toolchain default llvm@20.1.7
           cd "$(mktemp -d)"
@@ -86,7 +105,7 @@ jobs:
         run: |
           mcpp toolchain default llvm@20.1.7
           mcpp clean
-          mcpp build
+          mcpp run
 
   # ──────────────────────────────────────────────────────────────────
   # macOS: llvm@20.1.7
@@ -98,16 +117,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install xlings + mcpp
+      - name: Install xlings
         env:
           XLINGS_NON_INTERACTIVE: '1'
         run: |
-          curl -fsSL https://github.com/d2learn/xlings/releases/download/v0.4.30/xlings-0.4.30-macosx-arm64.tar.gz | tar -xzf - -C /tmp
-          /tmp/xlings-0.4.30-macosx-arm64/subos/default/bin/xlings self install
-          export PATH="$HOME/.xlings/subos/default/bin:$PATH"
-          xlings install mcpp -y
-          echo "$HOME/.xlings/subos/default/bin" >> "$GITHUB_PATH"
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash -s v0.4.38
+          echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
+
+      - name: Install mcpp and config mirror
+        run: |
+          xlings install mcpp -y -g  # install to global
           mcpp --version
+          mcpp self config --mirror GLOBAL
+
+          echo "mcpp debug info:"
+          which mcpp
+          cat $HOME/.xlings/.xlings.json
 
       - name: "LLVM: mcpp new → run"
         run: |
@@ -119,7 +144,7 @@ jobs:
       - name: "LLVM: build mcpp"
         run: |
           mcpp clean
-          mcpp build
+          mcpp run
 
   # ──────────────────────────────────────────────────────────────────
   # Windows: llvm@20.1.7 + MSVC STL
@@ -131,19 +156,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install xlings + mcpp
+      - name: Install xlings
         shell: pwsh
         env:
           XLINGS_NON_INTERACTIVE: '1'
         run: |
-          Invoke-WebRequest -Uri "https://github.com/d2learn/xlings/releases/download/v0.4.30/xlings-0.4.30-windows-x86_64.zip" -OutFile "$env:TEMP\xlings.zip"
-          Expand-Archive -Path "$env:TEMP\xlings.zip" -DestinationPath "$env:TEMP\xlings-extract" -Force
-          & "$env:TEMP\xlings-extract\xlings-0.4.30-windows-x86_64\subos\default\bin\xlings.exe" self install
-          $xlingsbin = "$env:USERPROFILE\.xlings\subos\default\bin"
+          irm https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1 | iex
+
+          $xlingsbin = "$env:USERPROFILE\.xlings\subos\current\bin"
           $env:PATH = "$xlingsbin;$env:PATH"
-          xlings install mcpp -y
           $xlingsbin | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
+      - name: Install mcpp and config mirror
+        shell: pwsh
+        run: |
+          xlings install mcpp -y -g --verbose
+
+          cat "$env:USERPROFILE\.xlings\.xlings.json"
           mcpp --version
+          mcpp self config --mirror GLOBAL
 
       - name: "LLVM: mcpp new → run"
         shell: pwsh
@@ -158,4 +189,4 @@ jobs:
         shell: pwsh
         run: |
           mcpp clean
-          mcpp build
+          mcpp run

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.23"
+version     = "0.0.24"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.23";
+inline constexpr std::string_view MCPP_VERSION = "0.0.24";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;


### PR DESCRIPTION
## Summary
- Bump mcpp version from 0.0.23 to 0.0.24
- Change ci-fresh-install trigger from PR to release publish
- Update xlings install steps (split install/config, pin xlings version)