### PR TITLE
refactor: extract fallback code into src/fallback/ modules

### DIFF
--- a/src/config.cppm
+++ b/src/config.cppm
@@ -24,6 +24,8 @@ import mcpp.pm.index_spec;
 import mcpp.xlings;
 import mcpp.platform;
 import mcpp.log;
+import mcpp.fallback.xlings_binary;
+import mcpp.fallback.config_migration;
 
 export namespace mcpp::config {
 
@@ -265,55 +267,7 @@ bool write_default_xlings_json(const std::filesystem::path& path,
     return std::filesystem::exists(path);
 }
 
-bool replace_all(std::string& text, std::string_view from, std::string_view to) {
-    bool changed = false;
-    for (std::size_t pos = 0;
-         (pos = text.find(from, pos)) != std::string::npos;) {
-        text.replace(pos, from.size(), to);
-        pos += to.size();
-        changed = true;
-    }
-    return changed;
-}
-
-bool write_text_if_changed(const std::filesystem::path& path,
-                           const std::string& original,
-                           const std::string& updated) {
-    if (updated == original) return false;
-    write_file(path, updated);
-    return true;
-}
-
-bool migrate_legacy_config_toml_index_names(const std::filesystem::path& path) {
-    std::ifstream is(path);
-    if (!is) return false;
-    std::stringstream ss;
-    ss << is.rdbuf();
-    auto original = ss.str();
-    auto updated = original;
-
-    replace_all(updated, "default = \"mcpp-index\"", "default = \"mcpplibs\"");
-    replace_all(updated, "[index.repos.\"mcpp-index\"]", "[index.repos.\"mcpplibs\"]");
-
-    return write_text_if_changed(path, original, updated);
-}
-
-bool migrate_legacy_xlings_json_index_names(const std::filesystem::path& path) {
-    std::ifstream is(path);
-    if (!is) return false;
-    std::stringstream ss;
-    ss << is.rdbuf();
-    auto original = ss.str();
-    auto updated = original;
-
-    // Older mcpp sandboxes seeded the package index under the repository
-    // name. Keep the URL and all xlings state intact; only rename the index
-    // key so xlings config/list output matches mcpp's default namespace.
-    replace_all(updated, "\"name\": \"mcpp-index\"", "\"name\": \"mcpplibs\"");
-    replace_all(updated, "\"name\":\"mcpp-index\"", "\"name\":\"mcpplibs\"");
-
-    return write_text_if_changed(path, original, updated);
-}
+// Migration helpers delegated to mcpp.fallback.config_migration.
 
 void canonicalize_legacy_index_names(GlobalConfig& cfg) {
     if (cfg.defaultIndex == "mcpp-index")
@@ -334,65 +288,7 @@ void canonicalize_legacy_index_names(GlobalConfig& cfg) {
     cfg.indexRepos = std::move(normalized);
 }
 
-// Try to acquire xlings binary. Returns the path if successful.
-std::expected<std::filesystem::path, std::string>
-acquire_xlings_binary(const std::filesystem::path& destBin, bool quiet)
-{
-    if (std::filesystem::exists(destBin)) return destBin;
-
-    std::error_code ec;
-    std::filesystem::create_directories(destBin.parent_path(), ec);
-
-    // 1. Explicit override
-    if (auto* e = std::getenv("MCPP_VENDORED_XLINGS"); e && *e) {
-        std::filesystem::path src{e};
-        if (std::filesystem::exists(src)) {
-            std::filesystem::copy_file(src, destBin,
-                std::filesystem::copy_options::overwrite_existing, ec);
-            if (!ec) {
-                std::filesystem::permissions(destBin,
-                    std::filesystem::perms::owner_exec
-                  | std::filesystem::perms::group_exec
-                  | std::filesystem::perms::others_exec,
-                  std::filesystem::perm_options::add, ec);
-                if (!quiet) print_status("Bundled",
-                    std::format("xlings v{} (from MCPP_VENDORED_XLINGS)", kXlingsPinnedVersion));
-                return destBin;
-            }
-        }
-    }
-
-    // 2. Copy from system (`which xlings`)
-    auto xlings_name = std::string("xlings") + std::string(mcpp::platform::exe_suffix);
-    auto sysXlings = mcpp::platform::fs::which(xlings_name);
-    if (sysXlings) {
-        std::string p = sysXlings->string();
-        if (!p.empty() && std::filesystem::exists(p)) {
-            std::filesystem::copy_file(p, destBin,
-                std::filesystem::copy_options::overwrite_existing, ec);
-            if (!ec) {
-                std::filesystem::permissions(destBin,
-                    std::filesystem::perms::owner_exec
-                  | std::filesystem::perms::group_exec
-                  | std::filesystem::perms::others_exec,
-                  std::filesystem::perm_options::add, ec);
-                if (!quiet) print_status("Bundled",
-                    std::format("xlings (copied from system: {})", p));
-                return destBin;
-            }
-        }
-    }
-
-    // 3. Download from GitHub Release (placeholder — real impl uses curl)
-    // We delegate to curl/wget in the bash bootstrap; for in-process robustness
-    // we just instruct the user.
-    return std::unexpected(std::format(
-        "xlings binary not found. Either:\n"
-        "  - install via: curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.sh | bash\n"
-        "  - export MCPP_VENDORED_XLINGS=/abs/path/to/xlings\n"
-        "  - set [xlings].binary = \"system\" in {}",
-        (destBin.parent_path().parent_path() / "config.toml").string()));
-}
+// Xlings binary acquisition delegated to mcpp.fallback.xlings_binary.
 
 // Run `xlings self init` against the sandbox to create the standard
 // directory layout (subos/default/{bin,lib,usr,generations}, data/, config/,
@@ -471,7 +367,7 @@ std::expected<GlobalConfig, ConfigError> load_or_init(
     // 3. Seed config.toml if missing
     bool fresh_config = !std::filesystem::exists(cfg.configFile);
     if (fresh_config) write_default_config_toml(cfg.configFile);
-    else migrate_legacy_config_toml_index_names(cfg.configFile);
+    else mcpp::fallback::migrate_config_toml_index_names(cfg.configFile);
 
     // 4. Load config.toml
     auto doc = t::parse_file(cfg.configFile);
@@ -556,12 +452,12 @@ std::expected<GlobalConfig, ConfigError> load_or_init(
     if (!std::filesystem::exists(xjson)) {
         write_default_xlings_json(xjson, cfg.indexRepos);
     } else {
-        migrate_legacy_xlings_json_index_names(xjson);
+        mcpp::fallback::migrate_xlings_json_index_names(xjson);
     }
 
     // 6. Acquire xlings binary if needed
     if (cfg.xlingsBinaryMode == "bundled") {
-        auto xbin = acquire_xlings_binary(cfg.xlingsBinary, quiet);
+        auto xbin = mcpp::fallback::acquire_xlings_binary(cfg.xlingsBinary, quiet);
         if (!xbin) return std::unexpected(ConfigError{xbin.error()});
     } else if (cfg.xlingsBinaryMode == "system") {
         auto sysPath = mcpp::platform::fs::which(

--- a/src/fallback/config_migration.cppm
+++ b/src/fallback/config_migration.cppm
@@ -1,0 +1,83 @@
+// mcpp.fallback.config_migration — legacy index name migration.
+//
+// Older mcpp sandboxes used "mcpp-index" as the default index name.
+// These helpers rename it to "mcpplibs" in config.toml and .xlings.json
+// so xlings config/list output matches mcpp's default namespace.
+
+export module mcpp.fallback.config_migration;
+
+import std;
+
+export namespace mcpp::fallback {
+
+// Migrate config.toml: rename "mcpp-index" to "mcpplibs".
+// Returns true if the file was modified.
+bool migrate_config_toml_index_names(const std::filesystem::path& path);
+
+// Migrate .xlings.json: rename "mcpp-index" to "mcpplibs".
+// Returns true if the file was modified.
+bool migrate_xlings_json_index_names(const std::filesystem::path& path);
+
+} // namespace mcpp::fallback
+
+namespace mcpp::fallback {
+
+namespace {
+
+bool replace_all(std::string& text, std::string_view from, std::string_view to) {
+    bool changed = false;
+    for (std::size_t pos = 0;
+         (pos = text.find(from, pos)) != std::string::npos;) {
+        text.replace(pos, from.size(), to);
+        pos += to.size();
+        changed = true;
+    }
+    return changed;
+}
+
+void write_file(const std::filesystem::path& p, std::string_view content) {
+    std::error_code ec;
+    std::filesystem::create_directories(p.parent_path(), ec);
+    std::ofstream os(p);
+    os << content;
+}
+
+bool write_text_if_changed(const std::filesystem::path& path,
+                           const std::string& original,
+                           const std::string& updated) {
+    if (updated == original) return false;
+    write_file(path, updated);
+    return true;
+}
+
+} // namespace
+
+bool migrate_config_toml_index_names(const std::filesystem::path& path) {
+    std::ifstream is(path);
+    if (!is) return false;
+    std::stringstream ss;
+    ss << is.rdbuf();
+    auto original = ss.str();
+    auto updated = original;
+
+    replace_all(updated, "default = \"mcpp-index\"", "default = \"mcpplibs\"");
+    replace_all(updated, "[index.repos.\"mcpp-index\"]", "[index.repos.\"mcpplibs\"]");
+
+    return write_text_if_changed(path, original, updated);
+}
+
+bool migrate_xlings_json_index_names(const std::filesystem::path& path) {
+    std::ifstream is(path);
+    if (!is) return false;
+    std::stringstream ss;
+    ss << is.rdbuf();
+    auto original = ss.str();
+    auto updated = original;
+
+    replace_all(updated, "\"name\": \"mcpp-index\"", "\"name\": \"mcpplibs\"");
+    replace_all(updated, "\"name\":\"mcpp-index\"", "\"name\":\"mcpplibs\"");
+
+    return write_text_if_changed(path, original, updated);
+}
+
+} // namespace mcpp::fallback

--- a/src/fallback/legacy_dirs.cppm
+++ b/src/fallback/legacy_dirs.cppm
@@ -1,0 +1,34 @@
+// mcpp.fallback.legacy_dirs — legacy xpkg directory scan.
+//
+// Last-resort fallback scan (COMPAT, remove in 1.0.0): walk xpkgs/
+// for any directory ending with -x-<qualifiedName> or -x-<shortName>.
+
+export module mcpp.fallback.legacy_dirs;
+
+import std;
+
+export namespace mcpp::fallback {
+
+// Scan the xpkgs base directory for a legacy install directory whose
+// name ends with "-x-<qualifiedName>" or "-x-<shortName>".
+// Returns the matching directory name (not the full path) if found.
+std::optional<std::string>
+scan_legacy_install_dirs(const std::filesystem::path& xpkgsBase,
+                         std::string_view qualifiedName,
+                         std::string_view shortName) {
+    std::error_code ec;
+    std::string suffix1 = std::format("-x-{}", qualifiedName);
+    std::string suffix2 = std::format("-x-{}", shortName);
+
+    for (auto& entry : std::filesystem::directory_iterator(xpkgsBase, ec)) {
+        if (!entry.is_directory()) continue;
+        auto dirname = entry.path().filename().string();
+        if (dirname.ends_with(suffix1))
+            return dirname;
+        if (suffix2 != suffix1 && dirname.ends_with(suffix2))
+            return dirname;
+    }
+    return std::nullopt;
+}
+
+} // namespace mcpp::fallback

--- a/src/fallback/probe_sysroot.cppm
+++ b/src/fallback/probe_sysroot.cppm
@@ -1,0 +1,75 @@
+// mcpp.fallback.probe_sysroot — sysroot detection strategies.
+//
+// Three strategies for discovering the sysroot:
+//   1. Remap GCC's baked-in build-time sysroot to the local xpkgs layout
+//   2. Parse Clang's .cfg file for --sysroot=
+//   3. macOS: use xcrun to discover the SDK path
+
+module;
+#include <cstdlib>
+
+export module mcpp.fallback.probe_sysroot;
+
+import std;
+import mcpp.xlings;
+import mcpp.platform;
+import mcpp.log;
+
+export namespace mcpp::fallback {
+
+// When GCC reports a sysroot ending in "subos/default" that doesn't exist
+// on the current machine (baked build-time path), remap it to the
+// equivalent sysroot relative to the compiler's own xpkgs directory.
+std::optional<std::filesystem::path>
+remap_xlings_baked_sysroot(std::string_view reportedPath,
+                           const std::filesystem::path& compilerBin) {
+    if (reportedPath.empty()) return std::nullopt;
+    if (!reportedPath.ends_with("subos/default")) return std::nullopt;
+    if (std::filesystem::exists(std::string(reportedPath))) return std::nullopt;
+
+    if (auto xpkgs = mcpp::xlings::paths::xpkgs_from_compiler(compilerBin)) {
+        // xpkgs is <registry>/data/xpkgs -> registry = xpkgs/../..
+        auto registrySysroot = xpkgs->parent_path().parent_path()
+                               / "subos" / "default";
+        if (std::filesystem::exists(registrySysroot / "usr" / "include"))
+            return registrySysroot;
+    }
+    return std::nullopt;
+}
+
+// Parse a Clang .cfg file alongside the compiler binary for --sysroot=.
+std::optional<std::filesystem::path>
+parse_clang_cfg_sysroot(const std::filesystem::path& compilerBin) {
+    auto stem = compilerBin.stem().string();
+    auto cfgPath = compilerBin.parent_path() / (stem + ".cfg");
+    if (!std::filesystem::exists(cfgPath)) return std::nullopt;
+
+    std::ifstream ifs(cfgPath);
+    std::string line;
+    while (std::getline(ifs, line)) {
+        constexpr std::string_view prefix = "--sysroot=";
+        if (line.starts_with(prefix)) {
+            // Trim whitespace
+            auto val = std::string(line.substr(prefix.size()));
+            while (!val.empty() && (val.back() == '\n' || val.back() == '\r' || val.back() == ' '))
+                val.pop_back();
+            while (!val.empty() && (val.front() == '\n' || val.front() == '\r' || val.front() == ' '))
+                val.erase(val.begin());
+            if (!val.empty() && std::filesystem::exists(val))
+                return std::filesystem::path(val);
+        }
+    }
+    return std::nullopt;
+}
+
+// macOS fallback: use xcrun to discover the SDK path.
+std::optional<std::filesystem::path>
+probe_macos_sdk_sysroot() {
+    auto sdk = mcpp::platform::macos::sdk_path();
+    if (sdk) {
+        mcpp::log::verbose("probe", std::format("sysroot (macOS SDK): {}", sdk->string()));
+    }
+    return sdk;
+}
+
+} // namespace mcpp::fallback

--- a/src/fallback/sysroot_complete.cppm
+++ b/src/fallback/sysroot_complete.cppm
@@ -1,0 +1,52 @@
+// mcpp.fallback.sysroot_complete — ensure sysroot has complete headers.
+//
+// When GCC's probed sysroot exists but may be missing linux kernel
+// headers or glibc headers, symlink them from the payload xpkgs.
+
+export module mcpp.fallback.sysroot_complete;
+
+import std;
+import mcpp.toolchain.model;
+
+export namespace mcpp::fallback {
+
+// Ensure sysroot directory has complete headers by symlinking from
+// payload xpkgs. Called when GCC's probed sysroot exists but may
+// be missing linux kernel headers or glibc headers.
+void ensure_sysroot_complete(const std::filesystem::path& sysroot,
+                             const mcpp::toolchain::PayloadPaths& pp) {
+    if (sysroot.empty()) return;
+
+    auto sysrootInclude = sysroot / "usr" / "include";
+    if (!std::filesystem::exists(sysrootInclude)) return;
+
+    std::error_code ec;
+
+    // Ensure linux kernel headers are present in sysroot.
+    // If missing, symlink from linux-headers payload.
+    if (!pp.linuxInclude.empty()) {
+        for (auto dir : {"linux", "asm", "asm-generic"}) {
+            auto target = sysrootInclude / dir;
+            auto source = pp.linuxInclude / dir;
+            if (!std::filesystem::exists(target, ec) && std::filesystem::exists(source, ec)) {
+                std::filesystem::create_directory_symlink(source, target, ec);
+            }
+        }
+    }
+
+    // Ensure glibc headers are present if sysroot is bare.
+    if (!std::filesystem::exists(sysrootInclude / "features.h", ec)) {
+        // Symlink individual glibc dirs/files into sysroot.
+        for (auto& entry : std::filesystem::directory_iterator(pp.glibcInclude, ec)) {
+            auto target = sysrootInclude / entry.path().filename();
+            if (!std::filesystem::exists(target, ec)) {
+                if (entry.is_directory(ec))
+                    std::filesystem::create_directory_symlink(entry.path(), target, ec);
+                else
+                    std::filesystem::create_symlink(entry.path(), target, ec);
+            }
+        }
+    }
+}
+
+} // namespace mcpp::fallback

--- a/src/fallback/xlings_binary.cppm
+++ b/src/fallback/xlings_binary.cppm
@@ -1,0 +1,85 @@
+// mcpp.fallback.xlings_binary — xlings binary acquisition chain.
+//
+// Tries multiple strategies to obtain the xlings binary:
+//   1. MCPP_VENDORED_XLINGS env var (explicit override)
+//   2. system `which xlings`
+//   3. Fail with user-facing instructions
+
+module;
+#include <cstdlib>
+
+export module mcpp.fallback.xlings_binary;
+
+import std;
+import mcpp.platform;
+
+export namespace mcpp::fallback {
+
+// Try to acquire (copy) the xlings binary to destBin.
+// Returns destBin on success or an error string.
+std::expected<std::filesystem::path, std::string>
+acquire_xlings_binary(const std::filesystem::path& destBin, bool quiet = false) {
+    if (std::filesystem::exists(destBin)) return destBin;
+
+    std::error_code ec;
+    std::filesystem::create_directories(destBin.parent_path(), ec);
+
+    // Right-pad verb to 12 columns (matches mcpp::ui::verb_padded layout).
+    auto print_status = [](std::string_view verb, std::string_view msg) {
+        constexpr std::size_t W = 12;
+        if (verb.size() >= W)
+            std::println("{} {}", verb, msg);
+        else
+            std::println("{}{} {}", std::string(W - verb.size(), ' '), verb, msg);
+    };
+
+    // 1. Explicit override
+    if (auto* e = std::getenv("MCPP_VENDORED_XLINGS"); e && *e) {
+        std::filesystem::path src{e};
+        if (std::filesystem::exists(src)) {
+            std::filesystem::copy_file(src, destBin,
+                std::filesystem::copy_options::overwrite_existing, ec);
+            if (!ec) {
+                std::filesystem::permissions(destBin,
+                    std::filesystem::perms::owner_exec
+                  | std::filesystem::perms::group_exec
+                  | std::filesystem::perms::others_exec,
+                  std::filesystem::perm_options::add, ec);
+                if (!quiet) print_status("Bundled",
+                    std::format("xlings (from MCPP_VENDORED_XLINGS)"));
+                return destBin;
+            }
+        }
+    }
+
+    // 2. Copy from system (`which xlings`)
+    auto xlings_name = std::string("xlings") + std::string(mcpp::platform::exe_suffix);
+    auto sysXlings = mcpp::platform::fs::which(xlings_name);
+    if (sysXlings) {
+        std::string p = sysXlings->string();
+        if (!p.empty() && std::filesystem::exists(p)) {
+            std::filesystem::copy_file(p, destBin,
+                std::filesystem::copy_options::overwrite_existing, ec);
+            if (!ec) {
+                std::filesystem::permissions(destBin,
+                    std::filesystem::perms::owner_exec
+                  | std::filesystem::perms::group_exec
+                  | std::filesystem::perms::others_exec,
+                  std::filesystem::perm_options::add, ec);
+                if (!quiet) print_status("Bundled",
+                    std::format("xlings (copied from system: {})", p));
+                return destBin;
+            }
+        }
+    }
+
+    // 3. Fail with instructions
+    return std::unexpected(std::format(
+        "xlings binary not found. Either:\n"
+        "  - install via: curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.sh | bash\n"
+        "  - export MCPP_VENDORED_XLINGS=/abs/path/to/xlings\n"
+        "  - set [xlings].binary = \"system\" in {}",
+        (destBin.parent_path().parent_path() / "config.toml").string()));
+}
+
+} // namespace mcpp::fallback

--- a/src/fallback/xpkg_copy.cppm
+++ b/src/fallback/xpkg_copy.cppm
@@ -1,0 +1,62 @@
+// mcpp.fallback.xpkg_copy — copy xpkg payload from global ~/.xlings/ to sandbox.
+//
+// Workaround: xlings may extract large packages (e.g. LLVM) into its
+// global data dir instead of the mcpp sandbox, because the extraction
+// subprocess doesn't always inherit XLINGS_HOME. This module detects
+// the global copy and mirrors it into the sandbox so mcpp remains
+// self-contained.
+
+module;
+#include <cstdlib>
+
+export module mcpp.fallback.xpkg_copy;
+
+import std;
+import mcpp.log;
+
+export namespace mcpp::fallback {
+
+// Try to copy an xpkg verdir from the global xlings home into the
+// sandbox. Returns true if the copy succeeded (verdir now exists).
+bool copy_xpkg_from_global(const std::filesystem::path& sandboxVerdir) {
+    if (std::filesystem::exists(sandboxVerdir)) return true;
+
+    mcpp::log::verbose("fallback", "verdir not in sandbox, checking global xlings");
+
+    const char* xhome = nullptr;
+#if defined(_WIN32)
+    xhome = std::getenv("USERPROFILE");
+#endif
+    if (!xhome) xhome = std::getenv("HOME");
+    if (!xhome) return false;
+
+    mcpp::log::debug("fallback", std::format("HOME={}", xhome));
+
+    // xlings stores xpkgs at <home>/.xlings/data/xpkgs/ or
+    // <home>/.xlings/subos/default/data/xpkgs/
+    auto pkgDir = sandboxVerdir.parent_path().filename().string();
+    auto verName = sandboxVerdir.filename().string();
+    std::filesystem::path candidates[] = {
+        std::filesystem::path(xhome) / ".xlings" / "data" / "xpkgs" / pkgDir / verName,
+        std::filesystem::path(xhome) / ".xlings" / "subos" / "default" / "data" / "xpkgs" / pkgDir / verName,
+    };
+
+    for (auto& src : candidates) {
+        std::error_code ec;
+        bool srcExists = std::filesystem::exists(src, ec) && std::filesystem::is_directory(src, ec);
+        mcpp::log::debug("fallback", std::format(
+            "candidate '{}' exists={}", src.string(), srcExists));
+        if (srcExists) {
+            std::filesystem::create_directories(sandboxVerdir.parent_path(), ec);
+            std::filesystem::copy(src, sandboxVerdir,
+                std::filesystem::copy_options::recursive
+                | std::filesystem::copy_options::overwrite_existing, ec);
+            mcpp::log::verbose("fallback", std::format(
+                "copied from global xlings: ec={}", ec.message()));
+            if (!ec) return true;
+        }
+    }
+    return false;
+}
+
+} // namespace mcpp::fallback

--- a/src/pm/package_fetcher.cppm
+++ b/src/pm/package_fetcher.cppm
@@ -19,6 +19,8 @@ import mcpp.pm.compat;
 import mcpp.pm.index_spec;
 import mcpp.xlings;
 import mcpp.libs.toml;       // re-used for tiny JSON-ish parsing? no — stick with manual
+import mcpp.fallback.xpkg_copy;
+import mcpp.fallback.legacy_dirs;
 
 export namespace mcpp::pm {
 
@@ -620,53 +622,8 @@ Fetcher::resolve_xpkg_path(std::string_view target,
         p.sourceDir = (subs.size() == 1) ? subs.front() : p.root;
     };
 
-    auto resolve = [&]() -> std::expected<XpkgPayload, CallError> {
-        // Workaround: xlings may extract large packages (e.g. LLVM) into its
-        // global data dir instead of the mcpp sandbox, because the extraction
-        // subprocess doesn't always inherit XLINGS_HOME. Detect this and copy
-        // the payload into the sandbox so mcpp remains self-contained.
-        // Originally Windows-only; extended to all platforms for the same
-        // reason (xlings subprocess XLINGS_HOME propagation is unreliable).
-        if (!std::filesystem::exists(verdir)) {
-            mcpp::log::verbose("fetcher", "verdir not in sandbox, checking global xlings");
-            const char* xhome = nullptr;
-#if defined(_WIN32)
-            xhome = std::getenv("USERPROFILE");
-#endif
-            if (!xhome) xhome = std::getenv("HOME");
-            if (xhome) {
-                mcpp::log::debug("fetcher", std::format("HOME={}", xhome));
-                // xlings stores xpkgs at <home>/.xlings/data/xpkgs/ or
-                // <home>/.xlings/subos/default/data/xpkgs/
-                auto pkgDir = verdir.parent_path().filename().string();
-                auto verName = verdir.filename().string();
-                std::filesystem::path candidates[] = {
-                    std::filesystem::path(xhome) / ".xlings" / "data" / "xpkgs" / pkgDir / verName,
-                    std::filesystem::path(xhome) / ".xlings" / "subos" / "default" / "data" / "xpkgs" / pkgDir / verName,
-                };
-                for (auto& src : candidates) {
-                    std::error_code ec;
-                    bool srcExists = std::filesystem::exists(src, ec) && std::filesystem::is_directory(src, ec);
-                    mcpp::log::debug("fetcher", std::format(
-                        "candidate '{}' exists={}", src.string(), srcExists));
-                    if (srcExists) {
-                        std::filesystem::create_directories(verdir.parent_path(), ec);
-                        std::filesystem::copy(src, verdir,
-                            std::filesystem::copy_options::recursive
-                            | std::filesystem::copy_options::overwrite_existing, ec);
-                        mcpp::log::verbose("fetcher", std::format(
-                            "copied from global xlings: ec={}", ec.message()));
-                        if (!ec) break;
-                    }
-                }
-            }
-        } else {
-            mcpp::log::debug("fetcher", "verdir exists in sandbox, no copy needed");
-        }
-        if (!std::filesystem::exists(verdir)) {
-            return std::unexpected(CallError{
-                std::format("xpkg payload missing: {}", verdir.string())});
-        }
+    // Build the payload from a verdir that is known to exist.
+    auto make_payload = [&]() -> XpkgPayload {
         XpkgPayload payload;
         // For xim packages (gcc, cmake, ...) the version dir IS the root.
         // For mcpplibs packages the version dir contains an extracted
@@ -677,7 +634,7 @@ Fetcher::resolve_xpkg_path(std::string_view target,
         for (auto& e : std::filesystem::directory_iterator(verdir, ec)) {
             if (e.is_directory()) subs.push_back(e.path());
         }
-        // If verdir directly contains bin/ or include/ → it's the root.
+        // If verdir directly contains bin/ or include/ -> it's the root.
         // Otherwise prefer the unique subdirectory.
         bool verdir_is_root = std::filesystem::exists(verdir / "bin")
                            || std::filesystem::exists(verdir / "include")
@@ -689,32 +646,42 @@ Fetcher::resolve_xpkg_path(std::string_view target,
         return payload;
     };
 
-    auto p = resolve();
-    if (p) return *p;
-
-    if (!autoInstall) {
-        return std::unexpected(p.error());
+    // 1. Sandbox check: verdir already exists locally.
+    if (std::filesystem::exists(verdir)) {
+        mcpp::log::debug("fetcher", "verdir exists in sandbox, no copy needed");
+        return make_payload();
     }
 
-    // Trigger install via xlings.
-    std::vector<std::string> targets {
-        std::format("{}:{}@{}", parsed.indexName, parsed.packageName, parsed.version)
-    };
-    mcpp::log::verbose("fetcher", std::format("triggering xlings install: {}", targets[0]));
-    auto inst = install(targets, handler);
-    if (!inst) return std::unexpected(inst.error());
-    mcpp::log::verbose("fetcher", std::format(
-        "xlings install exitCode={} verdir_exists={}",
-        inst->exitCode, std::filesystem::exists(verdir)));
-    if (inst->exitCode != 0) {
-        std::string err = std::format(
-            "xlings install of '{}:{}@{}' failed (exit {})",
-            parsed.indexName, parsed.packageName, parsed.version, inst->exitCode);
-        if (inst->error) err += ": " + inst->error->message;
-        return std::unexpected(CallError{err});
+    // 2. Install via xlings (if allowed).
+    if (autoInstall) {
+        std::vector<std::string> targets {
+            std::format("{}:{}@{}", parsed.indexName, parsed.packageName, parsed.version)
+        };
+        mcpp::log::verbose("fetcher", std::format("triggering xlings install: {}", targets[0]));
+        auto inst = install(targets, handler);
+        if (!inst) return std::unexpected(inst.error());
+        mcpp::log::verbose("fetcher", std::format(
+            "xlings install exitCode={} verdir_exists={}",
+            inst->exitCode, std::filesystem::exists(verdir)));
+        if (inst->exitCode != 0) {
+            std::string err = std::format(
+                "xlings install of '{}:{}@{}' failed (exit {})",
+                parsed.indexName, parsed.packageName, parsed.version, inst->exitCode);
+            if (inst->error) err += ": " + inst->error->message;
+            return std::unexpected(CallError{err});
+        }
+        if (std::filesystem::exists(verdir))
+            return make_payload();
     }
 
-    return resolve();
+    // 3. Copy fallback: xlings may have extracted into its global data dir
+    //    instead of the mcpp sandbox (XLINGS_HOME propagation is unreliable).
+    mcpp::fallback::copy_xpkg_from_global(verdir);
+    if (std::filesystem::exists(verdir))
+        return make_payload();
+
+    return std::unexpected(CallError{
+        std::format("xpkg payload missing: {}", verdir.string())});
 }
 
 // ─── Namespace-aware install_path (canonical, 0.0.10+) ──────────────
@@ -748,18 +715,8 @@ Fetcher::install_path(std::string_view ns, std::string_view shortName,
     // Last-resort fallback scan (COMPAT, remove in 1.0.0): walk xpkgs/ for
     // any directory ending with -x-<qname> or -x-<shortName>.
     auto qname = mcpp::pm::compat::qualified_name(ns, shortName);
-    std::error_code ec;
-    std::string suffix1 = std::format("-x-{}", qname);
-    std::string suffix2 = std::format("-x-{}", shortName);
-    for (auto& entry : std::filesystem::directory_iterator(base, ec)) {
-        if (!entry.is_directory()) continue;
-        auto dirname = entry.path().filename().string();
-        if (dirname.ends_with(suffix1)) {
-            if (auto p = try_dir(dirname)) return *p;
-        }
-        if (suffix2 != suffix1 && dirname.ends_with(suffix2)) {
-            if (auto p = try_dir(dirname)) return *p;
-        }
+    if (auto legacy = mcpp::fallback::scan_legacy_install_dirs(base, qname, shortName)) {
+        if (auto p = try_dir(*legacy)) return *p;
     }
     return std::nullopt;
 }

--- a/src/toolchain/probe.cppm
+++ b/src/toolchain/probe.cppm
@@ -17,6 +17,8 @@ import mcpp.toolchain.model;
 import mcpp.xlings;
 import mcpp.platform;
 import mcpp.log;
+import mcpp.fallback.sysroot_complete;
+import mcpp.fallback.probe_sysroot;
 
 export namespace mcpp::toolchain {
 
@@ -280,45 +282,19 @@ probe_sysroot(const std::filesystem::path& compilerBin,
 
         // GCC bakes the build-time sysroot into the binary. For xlings-built
         // GCC this is a path like <buildhost>/.xlings/subos/default that
-        // doesn't exist on the user's machine. If the reported path ends
-        // with subos/default, look for the equivalent sysroot relative to
-        // the compiler's own xpkgs directory (payload-derived).
-        if (!s.empty() && s.ends_with("subos/default")) {
-            if (auto xpkgs = mcpp::xlings::paths::xpkgs_from_compiler(compilerBin)) {
-                // xpkgs is <registry>/data/xpkgs → registry = xpkgs/../..
-                auto registrySysroot = xpkgs->parent_path().parent_path()
-                                       / "subos" / "default";
-                if (std::filesystem::exists(registrySysroot / "usr" / "include"))
-                    return registrySysroot;
-            }
-        }
+        // doesn't exist on the user's machine. Remap via fallback module.
+        if (auto remapped = mcpp::fallback::remap_xlings_baked_sysroot(s, compilerBin))
+            return *remapped;
     }
 
     // 2. Parse the compiler driver config file (Clang .cfg).
-    //    xlings-installed Clang ships a clang++.cfg alongside the binary
-    //    with --sysroot pointing to the payload's associated sysroot.
-    {
-        auto stem = compilerBin.stem().string();
-        auto cfgPath = compilerBin.parent_path() / (stem + ".cfg");
-        if (std::filesystem::exists(cfgPath)) {
-            std::ifstream ifs(cfgPath);
-            std::string line;
-            while (std::getline(ifs, line)) {
-                constexpr std::string_view prefix = "--sysroot=";
-                if (line.starts_with(prefix)) {
-                    auto val = trim_line(std::string(line.substr(prefix.size())));
-                    if (!val.empty() && std::filesystem::exists(val))
-                        return val;
-                }
-            }
-        }
-    }
+    if (auto cfg = mcpp::fallback::parse_clang_cfg_sysroot(compilerBin))
+        return *cfg;
 
     // 3. macOS fallback: use xcrun to discover the SDK path.
-    if (auto sdk = mcpp::platform::macos::sdk_path()) {
-        mcpp::log::verbose("probe", std::format("sysroot (macOS SDK): {}", sdk->string()));
+    if (auto sdk = mcpp::fallback::probe_macos_sdk_sysroot())
         return *sdk;
-    }
+
     mcpp::log::debug("probe", "no sysroot found");
     return {};
 }
@@ -363,38 +339,7 @@ probe_payload_paths(const std::filesystem::path& compilerBin) {
 
 void ensure_sysroot_complete(const std::filesystem::path& sysroot,
                              const PayloadPaths& pp) {
-    if (sysroot.empty()) return;
-
-    auto sysrootInclude = sysroot / "usr" / "include";
-    if (!std::filesystem::exists(sysrootInclude)) return;
-
-    std::error_code ec;
-
-    // Ensure linux kernel headers are present in sysroot.
-    // If missing, symlink from linux-headers payload.
-    if (!pp.linuxInclude.empty()) {
-        for (auto dir : {"linux", "asm", "asm-generic"}) {
-            auto target = sysrootInclude / dir;
-            auto source = pp.linuxInclude / dir;
-            if (!std::filesystem::exists(target, ec) && std::filesystem::exists(source, ec)) {
-                std::filesystem::create_directory_symlink(source, target, ec);
-            }
-        }
-    }
-
-    // Ensure glibc headers are present if sysroot is bare.
-    if (!std::filesystem::exists(sysrootInclude / "features.h", ec)) {
-        // Symlink individual glibc dirs/files into sysroot.
-        for (auto& entry : std::filesystem::directory_iterator(pp.glibcInclude, ec)) {
-            auto target = sysrootInclude / entry.path().filename();
-            if (!std::filesystem::exists(target, ec)) {
-                if (entry.is_directory(ec))
-                    std::filesystem::create_directory_symlink(entry.path(), target, ec);
-                else
-                    std::filesystem::create_symlink(entry.path(), target, ec);
-            }
-        }
-    }
+    mcpp::fallback::ensure_sysroot_complete(sysroot, pp);
 }
 
 } // namespace mcpp::toolchain


### PR DESCRIPTION
## Summary
Move fallback implementations from config.cppm, package_fetcher.cppm, and probe.cppm into dedicated modules under `src/fallback/`:

| Module | Function | Source |
|--------|----------|--------|
| `xpkg_copy.cppm` | `copy_xpkg_from_global()` | package_fetcher copy workaround |
| `xlings_binary.cppm` | `acquire_xlings_binary()` | config xlings binary chain |
| `config_migration.cppm` | `migrate_*_index_names()` | config legacy migration |
| `sysroot_complete.cppm` | `ensure_sysroot_complete()` | probe sysroot symlink |
| `legacy_dirs.cppm` | `scan_legacy_install_dirs()` | package_fetcher dir scan |
| `probe_sysroot.cppm` | `remap/parse/probe_macos` | probe sysroot strategies |

Also refactors `resolve_xpkg_path()` priority:
- Before: sandbox → copy → install (copy short-circuits install)
- After: sandbox → install → copy (install-first, copy is fallback)

## Test plan
- [x] `--verbose toolchain install llvm` works correctly
- [x] `mcpp new hello && mcpp run` works
- [x] `mcpp toolchain list` shows installed toolchains
- [ ] CI: Linux, macOS, Windows all pass