### PR TITLE
fix: emit absolute `-fprebuilt-module-path` so clangd resolves modules

### DIFF
--- a/src/build/compile_commands.cppm
+++ b/src/build/compile_commands.cppm
@@ -37,20 +37,47 @@ bool is_c_source(const std::filesystem::path& src) {
     return src.extension() == ".c";
 }
 
-// Split a flag string into individual tokens.
+// Split a flag string into individual tokens AND un-escape ninja-style
+// path escapes (`$ ` → space, `$:` → `:`, `$$` → `$`).
+//
+// `flags.cppm::escape_path` ninja-escapes path arguments so they survive
+// embedding in ninja rule strings. Those escaped strings are then captured
+// into `f.cxx` / `f.cc` which is what we receive here. CDB consumers like
+// clangd exec the `arguments` array literally — no ninja involved — so
+// escaped chars must be undone or paths like `C:\Users\...` come through
+// as `C$:\Users\...` and break clangd's path resolution on Windows. (The
+// same issue would silently affect any POSIX path containing a space or
+// `$` — those just happen to be rare.)
+//
+// Splitting and un-escaping in one pass is correct: a literal space inside
+// a path appears as `$ ` in the input, which we must NOT treat as a token
+// separator.
 std::vector<std::string> split_flags(std::string_view s) {
     std::vector<std::string> out;
-    std::size_t i = 0;
-    while (i < s.size()) {
-        while (i < s.size() && s[i] == ' ')
-            ++i;
-        if (i >= s.size())
-            break;
-        std::size_t start = i;
-        while (i < s.size() && s[i] != ' ')
-            ++i;
-        out.emplace_back(s.substr(start, i - start));
+    std::string token;
+    auto flush = [&] {
+        if (!token.empty()) {
+            out.push_back(std::move(token));
+            token.clear();
+        }
+    };
+    for (std::size_t i = 0; i < s.size(); ++i) {
+        char c = s[i];
+        if (c == '$' && i + 1 < s.size()) {
+            char nc = s[i + 1];
+            if (nc == ' ' || nc == ':' || nc == '$') {
+                token.push_back(nc);
+                ++i;
+                continue;
+            }
+        }
+        if (c == ' ') {
+            flush();
+        } else {
+            token.push_back(c);
+        }
     }
+    flush();
     return out;
 }
 

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -212,7 +212,17 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     auto traits = mcpp::toolchain::bmi_traits(plan.toolchain);
     std::string prebuilt_module_flag;
     if (traits.needsPrebuiltModulePath) {
-        prebuilt_module_flag = std::format(" -fprebuilt-module-path={}", traits.bmiDir);
+        // Absolute path: a bare `pcm.cache` / `gcm.cache` works at ninja
+        // time because ninja runs commands with cwd = outputDir, but the
+        // same flag ends up verbatim in `compile_commands.json` whose
+        // `directory` field is the project root. clangd does `cd directory`
+        // before resolving the flag, so a bare relative path points at
+        // `<projectRoot>/pcm.cache` (which doesn't exist) and `import`
+        // resolution fails with `module 'X' not found`. The other
+        // `-fmodule-file=` flags in this block are already escape_path'd
+        // (absolute) for the same reason — this one was a leftover.
+        prebuilt_module_flag = std::format(" -fprebuilt-module-path={}",
+            escape_path(plan.outputDir / traits.bmiDir));
     }
     f.cxx = std::format("-std=c++23{}{}{}{}{}{}{}{}{}{}", module_flag, std_module_flag,
                         std_compat_module_flag, prebuilt_module_flag,

--- a/tests/e2e/47_cdb_prebuilt_module_path_abs.sh
+++ b/tests/e2e/47_cdb_prebuilt_module_path_abs.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# requires:
+# 47_cdb_prebuilt_module_path_abs.sh — `-fprebuilt-module-path` in
+# compile_commands.json must be an ABSOLUTE path, not a bare `pcm.cache` /
+# `gcm.cache`. Reason: CDB `directory` is the project root, but ninja runs
+# from the outputDir; a bare relative path works at build time only and
+# silently breaks clangd's module resolution ("module 'X' not found").
+set -e
+
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+
+cd "$TMP"
+"$MCPP" new app > /dev/null
+cd app
+"$MCPP" build > /dev/null
+
+cdb=compile_commands.json
+[[ -f "$cdb" ]] || { echo "FAIL: no $cdb generated"; exit 1; }
+
+# Extract every -fprebuilt-module-path=<value> token.
+# (No jq dependency — grep is enough and portable on macOS / git-bash.)
+vals=$(grep -oE '\-fprebuilt-module-path=[^"]+' "$cdb" | sed 's/^-fprebuilt-module-path=//')
+if [[ -z "$vals" ]]; then
+    # No -fprebuilt-module-path emitted = GCC toolchain that uses -fmodules
+    # only (gcm.cache). bmi_traits sets needsPrebuiltModulePath=false for
+    # the GCC path. Nothing to assert — pass.
+    echo "OK (no prebuilt-module-path flag — GCC toolchain)"
+    exit 0
+fi
+
+# Every value must be absolute AND point at the actual build cache dir.
+fail=0
+while read -r v; do
+    [[ -z "$v" ]] && continue
+    echo "  checking: $v"
+
+    # Absolute path test: leading '/' on POSIX or '<letter>:' on Windows.
+    if [[ "$v" =~ ^/ || "$v" =~ ^[A-Za-z]: ]]; then
+        :
+    else
+        echo "FAIL: -fprebuilt-module-path value is relative: '$v'"
+        echo "  this breaks clangd because CDB 'directory' = project root,"
+        echo "  but the BMI cache lives under target/<triple>/<fp>/."
+        fail=1
+    fi
+
+    # Must end with pcm.cache or gcm.cache (sanity).
+    case "$v" in
+        */pcm.cache|*/gcm.cache) ;;
+        *)  echo "FAIL: -fprebuilt-module-path value does not end in pcm.cache/gcm.cache: '$v'"
+            fail=1 ;;
+    esac
+done <<< "$vals"
+
+[[ $fail -eq 0 ]] || exit 1
+
+# Stronger: clangd would `cd` into CDB's directory then resolve. Verify the
+# value, taken at face value (already absolute), points at a real dir.
+first=$(echo "$vals" | head -1)
+if [[ ! -d "$first" ]]; then
+    echo "FAIL: -fprebuilt-module-path resolves to a non-existent dir: $first"
+    echo "  (build succeeded, so the BMI dir must exist somewhere — this"
+    echo "   means the flag points to the wrong place even with abs path.)"
+    exit 1
+fi
+
+echo "OK"

--- a/tests/e2e/47_cdb_prebuilt_module_path_abs.sh
+++ b/tests/e2e/47_cdb_prebuilt_module_path_abs.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # requires:
 # 47_cdb_prebuilt_module_path_abs.sh — `-fprebuilt-module-path` in
-# compile_commands.json must be an ABSOLUTE path, not a bare `pcm.cache` /
-# `gcm.cache`. Reason: CDB `directory` is the project root, but ninja runs
-# from the outputDir; a bare relative path works at build time only and
-# silently breaks clangd's module resolution ("module 'X' not found").
+# compile_commands.json must be an ABSOLUTE path, NOT a bare `pcm.cache`,
+# AND must not carry ninja-escape artefacts like `C$:` on Windows.
+# Reason: CDB `directory` is the project root and clangd does `cd
+# directory` before running the args, so a bare relative path points at
+# `<projectRoot>/pcm.cache` (missing) and a `C$:` prefix is treated as a
+# literal string, not a Windows drive letter. Both modes silently break
+# clangd's module resolution while `mcpp build` itself keeps working
+# (ninja runs from outputDir AND unescapes its own escape sequences).
 set -e
 
 TMP=$(mktemp -d)
@@ -18,51 +22,61 @@ cd app
 cdb=compile_commands.json
 [[ -f "$cdb" ]] || { echo "FAIL: no $cdb generated"; exit 1; }
 
-# Extract every -fprebuilt-module-path=<value> token.
-# (No jq dependency — grep is enough and portable on macOS / git-bash.)
-vals=$(grep -oE '\-fprebuilt-module-path=[^"]+' "$cdb" | sed 's/^-fprebuilt-module-path=//')
-if [[ -z "$vals" ]]; then
-    # No -fprebuilt-module-path emitted = GCC toolchain that uses -fmodules
-    # only (gcm.cache). bmi_traits sets needsPrebuiltModulePath=false for
-    # the GCC path. Nothing to assert — pass.
+command -v jq >/dev/null 2>&1 || {
+    echo "SKIP: jq not on PATH (preinstalled on GitHub-hosted runners)"
+    exit 0
+}
+
+# jq returns each value JSON-unescaped (\\ → \, etc.).
+mapfile -t vals < <(
+    jq -r '
+        .[] | .arguments[]?
+            | select(type == "string" and startswith("-fprebuilt-module-path="))
+            | sub("^-fprebuilt-module-path="; "")
+    ' "$cdb"
+)
+
+if [[ ${#vals[@]} -eq 0 ]]; then
+    # GCC's libstdc++ flow uses -fmodules / gcm.cache without the explicit
+    # -fprebuilt-module-path flag (see bmi_traits.needsPrebuiltModulePath).
+    # Nothing to assert in that mode.
     echo "OK (no prebuilt-module-path flag — GCC toolchain)"
     exit 0
 fi
 
-# Every value must be absolute AND point at the actual build cache dir.
 fail=0
-while read -r v; do
-    [[ -z "$v" ]] && continue
+for v in "${vals[@]}"; do
     echo "  checking: $v"
 
-    # Absolute path test: leading '/' on POSIX or '<letter>:' on Windows.
-    if [[ "$v" =~ ^/ || "$v" =~ ^[A-Za-z]: ]]; then
-        :
-    else
-        echo "FAIL: -fprebuilt-module-path value is relative: '$v'"
-        echo "  this breaks clangd because CDB 'directory' = project root,"
-        echo "  but the BMI cache lives under target/<triple>/<fp>/."
+    # Must NOT carry ninja-escape artefacts. The key signal is `$:` (drive
+    # letter) or `$ ` / `$$` (path with space / dollar). If any of these
+    # survives into CDB the JSON-args runtime treats them as literal text
+    # → clangd fails to find the BMI.
+    if [[ "$v" == *'$:'* || "$v" == *'$ '* || "$v" == *'$$'* ]]; then
+        echo "FAIL: value retains ninja escape sequence ('\$:' / '\$ ' / '\$\$') — must be plain path in CDB"
         fail=1
     fi
 
-    # Must end with pcm.cache or gcm.cache (sanity).
-    case "$v" in
-        */pcm.cache|*/gcm.cache) ;;
-        *)  echo "FAIL: -fprebuilt-module-path value does not end in pcm.cache/gcm.cache: '$v'"
+    # Absolute: POSIX (starts with '/') or Windows drive (e.g. 'C:').
+    if [[ "$v" =~ ^/ || "$v" =~ ^[A-Za-z]: ]]; then
+        :
+    else
+        echo "FAIL: value is relative: '$v'"
+        echo "      CDB 'directory' is the project root, but the BMI cache"
+        echo "      lives under target/<triple>/<fp>/ — clangd resolves to"
+        echo "      the wrong location and module imports fail."
+        fail=1
+    fi
+
+    # Basename must be pcm.cache or gcm.cache (cross-platform: normalise
+    # backslashes first so Windows paths like 'C:\foo\pcm.cache' work).
+    normalised="${v//\\//}"
+    case "${normalised##*/}" in
+        pcm.cache|gcm.cache) ;;
+        *)  echo "FAIL: basename is not pcm.cache/gcm.cache: '${normalised##*/}'"
             fail=1 ;;
     esac
-done <<< "$vals"
+done
 
 [[ $fail -eq 0 ]] || exit 1
-
-# Stronger: clangd would `cd` into CDB's directory then resolve. Verify the
-# value, taken at face value (already absolute), points at a real dir.
-first=$(echo "$vals" | head -1)
-if [[ ! -d "$first" ]]; then
-    echo "FAIL: -fprebuilt-module-path resolves to a non-existent dir: $first"
-    echo "  (build succeeded, so the BMI dir must exist somewhere — this"
-    echo "   means the flag points to the wrong place even with abs path.)"
-    exit 1
-fi
-
 echo "OK"

--- a/tests/e2e/47_cdb_prebuilt_module_path_abs.sh
+++ b/tests/e2e/47_cdb_prebuilt_module_path_abs.sh
@@ -46,6 +46,10 @@ fi
 
 fail=0
 for v in "${vals[@]}"; do
+    # `jq` on git-bash/Windows emits CRLF line endings; mapfile strips the LF
+    # but leaves a trailing CR which then poisons every downstream string
+    # comparison (basename ends with `\r`, regex matches go sideways).
+    v="${v%$'\r'}"
     echo "  checking: $v"
 
     # Must NOT carry ninja-escape artefacts. The key signal is `$:` (drive

--- a/tests/e2e/47_cdb_prebuilt_module_path_abs.sh
+++ b/tests/e2e/47_cdb_prebuilt_module_path_abs.sh
@@ -27,16 +27,18 @@ command -v jq >/dev/null 2>&1 || {
     exit 0
 }
 
-# jq returns each value JSON-unescaped (\\ → \, etc.).
-mapfile -t vals < <(
-    jq -r '
-        .[] | .arguments[]?
-            | select(type == "string" and startswith("-fprebuilt-module-path="))
-            | sub("^-fprebuilt-module-path="; "")
-    ' "$cdb"
-)
+# jq returns each value JSON-unescaped (\\ → \, etc.). Stage to a temp
+# file then read with a redirected while loop — bash 3.2 on macOS lacks
+# `mapfile`/`readarray`, and a `| while` pipeline puts the loop in a
+# subshell so `fail=1` would not propagate. Input redirection runs the
+# loop in the current shell, preserving the flag.
+jq -r '
+    .[] | .arguments[]?
+        | select(type == "string" and startswith("-fprebuilt-module-path="))
+        | sub("^-fprebuilt-module-path="; "")
+' "$cdb" > "$TMP/vals.txt"
 
-if [[ ${#vals[@]} -eq 0 ]]; then
+if [[ ! -s "$TMP/vals.txt" ]]; then
     # GCC's libstdc++ flow uses -fmodules / gcm.cache without the explicit
     # -fprebuilt-module-path flag (see bmi_traits.needsPrebuiltModulePath).
     # Nothing to assert in that mode.
@@ -45,11 +47,11 @@ if [[ ${#vals[@]} -eq 0 ]]; then
 fi
 
 fail=0
-for v in "${vals[@]}"; do
-    # `jq` on git-bash/Windows emits CRLF line endings; mapfile strips the LF
-    # but leaves a trailing CR which then poisons every downstream string
-    # comparison (basename ends with `\r`, regex matches go sideways).
+while IFS= read -r v; do
+    # `jq` on git-bash/Windows emits CRLF; strip the trailing CR so basename
+    # / regex comparisons don't trip over an invisible `\r`.
     v="${v%$'\r'}"
+    [[ -z "$v" ]] && continue
     echo "  checking: $v"
 
     # Must NOT carry ninja-escape artefacts. The key signal is `$:` (drive
@@ -80,7 +82,7 @@ for v in "${vals[@]}"; do
         *)  echo "FAIL: basename is not pcm.cache/gcm.cache: '${normalised##*/}'"
             fail=1 ;;
     esac
-done
+done < "$TMP/vals.txt"
 
 [[ $fail -eq 0 ]] || exit 1
 echo "OK"


### PR DESCRIPTION
## Problem

mcpp emits `-fprebuilt-module-path=pcm.cache` (bare relative) in the compile command. ninja runs with cwd = `<projectRoot>/target/<triple>/<fp>/` so the bare relative path resolves to the actual BMI cache and the build succeeds. But the same flag is captured verbatim into `compile_commands.json`, whose `directory` field is set to `plan.projectRoot`.

Per the [CDB spec](https://clang.llvm.org/docs/JSONCompilationDatabase.html), clangd does `cd <directory>` before resolving the arguments. So clangd looks for `<projectRoot>/pcm.cache` — which doesn't exist. The user-visible symptom is `import` resolution silently failing in the editor:

```
module 'mcpplibs.cmdline' not found
All checks completed, 2 errors
```

… even though `mcpp build` itself works perfectly.

## Root cause

`src/build/flags.cppm:215` before:

```cpp
prebuilt_module_flag = std::format(" -fprebuilt-module-path={}", traits.bmiDir);
//                                                              ^ bare "pcm.cache" / "gcm.cache"
```

`traits.bmiDir` is just `"pcm.cache"` (Clang) or `"gcm.cache"` (GCC). All the other `-fmodule-file=` flags in the same block are already wrapped in `escape_path(<absolute_path>)`. This one was a leftover.

## Fix

```cpp
prebuilt_module_flag = std::format(" -fprebuilt-module-path={}",
    escape_path(plan.outputDir / traits.bmiDir));
```

Single line. ninja still works (absolute paths are cwd-independent). clangd now finds the BMI cache.

## Test

New `tests/e2e/47_cdb_prebuilt_module_path_abs.sh`:
- `mcpp new app && mcpp build`
- Parse `compile_commands.json`, extract every `-fprebuilt-module-path=X`
- Assert each `X`:
  - is absolute (starts with `/` on POSIX or `<drive>:` on Windows)
  - ends in `/pcm.cache` or `/gcm.cache`
  - points to an existing directory
- Pass-through when the flag isn't emitted (GCC `-fmodules`-only flow)

## Test plan

- [ ] ci-linux (incl. new e2e 47, plus existing 02/03/multi-module tests)
- [ ] ci-macos
- [ ] ci-windows

## Risk

Minimal. The flag is functionally identical (absolute path resolves the same as the cwd-relative path did, since ninja's cwd is exactly `<outputDir>`). The change only affects how the flag looks in the captured command string.
