### PR TITLE
chore: bump version to 0.0.30

### DIFF
--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.29"
+version     = "0.0.30"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.29";
+inline constexpr std::string_view MCPP_VERSION = "0.0.30";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;


### PR DESCRIPTION
## Summary
- bump package version to 0.0.30
- sync compiled MCPP_VERSION fingerprint to 0.0.30

## Test plan
- git diff --check
- CI: linux / macOS / Windows