### PR TITLE
fix(build): support xlings mcpp build dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 > 本文件追踪 `mcpp-community/mcpp` 公开仓的版本演进。
 > 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [0.0.31] — 2026-05-30
+
+### 修复
+
+- 修复 xlings 项目使用 mcpp 构建时 custom index 首次同步、project data
+  root 查找和 local index 相对路径解析的问题。
+- 支持 canonical nested dependency 写法:
+  `[dependencies] capi.lua = "0.0.3"` 和
+  `[dependencies.mcpplibs] capi.lua = "0.0.3"`。
+- 将 legacy flat dotted dependency key 兼容解析集中到 `mcpp.pm.compat`,
+  并标注该兼容路径将在 mcpp 1.0.0 移除。
+
 ## [0.0.14] — 2026-05-13
 
 LLVM / Clang 工具链支持与 xlings 镜像配置完善。

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.30"
+version     = "0.0.31"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/build/compile_commands.cppm
+++ b/src/build/compile_commands.cppm
@@ -81,6 +81,15 @@ std::vector<std::string> split_flags(std::string_view s) {
     return out;
 }
 
+std::vector<std::string> local_include_args(const CompileUnit& cu) {
+    std::vector<std::string> args;
+    args.reserve(cu.localIncludeDirs.size());
+    for (auto const& inc : cu.localIncludeDirs) {
+        args.push_back("-I" + inc.string());
+    }
+    return args;
+}
+
 }  // namespace
 
 std::string emit_compile_commands(const BuildPlan& plan, const CompileFlags& flags) {
@@ -96,6 +105,8 @@ std::string emit_compile_commands(const BuildPlan& plan, const CompileFlags& fla
         // Build arguments array.
         nlohmann::json args = nlohmann::json::array();
         args.push_back(compiler.string());
+        for (auto& f : local_include_args(cu))
+            args.push_back(std::move(f));
         for (auto& f : split_flags(flagStr))
             args.push_back(std::move(f));
         args.push_back("-c");

--- a/src/build/ninja_backend.cppm
+++ b/src/build/ninja_backend.cppm
@@ -72,6 +72,27 @@ std::string escape_ninja_path(const std::filesystem::path& p) {
     return out;
 }
 
+std::string escape_flag_path(const std::filesystem::path& p) {
+    auto s = p.string();
+    std::string out;
+    out.reserve(s.size());
+    for (char c : s) {
+        if (c == ' ' || c == '$' || c == ':')
+            out.push_back('$');
+        out.push_back(c);
+    }
+    return out;
+}
+
+std::string local_include_flags(const CompileUnit& cu) {
+    std::string flags;
+    for (auto const& inc : cu.localIncludeDirs) {
+        flags += " -I";
+        flags += escape_flag_path(inc);
+    }
+    return flags;
+}
+
 void write_file(const std::filesystem::path& p, std::string_view content) {
     std::filesystem::create_directories(p.parent_path());
     std::ofstream os(p);
@@ -294,13 +315,13 @@ std::string emit_ninja_string(const BuildPlan& plan) {
     if constexpr (mcpp::platform::is_windows) {
         // Windows: skip BMI restat optimization (requires POSIX shell).
         append(std::format("  command = "
-               "$cxx $cxxflags{} -c $in -o $out\n", module_output_flag));
+               "$cxx $local_includes $cxxflags{} -c $in -o $out\n", module_output_flag));
     } else {
         append(std::format("  command = "
                "if [ -n \"$bmi_out\" ] && [ -f \"$bmi_out\" ]; then "
                  "cp -p \"$bmi_out\" \"$bmi_out.bak\"; "
                "fi && "
-               "$cxx $cxxflags{} -c $in -o $out && "
+               "$cxx $local_includes $cxxflags{} -c $in -o $out && "
                "if [ -n \"$bmi_out\" ] && [ -f \"$bmi_out.bak\" ] && "
                   "cmp -s \"$bmi_out\" \"$bmi_out.bak\"; then "
                  "mv \"$bmi_out.bak\" \"$bmi_out\"; "
@@ -314,7 +335,7 @@ std::string emit_ninja_string(const BuildPlan& plan) {
     append("\n");
 
     append("rule cxx_object\n");
-    append("  command = $cxx $cxxflags -c $in -o $out\n");
+    append("  command = $cxx $local_includes $cxxflags -c $in -o $out\n");
     append("  description = OBJ $out\n");
     if (dyndep)
         append("  restat = 1\n");
@@ -322,7 +343,7 @@ std::string emit_ninja_string(const BuildPlan& plan) {
 
     if (need_c_rule) {
         append("rule c_object\n");
-        append("  command = $cc $cflags -c $in -o $out\n");
+        append("  command = $cc $local_includes $cflags -c $in -o $out\n");
         append("  description = CC $out\n");
         if (dyndep)
             append("  restat = 1\n");
@@ -348,7 +369,7 @@ std::string emit_ninja_string(const BuildPlan& plan) {
         append("rule cxx_scan\n");
         if (plan.scanDepsPath.empty()) {
             // GCC path: compiler-integrated P1689 scanning.
-            append("  command = $cxx $cxxflags -fmodules "
+            append("  command = $cxx $local_includes $cxxflags -fmodules "
                    "-fdeps-format=p1689r5 "
                    "-fdeps-file=$out -fdeps-target=$compile_target "
                    "-M -MM -MF $out.dep -E $in -o $compile_target\n");
@@ -358,10 +379,10 @@ std::string emit_ninja_string(const BuildPlan& plan) {
                 // Wrap in cmd /c for shell redirection (ninja on Windows uses
                 // CreateProcess which doesn't interpret > as redirect).
                 append("  command = cmd /c \"$scan_deps -format=p1689 -- "
-                       "$cxx $cxxflags -c $in -o $compile_target > $out\"\n");
+                       "$cxx $local_includes $cxxflags -c $in -o $compile_target > $out\"\n");
             } else {
                 append("  command = $scan_deps -format=p1689 -- "
-                       "$cxx $cxxflags -c $in -o $compile_target > $out\n");
+                       "$cxx $local_includes $cxxflags -c $in -o $compile_target > $out\n");
             }
         }
         append("  description = SCAN $out\n\n");
@@ -438,6 +459,8 @@ std::string emit_ninja_string(const BuildPlan& plan) {
             append(std::format("build {} : cxx_scan {}\n", escape_ninja_path(ddi),
                                escape_ninja_path(cu.source)));
             append(std::format("  compile_target = {}\n", escape_ninja_path(cu.object)));
+            if (auto includes = local_include_flags(cu); !includes.empty())
+                append(std::format("  local_includes ={}\n", includes));
         }
         append("\n");
 
@@ -481,6 +504,8 @@ std::string emit_ninja_string(const BuildPlan& plan) {
             } else {
                 out_line += "\n";
             }
+            if (auto includes = local_include_flags(cu); !includes.empty())
+                out_line += "  local_includes =" + includes + "\n";
             append(std::move(out_line));
         }
         append("\n");
@@ -519,6 +544,8 @@ std::string emit_ninja_string(const BuildPlan& plan) {
             if (!implicit.empty())
                 out_line += " |" + implicit;
             out_line += "\n";
+            if (auto includes = local_include_flags(cu); !includes.empty())
+                out_line += "  local_includes =" + includes + "\n";
             // Clang needs $bmi_out to emit -fmodule-output=$bmi_out
             if (cu.providesModule) {
                 out_line += "  bmi_out = " + bmi_path(*cu.providesModule) + "\n";

--- a/src/build/plan.cppm
+++ b/src/build/plan.cppm
@@ -17,6 +17,7 @@ export namespace mcpp::build {
 struct CompileUnit {
     std::filesystem::path           source;
     std::filesystem::path           object;            // relative to plan.outputDir
+    std::vector<std::filesystem::path> localIncludeDirs;
     std::optional<std::string>      providesModule;   // logical name, if .cppm export
     std::vector<std::string>        imports;           // logical names imported
 };
@@ -119,6 +120,7 @@ BuildPlan make_plan(const mcpp::manifest::Manifest&         manifest,
         auto& u = graph.units[idx];
         CompileUnit cu;
         cu.source = u.path;
+        cu.localIncludeDirs = u.localIncludeDirs;
         const auto fname = object_filename_for(u.path);
         if (basenameCount[fname] > 1) {
             // Use <sanitized-pkg>/<parent-dir-name> as prefix to handle

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -1368,17 +1368,17 @@ prepare_build(bool print_fingerprint,
     }
 
     // Set up project-level .mcpp/ directory for custom indices.
-    // This creates .mcpp/.xlings.json with non-builtin, non-local index
+    // This creates .mcpp/.xlings.json with custom non-builtin index
     // entries so xlings can clone them into the project-scoped data dir.
     if (!m->indices.empty()) {
         auto cfg2 = get_cfg();
         if (cfg2) {
             mcpp::config::ensure_project_index_dir(**cfg2, *root, m->indices);
 
-            // On first build, .mcpp/data/ may be empty because
+            // On first build, the project xlings data root may be empty because
             // ensure_project_index_dir only writes .xlings.json but doesn't
             // trigger clone/link creation. Check whether there are any custom
-            // non-builtin indices and whether .mcpp/data/ has index content.
+            // non-builtin indices and whether the project data roots have index content.
             // If not, run xlings update before dependency resolution.
             bool hasCustomIndices = false;
             for (auto& [idxName, spec] : m->indices) {
@@ -1388,22 +1388,7 @@ prepare_build(bool print_fingerprint,
                 }
             }
             if (hasCustomIndices) {
-                auto dataDir = *root / ".mcpp" / "data";
-                bool needsClone = !std::filesystem::exists(dataDir);
-                if (!needsClone) {
-                    // Check if data/ has any index directories (dirs with pkgs/ subdir)
-                    std::error_code ec;
-                    bool hasIndexRepo = false;
-                    if (std::filesystem::is_directory(dataDir, ec)) {
-                        for (auto& entry : std::filesystem::directory_iterator(dataDir, ec)) {
-                            if (entry.is_directory() && std::filesystem::exists(entry.path() / "pkgs")) {
-                                hasIndexRepo = true;
-                                break;
-                            }
-                        }
-                    }
-                    needsClone = !hasIndexRepo;
-                }
+                bool needsClone = !mcpp::config::project_index_data_initialized(*root);
                 if (needsClone) {
                     mcpp::ui::status("Fetching", "custom index repos (first use)");
                     auto projEnv = mcpp::config::make_project_xlings_env(**cfg2, *root);
@@ -1513,17 +1498,18 @@ prepare_build(bool print_fingerprint,
         // validate the lua exists, then fall through to the normal install
         // flow below.
         if (idxSpec && idxSpec->is_local()) {
+            auto indexPath = mcpp::config::resolve_project_index_path(*root, *idxSpec);
             auto luaCheck = mcpp::fetcher::Fetcher::read_xpkg_lua_from_path(
-                idxSpec->path, shortName);
+                indexPath, shortName);
             if (!luaCheck) return std::unexpected(std::format(
                 "dependency '{}': not found in local index at '{}'",
-                depName, idxSpec->path.string()));
+                depName, indexPath.string()));
             // lua found — fall through to normal install path resolution.
         }
 
         const bool useProjectEnv = idxSpec && !idxSpec->is_builtin();
 
-        // For custom indices, try project-level .mcpp/data/ first.
+        // For custom indices, try project-level xlings data roots first.
         std::optional<std::filesystem::path> installed;
         if (useProjectEnv) {
             installed = mcpp::fetcher::Fetcher::install_path_from_project_data(
@@ -1798,7 +1784,7 @@ prepare_build(bool print_fingerprint,
         auto& spec = item.spec;
 
         mcpp::pm::compat::normalize_nested_namespace(
-            spec.namespace_, spec.shortName);
+            spec.namespace_, spec.shortName, spec.legacyDottedKey);
 
         // Pin SemVer constraint before dedup/fetch.
         if (auto r = resolveSemver(spec, name); !r) {
@@ -2965,7 +2951,7 @@ int cmd_index_update(const mcpplibs::cmdline::ParsedArgs& parsed) {
                 } else {
                     mcpp::ui::status("Updated", std::format("project index `{}`", idxName));
                 }
-                break;  // ensure_project_index_dir handles all non-local indices at once
+                break;  // ensure_project_index_dir handles all custom indices at once
             }
         }
     }

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -1375,19 +1375,19 @@ prepare_build(bool print_fingerprint,
         if (cfg2) {
             mcpp::config::ensure_project_index_dir(**cfg2, *root, m->indices);
 
-            // Gap 1: On first build, .mcpp/data/ may be empty because
+            // On first build, .mcpp/data/ may be empty because
             // ensure_project_index_dir only writes .xlings.json but doesn't
-            // trigger the actual clone. Check if there are any non-local,
-            // non-builtin indices and whether .mcpp/data/ exists with content.
-            // If not, run xlings update to clone them before dependency resolution.
-            bool hasCustomGitIndices = false;
+            // trigger clone/link creation. Check whether there are any custom
+            // non-builtin indices and whether .mcpp/data/ has index content.
+            // If not, run xlings update before dependency resolution.
+            bool hasCustomIndices = false;
             for (auto& [idxName, spec] : m->indices) {
-                if (!spec.is_local() && !spec.is_builtin()) {
-                    hasCustomGitIndices = true;
+                if (!spec.is_builtin()) {
+                    hasCustomIndices = true;
                     break;
                 }
             }
-            if (hasCustomGitIndices) {
+            if (hasCustomIndices) {
                 auto dataDir = *root / ".mcpp" / "data";
                 bool needsClone = !std::filesystem::exists(dataDir);
                 if (!needsClone) {
@@ -1521,9 +1521,11 @@ prepare_build(bool print_fingerprint,
             // lua found — fall through to normal install path resolution.
         }
 
-        // For custom git indices, try project-level .mcpp/data/ first.
+        const bool useProjectEnv = idxSpec && !idxSpec->is_builtin();
+
+        // For custom indices, try project-level .mcpp/data/ first.
         std::optional<std::filesystem::path> installed;
-        if (idxSpec && !idxSpec->is_local() && !idxSpec->is_builtin()) {
+        if (useProjectEnv) {
             installed = mcpp::fetcher::Fetcher::install_path_from_project_data(
                 *root, ns, shortName, version);
         }
@@ -1538,11 +1540,6 @@ prepare_build(bool print_fingerprint,
             auto fqname = ns.empty() ? shortName
                 : std::format("{}.{}", ns, shortName);
             mcpp::ui::info("Downloading", std::format("{} v{}", fqname, version));
-
-            // Gap 2: For custom git indices, install using the project-level
-            // xlings env so packages land in .mcpp/data/xpkgs/ and the custom
-            // index clone is visible to xlings during resolution.
-            bool useProjectEnv = idxSpec && !idxSpec->is_local() && !idxSpec->is_builtin();
 
             auto install_one = [&](std::string target) -> std::expected<mcpp::xlings::CallResult, mcpp::pm::CallError> {
                 if (useProjectEnv) {
@@ -1559,7 +1556,7 @@ prepare_build(bool print_fingerprint,
                 return fetcher.install(targets, &progress);
             };
             auto target = std::format("{}@{}", fqname, version);
-            // For custom git indices, use indexName:shortName@version format
+            // For custom indices, use indexName:shortName@version format
             // so xlings knows which index to resolve from.
             if (useProjectEnv) {
                 target = std::format("{}:{}@{}", ns, shortName, version);
@@ -1799,6 +1796,9 @@ prepare_build(bool print_fingerprint,
 
         const auto& name = item.name;
         auto& spec = item.spec;
+
+        mcpp::pm::compat::normalize_nested_namespace(
+            spec.namespace_, spec.shortName);
 
         // Pin SemVer constraint before dedup/fetch.
         if (auto r = resolveSemver(spec, name); !r) {

--- a/src/config.cppm
+++ b/src/config.cppm
@@ -104,6 +104,51 @@ mcpp::xlings::Env make_project_xlings_env(const GlobalConfig& cfg,
     return { cfg.xlingsBinary, cfg.xlingsHome(), projectDir / ".mcpp" };
 }
 
+std::vector<std::filesystem::path>
+project_xlings_data_roots(const std::filesystem::path& projectDir)
+{
+    auto dotMcpp = projectDir / ".mcpp";
+    return {
+        dotMcpp / "data",
+        dotMcpp / ".xlings" / "data",
+    };
+}
+
+std::filesystem::path
+resolve_project_index_path(const std::filesystem::path& projectDir,
+                           const mcpp::pm::IndexSpec& spec)
+{
+    auto source = spec.path;
+    if (source.is_relative()) source = projectDir / source;
+    return source.lexically_normal();
+}
+
+bool project_index_data_initialized(const std::filesystem::path& projectDir)
+{
+    std::error_code ec;
+    for (auto const& data : project_xlings_data_roots(projectDir)) {
+        auto reposDir = data / "xim-index-repos";
+        if (std::filesystem::exists(reposDir / "xim-indexrepos.json", ec)) {
+            return true;
+        }
+        if (std::filesystem::is_directory(reposDir, ec)) {
+            for (auto const& entry : std::filesystem::directory_iterator(reposDir, ec)) {
+                if (entry.is_directory(ec) && std::filesystem::exists(entry.path() / "pkgs", ec)) {
+                    return true;
+                }
+            }
+        }
+        if (std::filesystem::is_directory(data, ec)) {
+            for (auto const& entry : std::filesystem::directory_iterator(data, ec)) {
+                if (entry.is_directory(ec) && std::filesystem::exists(entry.path() / "pkgs", ec)) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
 // Check that the sandbox bootstrap completed successfully.
 // Returns empty string if ok, or a description of what's missing.
 std::string check_base_init(const GlobalConfig& cfg) {
@@ -160,7 +205,7 @@ void reset_registry(const GlobalConfig& cfg) {
 }
 
 // Ensure the project-level .mcpp/ directory exists and contains a
-// .xlings.json seeded with the custom (non-builtin, non-local) index
+// .xlings.json seeded with custom non-builtin index entries
 // entries. Returns true if a .mcpp/ directory was created/updated.
 bool ensure_project_index_dir(
     const GlobalConfig& cfg,
@@ -620,9 +665,8 @@ bool ensure_project_index_dir(
     for (auto& [name, spec] : indices) {
         if (spec.is_builtin()) continue;
         if (spec.is_local()) {
-            auto source = spec.path;
-            if (source.is_relative()) source = projectDir / source;
-            customRepos.emplace_back(name, source.lexically_normal().string());
+            auto source = resolve_project_index_path(projectDir, spec);
+            customRepos.emplace_back(name, source.string());
             continue;
         }
         customRepos.emplace_back(name, spec.url);

--- a/src/config.cppm
+++ b/src/config.cppm
@@ -613,11 +613,18 @@ bool ensure_project_index_dir(
     const std::filesystem::path& projectDir,
     const std::map<std::string, mcpp::pm::IndexSpec>& indices)
 {
-    // Collect custom (non-builtin, non-local) indices that need xlings cloning.
+    // Collect custom non-builtin indices that need xlings project-scope data.
+    // Local path indices are also seeded so xlings can create its own
+    // project-local repo link and install packages from that index.
     std::vector<std::pair<std::string,std::string>> customRepos;
     for (auto& [name, spec] : indices) {
         if (spec.is_builtin()) continue;
-        if (spec.is_local())   continue;   // local path, mcpp reads directly
+        if (spec.is_local()) {
+            auto source = spec.path;
+            if (source.is_relative()) source = projectDir / source;
+            customRepos.emplace_back(name, source.lexically_normal().string());
+            continue;
+        }
         customRepos.emplace_back(name, spec.url);
     }
 

--- a/src/libs/toml.cppm
+++ b/src/libs/toml.cppm
@@ -69,7 +69,8 @@ private:
 
 class Document {
 public:
-    explicit Document(Table root) : root_(std::move(root)) {}
+    explicit Document(Table root, std::set<std::string, std::less<>> explicitTables = {})
+        : root_(std::move(root)), explicitTables_(std::move(explicitTables)) {}
 
     const Table& root() const { return root_; }
     Table&       root()       { return root_; }
@@ -83,9 +84,13 @@ public:
     std::optional<bool>                   get_bool(std::string_view path) const;
     std::optional<std::vector<std::string>> get_string_array(std::string_view path) const;
     const Table*                          get_table(std::string_view path) const;
+    bool                                  has_explicit_table(std::string_view path) const {
+        return explicitTables_.contains(path);
+    }
 
 private:
     Table root_;
+    std::set<std::string, std::less<>> explicitTables_;
 };
 
 std::expected<Document, ParseError> parse(std::string_view src);
@@ -328,6 +333,13 @@ inline Table* dive(Table& root, const std::vector<std::string>& path, bool creat
     return cur;
 }
 
+inline std::string join_path(const std::vector<std::string>& path) {
+    return std::accumulate(path.begin(), path.end(), std::string{},
+        [](std::string a, const std::string& b){
+            return a.empty() ? b : a + "." + b;
+        });
+}
+
 } // namespace detail
 
 const Value* Document::get(std::string_view dotted_path) const {
@@ -390,6 +402,7 @@ std::expected<Document, ParseError> parse(std::string_view src) {
     using namespace detail;
     Lexer L { src };
     Table root;
+    std::set<std::string, std::less<>> explicitTables;
     Table* current_table = &root;
 
     while (true) {
@@ -412,11 +425,9 @@ std::expected<Document, ParseError> parse(std::string_view src) {
             auto* t = dive(root, *path);
             if (!t) return std::unexpected(ParseError{
                 std::format("table path '{}' conflicts with non-table value",
-                            std::accumulate(path->begin(), path->end(), std::string{},
-                                [](std::string a, const std::string& b){
-                                    return a.empty() ? b : a + "." + b;
-                                })),
+                            join_path(*path)),
                 L.position()});
+            explicitTables.insert(join_path(*path));
             current_table = t;
         } else {
             // key = value
@@ -441,7 +452,7 @@ std::expected<Document, ParseError> parse(std::string_view src) {
         }
     }
 
-    return Document{std::move(root)};
+    return Document{std::move(root), std::move(explicitTables)};
 }
 
 std::expected<Document, ParseError> parse_file(const std::filesystem::path& p) {

--- a/src/libs/toml.cppm
+++ b/src/libs/toml.cppm
@@ -224,7 +224,12 @@ inline std::expected<Value, ParseError> read_array(Lexer& L) {
         if (!v) return std::unexpected(v.error());
         out.push_back(std::move(*v));
         L.skip_whitespace_and_comments();
-        if (L.peek() == ',') { L.advance(); continue; }
+        if (L.peek() == ',') {
+            L.advance();
+            L.skip_whitespace_and_comments();
+            if (L.peek() == ']') { L.advance(); break; }
+            continue;
+        }
         if (L.peek() == ']') { L.advance(); break; }
         return std::unexpected(ParseError{"expected ',' or ']' in array", L.position()});
     }

--- a/src/manifest.cppm
+++ b/src/manifest.cppm
@@ -5,6 +5,7 @@ export module mcpp.manifest;
 import std;
 import mcpp.libs.toml;
 import mcpp.pm.dep_spec;     // M5.x pm/ subsystem refactor: DependencySpec lives here
+import mcpp.pm.compat;       // Legacy dependency-key compatibility helpers
 import mcpp.pm.index_spec;   // IndexSpec for [indices] section
 
 export namespace mcpp::manifest {
@@ -461,10 +462,88 @@ std::expected<Manifest, ManifestError> parse_string(std::string_view content,
         return {};
     };
 
-    auto split_legacy_dotted = [](std::string_view k) -> std::pair<std::string, std::string> {
-        auto pos = k.find('.');
-        if (pos == std::string_view::npos) return {std::string{kDefaultNamespace}, std::string{k}};
-        return {std::string{k.substr(0, pos)}, std::string{k.substr(pos + 1)}};
+    auto dependency_key = [](std::string_view ns,
+                             std::string_view shortName,
+                             bool bareDefaultKey) {
+        if (bareDefaultKey) return std::string{shortName};
+        return std::format("{}.{}", ns, shortName);
+    };
+
+    auto assign_dep = [&](std::string_view section,
+                          std::map<std::string, DependencySpec>& out,
+                          std::string_view ns,
+                          std::string_view shortName,
+                          const t::Value& value,
+                          bool legacyDottedKey,
+                          bool bareDefaultKey)
+        -> std::expected<void, ManifestError>
+    {
+        DependencySpec spec;
+        spec.namespace_ = std::string{ns};
+        spec.shortName = std::string{shortName};
+        spec.legacyDottedKey = legacyDottedKey;
+
+        auto key = dependency_key(ns, shortName, bareDefaultKey);
+        if (value.is_string()) {
+            spec.version = value.as_string();
+        } else if (value.is_table()) {
+            auto& sub = value.as_table();
+            if (!looks_like_inline_dep_spec(sub)) {
+                return std::unexpected(error(origin, std::format(
+                    "[{}.{}] must be a version string or table of "
+                    "(path/version/git/rev/tag/branch/features)",
+                    section, key)));
+            }
+            if (auto r = fill_inline_spec(spec, section, key, sub); !r) return r;
+        } else {
+            return std::unexpected(error(origin, std::format(
+                "[{}].{} must be a string (version) or table (path/version/...)",
+                section, key)));
+        }
+
+        out[key] = std::move(spec);
+        return {};
+    };
+
+    auto is_namespace_table = [&](std::string_view section,
+                                  std::string_view key) {
+        auto path = std::format("{}.{}", section, key);
+        return doc->has_explicit_table(path)
+            || key == kDefaultNamespace
+            || key == "compat"
+            || key.find('.') != std::string_view::npos
+            || m.indices.find(std::string{key}) != m.indices.end();
+    };
+
+    std::function<std::expected<void, ManifestError>(
+        std::string_view,
+        std::map<std::string, DependencySpec>&,
+        std::string,
+        const t::Table&)> load_nested_dep_table;
+
+    load_nested_dep_table =
+        [&](std::string_view section,
+            std::map<std::string, DependencySpec>& out,
+            std::string ns,
+            const t::Table& table) -> std::expected<void, ManifestError>
+    {
+        for (auto& [k, v] : table) {
+            if (v.is_string() ||
+                (v.is_table() && looks_like_inline_dep_spec(v.as_table()))) {
+                if (auto r = assign_dep(section, out, ns, k, v, false, false); !r)
+                    return r;
+                continue;
+            }
+            if (!v.is_table()) {
+                return std::unexpected(error(origin, std::format(
+                    "[{}].{}.{} must be a string, inline dep table, or nested table",
+                    section, ns, k)));
+            }
+            auto childNs = std::format("{}.{}", ns, k);
+            if (auto r = load_nested_dep_table(section, out, childNs, v.as_table()); !r)
+                return r;
+        }
+        return {};
     };
 
     auto load_deps = [&](std::string_view section, std::map<std::string, DependencySpec>& out)
@@ -476,18 +555,16 @@ std::expected<Manifest, ManifestError> parse_string(std::string_view content,
             // (1) string value → flat default-ns short version, or
             // (3) legacy "ns.name" = "ver" (dotted key).
             if (v.is_string()) {
-                DependencySpec spec;
-                spec.version = v.as_string();
                 if (k.find('.') != std::string::npos) {
-                    auto [ns, sn] = split_legacy_dotted(k);
-                    spec.namespace_ = ns;
-                    spec.shortName  = sn;
-                    out[k] = std::move(spec);   // map key keeps composite form for fetcher
-                } else {
-                    spec.namespace_ = std::string{kDefaultNamespace};
-                    spec.shortName  = k;
-                    out[k] = std::move(spec);
+                    auto legacyKey = mcpp::pm::compat::split_legacy_dependency_key(k);
+                    if (auto r = assign_dep(section, out,
+                                            legacyKey.namespace_, legacyKey.shortName,
+                                            v, legacyKey.legacyDottedKey, false); !r)
+                        return r;
+                    continue;
                 }
+                if (auto r = assign_dep(section, out, kDefaultNamespace, k, v, false, true); !r)
+                    return r;
                 continue;
             }
 
@@ -503,48 +580,30 @@ std::expected<Manifest, ManifestError> parse_string(std::string_view content,
             //         "mcpplibs.cmdline" = { version = "0.0.2" }
             // The latter is the legacy dotted-key form; same treatment as (3).
             if (looks_like_inline_dep_spec(sub)) {
-                DependencySpec spec;
-                if (auto r = fill_inline_spec(spec, section, k, sub); !r) return r;
                 if (k.find('.') != std::string::npos) {
-                    auto [ns, sn]  = split_legacy_dotted(k);
-                    spec.namespace_ = ns;
-                    spec.shortName  = sn;
-                    out[k] = std::move(spec);
-                } else {
-                    spec.namespace_ = std::string{kDefaultNamespace};
-                    spec.shortName  = k;
-                    out[k] = std::move(spec);
+                    auto legacyKey = mcpp::pm::compat::split_legacy_dependency_key(k);
+                    if (auto r = assign_dep(section, out,
+                                            legacyKey.namespace_, legacyKey.shortName,
+                                            v, legacyKey.legacyDottedKey, false); !r)
+                        return r;
+                    continue;
                 }
+                if (auto r = assign_dep(section, out, kDefaultNamespace, k, v, false, true); !r)
+                    return r;
                 continue;
             }
 
-            // (2) namespaced subtable: `[dependencies.<ns>] sub-key = value`.
-            // The outer key `k` is the namespace; each `(sk, sv)` inside is
-            // a dep in that namespace, accepting the same string-or-inline-spec
-            // shapes as the flat form.
-            const std::string ns = k;
-            for (auto& [sk, sv] : sub) {
-                DependencySpec spec;
-                spec.namespace_ = ns;
-                spec.shortName  = sk;
-                std::string fq  = std::format("{}.{}", ns, sk);
-                if (sv.is_string()) {
-                    spec.version = sv.as_string();
-                } else if (sv.is_table()) {
-                    auto& subsub = sv.as_table();
-                    if (!looks_like_inline_dep_spec(subsub)) {
-                        return std::unexpected(error(origin, std::format(
-                            "[{}.{}.{}] must be a version string or table of "
-                            "(path/version/git/rev/tag/branch/features)",
-                            section, ns, sk)));
-                    }
-                    if (auto r = fill_inline_spec(spec, section, fq, subsub); !r) return r;
-                } else {
-                    return std::unexpected(error(origin, std::format(
-                        "[{}.{}.{}] must be a version string or inline table",
-                        section, ns, sk)));
-                }
-                out[fq] = std::move(spec);
+            // (2) namespaced or nested subtable.
+            //
+            // Explicit tables such as `[dependencies.acme]` are namespace
+            // roots. Dotted keys written inside a dependency table, such as
+            // `[dependencies] capi.lua = "0.0.3"`, are canonical nested
+            // packages under the default namespace: mcpplibs.capi:lua.
+            std::string ns = is_namespace_table(section, k)
+                ? k
+                : std::format("{}.{}", kDefaultNamespace, k);
+            if (auto r = load_nested_dep_table(section, out, std::move(ns), sub); !r) {
+                return r;
             }
         }
         return {};
@@ -638,14 +697,10 @@ std::expected<Manifest, ManifestError> parse_string(std::string_view content,
                 if (v.is_string()) {
                     DependencySpec spec;
                     spec.version = v.as_string();
-                    if (k.find('.') != std::string::npos) {
-                        auto pos = k.find('.');
-                        spec.namespace_ = k.substr(0, pos);
-                        spec.shortName  = k.substr(pos + 1);
-                    } else {
-                        spec.namespace_ = std::string{kDefaultNamespace};
-                        spec.shortName  = k;
-                    }
+                    auto depKey = mcpp::pm::compat::split_legacy_dependency_key(k);
+                    spec.namespace_ = std::move(depKey.namespace_);
+                    spec.shortName = std::move(depKey.shortName);
+                    spec.legacyDottedKey = depKey.legacyDottedKey;
                     m.workspace.dependencies[k] = std::move(spec);
                     continue;
                 }
@@ -1309,13 +1364,10 @@ synthesize_from_xpkg_lua(std::string_view luaContent,
                 if (!dname.empty()) {
                     DependencySpec spec;
                     spec.version = dver;
-                    if (auto pos = dname.find('.'); pos != std::string::npos) {
-                        spec.namespace_ = dname.substr(0, pos);
-                        spec.shortName  = dname.substr(pos + 1);
-                    } else {
-                        spec.namespace_ = std::string{kDefaultNamespace};
-                        spec.shortName  = dname;
-                    }
+                    auto depKey = mcpp::pm::compat::split_legacy_dependency_key(dname);
+                    spec.namespace_ = std::move(depKey.namespace_);
+                    spec.shortName = std::move(depKey.shortName);
+                    spec.legacyDottedKey = depKey.legacyDottedKey;
                     m.dependencies[dname] = std::move(spec);
                 }
                 cur.skip_ws_and_comments();

--- a/src/modgraph/graph.cppm
+++ b/src/modgraph/graph.cppm
@@ -15,6 +15,7 @@ struct ModuleId {
 struct SourceUnit {
     std::filesystem::path           path;
     std::string                     packageName;
+    std::vector<std::filesystem::path> localIncludeDirs;
     std::optional<ModuleId>         provides;
     std::vector<ModuleId>           requires_;
     bool                            isModuleInterface = false;   // .cppm with export module

--- a/src/modgraph/scanner.cppm
+++ b/src/modgraph/scanner.cppm
@@ -314,6 +314,23 @@ std::expected<SourceUnit, ScanError> scan_file(const std::filesystem::path& file
 
 namespace {
 
+std::vector<std::filesystem::path>
+local_include_dirs_for(const std::filesystem::path& root,
+                       const mcpp::manifest::Manifest& manifest)
+{
+    std::vector<std::filesystem::path> dirs;
+    for (auto const& inc : manifest.buildConfig.includeDirs) {
+        if (inc.is_absolute()) {
+            dirs.push_back(inc);
+            continue;
+        }
+        for (auto& d : expand_dir_glob(root, inc.generic_string())) {
+            dirs.push_back(std::move(d));
+        }
+    }
+    return dirs;
+}
+
 // Phase 1: scan a single package, append units to result.graph.units;
 // errors go straight into result.errors. producerOf/edges are NOT built
 // here — the caller does that after all packages are scanned.
@@ -348,6 +365,7 @@ void scan_one_into(ScanResult& result,
         manifest.package.namespace_.empty()
             ? manifest.package.name
             : manifest.package.namespace_ + "." + manifest.package.name;
+    const auto localIncludeDirs = local_include_dirs_for(root, manifest);
 
     for (auto const& f : all_files) {
         auto r = scan_file(f, qualifiedName);
@@ -355,6 +373,7 @@ void scan_one_into(ScanResult& result,
             result.errors.push_back(r.error());
             continue;
         }
+        r->localIncludeDirs = localIncludeDirs;
         result.graph.units.push_back(std::move(*r));
     }
 }
@@ -422,6 +441,7 @@ ScanResult scan_packages_p1689(const std::vector<PackageRoot>&     packages,
         for (auto const& g : p.manifest.modules.sources) {
             for (auto& f : expand_glob(p.root, g)) all_files.insert(f);
         }
+        const auto localIncludeDirs = local_include_dirs_for(p.root, p.manifest);
         for (auto const& f : all_files) {
             auto r = mcpp::modgraph::p1689::scan_file(
                 f, p.manifest.package.name, tc, tmpDir);
@@ -429,6 +449,7 @@ ScanResult scan_packages_p1689(const std::vector<PackageRoot>&     packages,
                 result.errors.push_back(ScanError{ f, 0, r.error() });
                 continue;
             }
+            r->localIncludeDirs = localIncludeDirs;
             result.graph.units.push_back(std::move(*r));
         }
     }

--- a/src/pm/compat.cppm
+++ b/src/pm/compat.cppm
@@ -82,13 +82,60 @@ inline std::string qualified_name(std::string_view ns,
     return std::format("{}.{}", ns, shortName);
 }
 
+// ─── Legacy dependency key parsing ─────────────────────────────────
+//
+// COMPAT: legacy flat dependency keys used quoted dotted names under a
+// dependency table:
+//
+//     [dependencies]
+//     "mcpplibs.cmdline" = "0.0.2"
+//
+// Canonical projects should use namespaced TOML tables instead:
+//
+//     [dependencies.mcpplibs]
+//     cmdline = "0.0.2"
+//
+// Nested default-namespace packages can also be written without quotes:
+//
+//     [dependencies]
+//     capi.lua = "0.0.3"
+//
+// This compatibility parser is slated for removal in mcpp 1.0.0.
+
+struct LegacyDependencyKey {
+    std::string namespace_;
+    std::string shortName;
+    bool        legacyDottedKey = false;
+};
+
+inline LegacyDependencyKey split_legacy_dependency_key(std::string_view key)
+{
+    auto dot = key.find('.');
+    if (dot == std::string_view::npos) {
+        return LegacyDependencyKey {
+            .namespace_ = std::string(mcpp::pm::kDefaultNamespace),
+            .shortName = std::string(key),
+            .legacyDottedKey = false,
+        };
+    }
+
+    return LegacyDependencyKey {
+        .namespace_ = std::string(key.substr(0, dot)),
+        .shortName = std::string(key.substr(dot + 1)),
+        .legacyDottedKey = true,
+    };
+}
+
 // Normalize legacy nested names after the first-dot split:
 //   ns="mcpplibs", shortName="capi.lua" → ns="mcpplibs.capi", shortName="lua".
 //
 // This preserves the fully qualified name while making dependency de-dup use
-// the same structured key as TOML-native [dependencies."mcpplibs.capi"].
-inline void normalize_nested_namespace(std::string& ns, std::string& shortName)
+// the same structured key as canonical [dependencies.mcpplibs] capi.lua.
+inline void normalize_nested_namespace(std::string& ns,
+                                       std::string& shortName,
+                                       bool legacyDottedKey)
 {
+    if (!legacyDottedKey) return;
     if (ns.empty()) return;
     auto dot = shortName.rfind('.');
     if (dot == std::string::npos || dot + 1 >= shortName.size()) return;

--- a/src/pm/compat.cppm
+++ b/src/pm/compat.cppm
@@ -82,6 +82,22 @@ inline std::string qualified_name(std::string_view ns,
     return std::format("{}.{}", ns, shortName);
 }
 
+// Normalize legacy nested names after the first-dot split:
+//   ns="mcpplibs", shortName="capi.lua" → ns="mcpplibs.capi", shortName="lua".
+//
+// This preserves the fully qualified name while making dependency de-dup use
+// the same structured key as TOML-native [dependencies."mcpplibs.capi"].
+inline void normalize_nested_namespace(std::string& ns, std::string& shortName)
+{
+    if (ns.empty()) return;
+    auto dot = shortName.rfind('.');
+    if (dot == std::string::npos || dot + 1 >= shortName.size()) return;
+
+    ns += ".";
+    ns += shortName.substr(0, dot);
+    shortName = shortName.substr(dot + 1);
+}
+
 // ─── Index directory naming ──────────────────────────────────────────
 //
 // Maps (indexName, namespace, shortName) → the xpkgs subdirectory name
@@ -199,6 +215,17 @@ inline std::vector<std::string> install_dir_candidates(std::string_view ns,
     if (!ns.empty()) {
         candidates.push_back(std::format("{}-x-{}", ns, shortName));
         candidates.push_back(std::format("{}-x-{}", indexName, shortName));
+    }
+
+    // Legacy dotted dependency keys such as "mcpplibs.capi.lua" are parsed as
+    // ns="mcpplibs", shortName="capi.lua". Some xlings indices store these as
+    // nested namespaces: mcpplibs.capi-x-mcpplibs.capi.lua.
+    if (!ns.empty()) {
+        auto dot = shortName.rfind('.');
+        if (dot != std::string_view::npos) {
+            auto nestedNs = std::format("{}.{}", ns, shortName.substr(0, dot));
+            candidates.push_back(std::format("{}-x-{}", nestedNs, fqname));
+        }
     }
 
     return candidates;

--- a/src/pm/dep_spec.cppm
+++ b/src/pm/dep_spec.cppm
@@ -33,6 +33,7 @@ struct DependencySpec {
     std::string                 gitRefKind;     // "rev" / "tag" / "branch" (for clarity)
 
     bool                        inheritWorkspace = false;  // .workspace = true
+    bool                        legacyDottedKey = false;   // parsed from legacy "ns.name" flat key
 
     bool isPath()    const { return !path.empty(); }
     bool isGit()     const { return !git.empty(); }

--- a/src/pm/package_fetcher.cppm
+++ b/src/pm/package_fetcher.cppm
@@ -16,6 +16,7 @@ import std;
 import mcpp.config;
 import mcpp.log;
 import mcpp.pm.compat;
+import mcpp.pm.dep_spec;
 import mcpp.pm.index_spec;
 import mcpp.xlings;
 import mcpp.libs.toml;       // re-used for tiny JSON-ish parsing? no — stick with manual
@@ -235,6 +236,16 @@ std::string make_targets_args(const std::vector<std::string>& targets,
     if (yes) out += ",\"yes\":true";
     out += "}";
     return out;
+}
+
+std::vector<std::filesystem::path>
+project_data_roots(const std::filesystem::path& projectDir)
+{
+    auto dotMcpp = projectDir / ".mcpp";
+    return {
+        dotMcpp / "data",
+        dotMcpp / ".xlings" / "data",
+    };
 }
 
 } // namespace
@@ -479,24 +490,24 @@ Fetcher::read_xpkg_lua_from_project_data(const std::filesystem::path& projectDir
 {
     if (shortName.empty()) return std::nullopt;
 
-    auto data = projectDir / ".mcpp" / "data";
-    if (!std::filesystem::exists(data)) return std::nullopt;
-
     auto filenames = mcpp::pm::compat::xpkg_lua_candidates(ns, shortName);
 
     std::error_code ec;
-    for (auto& entry : std::filesystem::directory_iterator(data, ec)) {
-        if (!entry.is_directory()) continue;
-        auto pkgsDir = entry.path() / "pkgs";
-        if (!std::filesystem::exists(pkgsDir)) continue;
-        for (auto& fname : filenames) {
-            char first = static_cast<char>(std::tolower(
-                static_cast<unsigned char>(fname.front())));
-            auto candidate = pkgsDir / std::string(1, first) / fname;
-            if (std::filesystem::exists(candidate)) {
-                std::ifstream is(candidate);
-                std::stringstream ss; ss << is.rdbuf();
-                return ss.str();
+    for (auto& data : project_data_roots(projectDir)) {
+        if (!std::filesystem::exists(data)) continue;
+        for (auto& entry : std::filesystem::directory_iterator(data, ec)) {
+            if (!entry.is_directory()) continue;
+            auto pkgsDir = entry.path() / "pkgs";
+            if (!std::filesystem::exists(pkgsDir)) continue;
+            for (auto& fname : filenames) {
+                char first = static_cast<char>(std::tolower(
+                    static_cast<unsigned char>(fname.front())));
+                auto candidate = pkgsDir / std::string(1, first) / fname;
+                if (std::filesystem::exists(candidate)) {
+                    std::ifstream is(candidate);
+                    std::stringstream ss; ss << is.rdbuf();
+                    return ss.str();
+                }
             }
         }
     }
@@ -513,17 +524,28 @@ Fetcher::install_path_from_project_data(const std::filesystem::path& projectDir,
                                          std::string_view shortName,
                                          std::string_view version)
 {
-    auto base = projectDir / ".mcpp" / "data" / "xpkgs";
-    if (!std::filesystem::exists(base)) return std::nullopt;
+    for (auto& data : project_data_roots(projectDir)) {
+        auto base = data / "xpkgs";
+        if (!std::filesystem::exists(base)) continue;
 
-    // Try canonical directory name: ns.shortName
-    auto qname = std::string(ns) + "." + std::string(shortName);
-    auto verdir = base / qname / std::string(version);
-    if (std::filesystem::exists(verdir)) return verdir;
+        // Try canonical directory name: ns.shortName
+        auto qname = std::string(ns) + "." + std::string(shortName);
+        auto verdir = base / qname / std::string(version);
+        if (std::filesystem::exists(verdir)) return verdir;
 
-    // Try shortName alone.
-    verdir = base / std::string(shortName) / std::string(version);
-    if (std::filesystem::exists(verdir)) return verdir;
+        // Try shortName alone.
+        verdir = base / std::string(shortName) / std::string(version);
+        if (std::filesystem::exists(verdir)) return verdir;
+
+        auto indexName = ns.empty()
+            ? std::string{mcpp::pm::kDefaultNamespace}
+            : std::string{ns};
+        for (auto& dirName : mcpp::pm::compat::install_dir_candidates(
+                 ns, shortName, indexName)) {
+            verdir = base / dirName / std::string(version);
+            if (std::filesystem::exists(verdir)) return verdir;
+        }
+    }
 
     return std::nullopt;
 }

--- a/src/pm/package_fetcher.cppm
+++ b/src/pm/package_fetcher.cppm
@@ -115,7 +115,7 @@ public:
         read_xpkg_lua_from_path(const std::filesystem::path& indexPath,
                                 std::string_view shortName);
 
-    // Read xpkg .lua from a project-level data directory (.mcpp/data/).
+    // Read xpkg .lua from a project-level xlings data directory.
     // Used for custom git indices whose clone lives under the project's
     // .mcpp/ directory rather than the global xlings home.
     static std::optional<std::string>
@@ -123,7 +123,7 @@ public:
                                         std::string_view ns,
                                         std::string_view shortName);
 
-    // Install path under a project-level data directory (.mcpp/data/xpkgs/).
+    // Install path under a project-level xlings data directory.
     static std::optional<std::filesystem::path>
         install_path_from_project_data(const std::filesystem::path& projectDir,
                                        std::string_view ns,
@@ -236,16 +236,6 @@ std::string make_targets_args(const std::vector<std::string>& targets,
     if (yes) out += ",\"yes\":true";
     out += "}";
     return out;
-}
-
-std::vector<std::filesystem::path>
-project_data_roots(const std::filesystem::path& projectDir)
-{
-    auto dotMcpp = projectDir / ".mcpp";
-    return {
-        dotMcpp / "data",
-        dotMcpp / ".xlings" / "data",
-    };
 }
 
 } // namespace
@@ -480,8 +470,8 @@ Fetcher::read_xpkg_lua_from_path(const std::filesystem::path& indexPath,
 
 // ─── read_xpkg_lua from project-level data dir ─────────────────────
 //
-// For custom git indices cloned into .mcpp/data/, scan the data
-// directory the same way the global read_xpkg_lua does.
+// For custom git indices cloned into the project xlings data roots,
+// scan the data directory the same way the global read_xpkg_lua does.
 
 std::optional<std::string>
 Fetcher::read_xpkg_lua_from_project_data(const std::filesystem::path& projectDir,
@@ -493,7 +483,7 @@ Fetcher::read_xpkg_lua_from_project_data(const std::filesystem::path& projectDir
     auto filenames = mcpp::pm::compat::xpkg_lua_candidates(ns, shortName);
 
     std::error_code ec;
-    for (auto& data : project_data_roots(projectDir)) {
+    for (auto& data : mcpp::config::project_xlings_data_roots(projectDir)) {
         if (!std::filesystem::exists(data)) continue;
         for (auto& entry : std::filesystem::directory_iterator(data, ec)) {
             if (!entry.is_directory()) continue;
@@ -516,7 +506,7 @@ Fetcher::read_xpkg_lua_from_project_data(const std::filesystem::path& projectDir
 
 // ─── install_path from project-level data dir ──────────────────────
 //
-// For packages installed under .mcpp/data/xpkgs/ by custom git indices.
+// For packages installed under project xlings data roots by custom git indices.
 
 std::optional<std::filesystem::path>
 Fetcher::install_path_from_project_data(const std::filesystem::path& projectDir,
@@ -524,7 +514,7 @@ Fetcher::install_path_from_project_data(const std::filesystem::path& projectDir,
                                          std::string_view shortName,
                                          std::string_view version)
 {
-    for (auto& data : project_data_roots(projectDir)) {
+    for (auto& data : mcpp::config::project_xlings_data_roots(projectDir)) {
         auto base = data / "xpkgs";
         if (!std::filesystem::exists(base)) continue;
 

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.30";
+inline constexpr std::string_view MCPP_VERSION = "0.0.31";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;

--- a/tests/unit/test_config.cpp
+++ b/tests/unit/test_config.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+import std;
+import mcpp.config;
+import mcpp.pm.index_spec;
+
+namespace {
+
+std::filesystem::path make_tempdir(std::string_view name) {
+    auto base = std::filesystem::temp_directory_path()
+              / std::format("{}-{}", name, std::chrono::steady_clock::now().time_since_epoch().count());
+    std::filesystem::create_directories(base);
+    return base;
+}
+
+}  // namespace
+
+TEST(Config, ProjectXlingsDataRootsIncludeLegacyAndNestedLayouts) {
+    auto project = std::filesystem::path{"/tmp/mcpp-project"};
+    auto roots = mcpp::config::project_xlings_data_roots(project);
+
+    ASSERT_EQ(roots.size(), 2u);
+    EXPECT_EQ(roots[0], project / ".mcpp" / "data");
+    EXPECT_EQ(roots[1], project / ".mcpp" / ".xlings" / "data");
+}
+
+TEST(Config, ProjectIndexDataInitializedChecksNestedXlingsData) {
+    auto project = make_tempdir("mcpp-config-index-state");
+    auto nestedIndexDir = project / ".mcpp" / ".xlings" / "data" / "xim-index-repos";
+    std::filesystem::create_directories(nestedIndexDir);
+    {
+        std::ofstream os(nestedIndexDir / "xim-indexrepos.json");
+        os << "{}";
+    }
+
+    EXPECT_TRUE(mcpp::config::project_index_data_initialized(project));
+
+    std::filesystem::remove_all(project);
+}
+
+TEST(Config, ResolveProjectIndexPathUsesProjectRootForRelativeLocalIndex) {
+    auto project = std::filesystem::path{"/tmp/mcpp-project"};
+    mcpp::pm::IndexSpec spec;
+    spec.name = "xlings";
+    spec.path = "mcpp";
+
+    EXPECT_EQ(mcpp::config::resolve_project_index_path(project, spec),
+              (project / "mcpp").lexically_normal());
+}

--- a/tests/unit/test_manifest.cpp
+++ b/tests/unit/test_manifest.cpp
@@ -237,6 +237,7 @@ gtest = "1.15.2"
     EXPECT_EQ(cmdline.namespace_, "mcpplibs");
     EXPECT_EQ(cmdline.shortName,  "cmdline");
     EXPECT_EQ(cmdline.version,    "0.0.2");
+    EXPECT_FALSE(cmdline.legacyDottedKey);
 
     auto& tmpl = m->dependencies.at("mcpplibs.templates");
     EXPECT_EQ(tmpl.namespace_, "mcpplibs");
@@ -266,6 +267,47 @@ version = "0.1.0"
     EXPECT_EQ(s.namespace_, "mcpplibs");
     EXPECT_EQ(s.shortName,  "cmdline");
     EXPECT_EQ(s.version,    "0.0.2");
+    EXPECT_TRUE(s.legacyDottedKey);
+}
+
+TEST(Manifest, DependenciesDefaultNamespaceNestedDottedKeyIsCanonical) {
+    constexpr auto src = R"(
+[package]
+name    = "x"
+version = "0.1.0"
+
+[dependencies]
+capi.lua = "0.0.3"
+)";
+    auto m = mcpp::manifest::parse_string(src);
+    ASSERT_TRUE(m.has_value()) << m.error().format();
+    ASSERT_EQ(m->dependencies.size(), 1u);
+
+    auto& s = m->dependencies.at("mcpplibs.capi.lua");
+    EXPECT_EQ(s.namespace_, "mcpplibs.capi");
+    EXPECT_EQ(s.shortName,  "lua");
+    EXPECT_EQ(s.version,    "0.0.3");
+    EXPECT_FALSE(s.legacyDottedKey);
+}
+
+TEST(Manifest, DependenciesNamespacedSubtableNestedDottedKeyIsCanonical) {
+    constexpr auto src = R"(
+[package]
+name    = "x"
+version = "0.1.0"
+
+[dependencies.mcpplibs]
+capi.lua = "0.0.3"
+)";
+    auto m = mcpp::manifest::parse_string(src);
+    ASSERT_TRUE(m.has_value()) << m.error().format();
+    ASSERT_EQ(m->dependencies.size(), 1u);
+
+    auto& s = m->dependencies.at("mcpplibs.capi.lua");
+    EXPECT_EQ(s.namespace_, "mcpplibs.capi");
+    EXPECT_EQ(s.shortName,  "lua");
+    EXPECT_EQ(s.version,    "0.0.3");
+    EXPECT_FALSE(s.legacyDottedKey);
 }
 
 TEST(Manifest, DependenciesInlineSpecCoexistsWithSubtable) {

--- a/tests/unit/test_modgraph.cpp
+++ b/tests/unit/test_modgraph.cpp
@@ -46,6 +46,30 @@ TEST(Scanner, ProvidesAndRequires) {
     std::filesystem::remove_all(dir);
 }
 
+TEST(Scanner, RecordsPackageLocalIncludeDirs) {
+    auto dir = make_tempdir("mcpp-scanner-includes");
+    write(dir / "src" / "foo.cpp",
+          "int answer() { return 42; }\n");
+    std::filesystem::create_directories(dir / "include");
+    std::filesystem::create_directories(dir / "private" / "nested");
+
+    mcpp::manifest::Manifest m;
+    m.package.name = "pkg";
+    m.modules.sources = {"src/*.cpp"};
+    m.buildConfig.includeDirs = {"include", "private/*"};
+
+    auto r = scan_packages({PackageRoot{dir, m}});
+    ASSERT_TRUE(r.errors.empty());
+    ASSERT_EQ(r.graph.units.size(), 1u);
+
+    auto const& dirs = r.graph.units[0].localIncludeDirs;
+    ASSERT_EQ(dirs.size(), 2u);
+    EXPECT_EQ(dirs[0], dir / "include");
+    EXPECT_EQ(dirs[1], dir / "private" / "nested");
+
+    std::filesystem::remove_all(dir);
+}
+
 TEST(Scanner, PartitionImportFromPrimaryInterface) {
     // Primary module interface: `export module foo;` → logicalName = "foo".
     // `import :tls;` resolves to "foo:tls".

--- a/tests/unit/test_pm_compat.cpp
+++ b/tests/unit/test_pm_compat.cpp
@@ -17,10 +17,31 @@ TEST(PmCompat, NormalizeNestedNamespacePreservesQualifiedName) {
     std::string ns = "mcpplibs";
     std::string shortName = "capi.lua";
 
-    mcpp::pm::compat::normalize_nested_namespace(ns, shortName);
+    mcpp::pm::compat::normalize_nested_namespace(ns, shortName,
+                                                  /*legacyDottedKey=*/true);
 
     EXPECT_EQ(ns, "mcpplibs.capi");
     EXPECT_EQ(shortName, "lua");
     EXPECT_EQ(mcpp::pm::compat::qualified_name(ns, shortName),
               "mcpplibs.capi.lua");
+}
+
+TEST(PmCompat, SplitLegacyDependencyKeyMarksDottedKeyAsCompat) {
+    auto key = mcpp::pm::compat::split_legacy_dependency_key(
+        "mcpplibs.capi.lua");
+
+    EXPECT_EQ(key.namespace_, "mcpplibs");
+    EXPECT_EQ(key.shortName, "capi.lua");
+    EXPECT_TRUE(key.legacyDottedKey);
+}
+
+TEST(PmCompat, NormalizeNestedNamespaceSkipsCanonicalNamespacedDeps) {
+    std::string ns = "mcpplibs.capi";
+    std::string shortName = "lua.extra";
+
+    mcpp::pm::compat::normalize_nested_namespace(ns, shortName,
+                                                  /*legacyDottedKey=*/false);
+
+    EXPECT_EQ(ns, "mcpplibs.capi");
+    EXPECT_EQ(shortName, "lua.extra");
 }

--- a/tests/unit/test_pm_compat.cpp
+++ b/tests/unit/test_pm_compat.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+
+import std;
+import mcpp.pm.compat;
+
+TEST(PmCompat, InstallDirCandidatesIncludeNestedNamespaceFallback) {
+    auto candidates = mcpp::pm::compat::install_dir_candidates(
+        "mcpplibs", "capi.lua", "mcpplibs");
+
+    EXPECT_NE(
+        std::find(candidates.begin(), candidates.end(),
+                  "mcpplibs.capi-x-mcpplibs.capi.lua"),
+        candidates.end());
+}
+
+TEST(PmCompat, NormalizeNestedNamespacePreservesQualifiedName) {
+    std::string ns = "mcpplibs";
+    std::string shortName = "capi.lua";
+
+    mcpp::pm::compat::normalize_nested_namespace(ns, shortName);
+
+    EXPECT_EQ(ns, "mcpplibs.capi");
+    EXPECT_EQ(shortName, "lua");
+    EXPECT_EQ(mcpp::pm::compat::qualified_name(ns, shortName),
+              "mcpplibs.capi.lua");
+}

--- a/tests/unit/test_toml.cpp
+++ b/tests/unit/test_toml.cpp
@@ -41,6 +41,19 @@ TEST(Toml, ArrayOfStrings) {
     EXPECT_EQ((*arr)[2], "c");
 }
 
+TEST(Toml, ArrayAllowsTrailingComma) {
+    auto d = t::parse(R"(
+items = [
+  "a",
+  "b",
+]
+)");
+    ASSERT_TRUE(d.has_value()) << d.error().message;
+    auto arr = d->get_string_array("items");
+    ASSERT_TRUE(arr.has_value());
+    EXPECT_EQ(*arr, std::vector<std::string>({"a", "b"}));
+}
+
 TEST(Toml, EscapedString) {
     auto d = t::parse(R"(s = "a\tb\nc")");
     ASSERT_TRUE(d.has_value());


### PR DESCRIPTION
## Summary

- Support local/custom xlings-backed package indices during dependency install and lookup.
- Add compatibility handling for nested namespace package names such as `mcpplibs.capi.lua`.
- Preserve package-local include directory precedence through scanning, planning, Ninja rules, and `compile_commands.json`.
- Allow TOML arrays with a trailing comma.

## Why

This preserves the mcpp-side fixes discovered while adding mcpp build support for `openxlings/xlings`. Without these changes, the xlings build fails on local path indices, project-scoped xlings install paths, nested namespace dependency de-duplication, and C package headers with colliding names such as `common.h`.

## Validation

- `git diff --check`
- `MCPP_HOME=/home/speak/.xlings/data/xpkgs/xim-x-mcpp/0.0.20 /home/speak/.xlings/data/xpkgs/xim-x-mcpp/0.0.30/bin/mcpp test -- --gtest_filter=Scanner.*:PmCompat.*:Toml.*`
- `MCPP_HOME=/home/speak/.xlings/data/xpkgs/xim-x-mcpp/0.0.20 /home/speak/.xlings/data/xpkgs/xim-x-mcpp/0.0.30/bin/mcpp build --print-fingerprint`

Draft PR for review and preservation; not ready to merge until review findings are addressed.
