### PR TITLE
refactor(pm): isolate legacy compat helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 > 本文件追踪 `mcpp-community/mcpp` 公开仓的版本演进。
 > 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [0.0.33] — 2026-05-30
+
+### 改进
+
+- 将 legacy dotted dependency key 兼容解析移入 `mcpp.pm.compat.legacy`
+  模块,保留 `mcpp.pm.compat` 作为 facade,并明确标注该兼容路径将在
+  mcpp 1.0.0 移除。
+
 ## [0.0.32] — 2026-05-30
 
 ### 修复

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.32"
+version     = "0.0.33"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/pm/compat.cppm
+++ b/src/pm/compat.cppm
@@ -1,6 +1,6 @@
-// mcpp.pm.compat — backward-compatibility shims for evolving package
-// conventions. Centralises all migration logic so it can be retired
-// cleanly in a future major version.
+// mcpp.pm.compat - compatibility facade for evolving package conventions.
+// Legacy-only behavior lives under src/pm/compat/legacy.cppm so it has an
+// explicit retirement boundary.
 //
 // DEPRECATION SCHEDULE:
 //   The shims in this module are slated for removal in mcpp 1.0.0.
@@ -19,6 +19,8 @@
 // See also: mcpp.pm.dep_spec (kDefaultNamespace definition).
 
 export module mcpp.pm.compat;
+
+export import mcpp.pm.compat.legacy;
 
 import std;
 import mcpp.pm.dep_spec;
@@ -80,69 +82,6 @@ inline std::string qualified_name(std::string_view ns,
     if (ns.empty() || ns == mcpp::pm::kDefaultNamespace)
         return std::string(shortName);
     return std::format("{}.{}", ns, shortName);
-}
-
-// ─── Legacy dependency key parsing ─────────────────────────────────
-//
-// COMPAT: legacy flat dependency keys used quoted dotted names under a
-// dependency table:
-//
-//     [dependencies]
-//     "mcpplibs.cmdline" = "0.0.2"
-//
-// Canonical projects should use namespaced TOML tables instead:
-//
-//     [dependencies.mcpplibs]
-//     cmdline = "0.0.2"
-//
-// Nested default-namespace packages can also be written without quotes:
-//
-//     [dependencies]
-//     capi.lua = "0.0.3"
-//
-// This compatibility parser is slated for removal in mcpp 1.0.0.
-
-struct LegacyDependencyKey {
-    std::string namespace_;
-    std::string shortName;
-    bool        legacyDottedKey = false;
-};
-
-inline LegacyDependencyKey split_legacy_dependency_key(std::string_view key)
-{
-    auto dot = key.find('.');
-    if (dot == std::string_view::npos) {
-        return LegacyDependencyKey {
-            .namespace_ = std::string(mcpp::pm::kDefaultNamespace),
-            .shortName = std::string(key),
-            .legacyDottedKey = false,
-        };
-    }
-
-    return LegacyDependencyKey {
-        .namespace_ = std::string(key.substr(0, dot)),
-        .shortName = std::string(key.substr(dot + 1)),
-        .legacyDottedKey = true,
-    };
-}
-
-// Normalize legacy nested names after the first-dot split:
-//   ns="mcpplibs", shortName="capi.lua" → ns="mcpplibs.capi", shortName="lua".
-//
-// This preserves the fully qualified name while making dependency de-dup use
-// the same structured key as canonical [dependencies.mcpplibs] capi.lua.
-inline void normalize_nested_namespace(std::string& ns,
-                                       std::string& shortName,
-                                       bool legacyDottedKey)
-{
-    if (!legacyDottedKey) return;
-    if (ns.empty()) return;
-    auto dot = shortName.rfind('.');
-    if (dot == std::string::npos || dot + 1 >= shortName.size()) return;
-
-    ns += ".";
-    ns += shortName.substr(0, dot);
-    shortName = shortName.substr(dot + 1);
 }
 
 // ─── Index directory naming ──────────────────────────────────────────

--- a/src/pm/compat/legacy.cppm
+++ b/src/pm/compat/legacy.cppm
@@ -1,0 +1,67 @@
+// mcpp.pm.compat.legacy - legacy dependency-key compatibility.
+//
+// COMPAT: This module exists only to keep pre-namespace dependency syntax
+// working during migration. It is slated for removal in mcpp 1.0.0.
+// TODO(mcpp 1.0.0): remove this module and the legacy dotted-key parser.
+//
+// Deprecated:
+//
+//     [dependencies]
+//     "mcpplibs.cmdline" = "0.0.2"
+//
+// Canonical:
+//
+//     [dependencies.mcpplibs]
+//     cmdline = "0.0.2"
+
+export module mcpp.pm.compat.legacy;
+
+import std;
+import mcpp.pm.dep_spec;
+
+export namespace mcpp::pm::compat {
+
+struct LegacyDependencyKey {
+    std::string namespace_;
+    std::string shortName;
+    bool        legacyDottedKey = false;
+};
+
+inline LegacyDependencyKey split_legacy_dependency_key(std::string_view key)
+{
+    auto dot = key.find('.');
+    if (dot == std::string_view::npos) {
+        return LegacyDependencyKey {
+            .namespace_ = std::string(mcpp::pm::kDefaultNamespace),
+            .shortName = std::string(key),
+            .legacyDottedKey = false,
+        };
+    }
+
+    return LegacyDependencyKey {
+        .namespace_ = std::string(key.substr(0, dot)),
+        .shortName = std::string(key.substr(dot + 1)),
+        .legacyDottedKey = true,
+    };
+}
+
+// Normalize legacy nested names after the first-dot split:
+//   ns="mcpplibs", shortName="capi.lua" -> ns="mcpplibs.capi", shortName="lua".
+//
+// This preserves the fully qualified name while making dependency de-dup use
+// the same structured key as canonical [dependencies.mcpplibs] capi.lua.
+inline void normalize_nested_namespace(std::string& ns,
+                                       std::string& shortName,
+                                       bool legacyDottedKey)
+{
+    if (!legacyDottedKey) return;
+    if (ns.empty()) return;
+    auto dot = shortName.rfind('.');
+    if (dot == std::string::npos || dot + 1 >= shortName.size()) return;
+
+    ns += ".";
+    ns += shortName.substr(0, dot);
+    shortName = shortName.substr(dot + 1);
+}
+
+} // namespace mcpp::pm::compat

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.32";
+inline constexpr std::string_view MCPP_VERSION = "0.0.33";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;


### PR DESCRIPTION
## Summary
- move legacy dotted dependency-key compatibility helpers into `src/pm/compat/legacy.cppm`
- keep `mcpp.pm.compat` as the public facade by re-exporting the legacy module
- mark the legacy compatibility module as migration-only and slated for removal in `mcpp 1.0.0`
- bump mcpp to `0.0.33` so merging this PR can produce a new release tag instead of rebuilding the existing `v0.0.32`

## Verification
- `git diff --check`
- `mcpp build`
- attempted `mcpp test -- --gtest_filter=PmCompat.*:Manifest.Dependencies*`, but this local sandbox is missing `xim-x-binutils/2.42/bin/as` after xlings install; PR CI is the authoritative cross-platform verification

## Release context
- `0.0.31` is already included in the PR base via `main`/`v0.0.32`; this PR adds the next release bump for the new compat-module cleanup.
