### PR TITLE
chore(release): bump version to 0.0.34

### DIFF
--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.33"
+version     = "0.0.34"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.33";
+inline constexpr std::string_view MCPP_VERSION = "0.0.34";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;


### PR DESCRIPTION
## Summary
- bump package version to 0.0.34
- update MCPP_VERSION so runtime reporting and BMI fingerprints use 0.0.34

## Verification
- `mcpp build`
- `target/x86_64-linux-gnu/4d24c8b57fdbbbb4/bin/mcpp --version` -> `mcpp 0.0.34 -`
- `target/x86_64-linux-gnu/4d24c8b57fdbbbb4/bin/mcpp publish --dry-run --allow-dirty`
- `MCPP=$PWD/target/x86_64-linux-gnu/4d24c8b57fdbbbb4/bin/mcpp bash tests/e2e/49_bmi_cache_nested_custom_index.sh`
- `target/x86_64-linux-gnu/ff952c89919589bb/bin/test_bmi_cache --gtest_filter=BmiCache.*`