### PR TITLE
fix(index): refresh missing default mcpplibs index

### DIFF
--- a/.agents/docs/2026-05-30-bmi-cache-custom-index-fix.md
+++ b/.agents/docs/2026-05-30-bmi-cache-custom-index-fix.md
@@ -81,3 +81,29 @@ There is also a cache-key correctness gap: all dependency cache entries currentl
 - Local verification: `mcpp build` succeeded, then `MCPP=target/x86_64-linux-gnu/4d24c8b57fdbbbb4/bin/mcpp bash tests/e2e/49_bmi_cache_nested_custom_index.sh` returned `OK`.
 - `mcpp test -- --gtest_filter=BmiCache.*` initially exposed an unrelated local environment issue: `~/.mcpp/registry/data/xpkgs/xim-x-binutils/2.42` only had `.xpkg.lua` and no `bin/as`. Re-running with a temporary `MCPP_HOME` pointed at the complete installed mcpp registry passed: 15 test binaries ok, 0 failed.
 - Remote custom-index first-use sync keeps the mcpp-level `Fetching custom index repos (first use)` status, but calls `update_index(..., quiet=true)` so `mcpp build` does not expose xlings update output. A non-zero update exits with a concise mcpp-level error.
+
+## Final Outcome
+
+- Landed with PR #88: https://github.com/mcpp-community/mcpp/pull/88
+- Released in `mcpp 0.0.35`: https://github.com/mcpp-community/mcpp/releases/tag/v0.0.35
+- The mcpp status line remains visible, but internal `xlings update` output is quiet.
+- The xlings migration PR #314 completed without `warning: bmi cache populate failed` in the Linux `E2E-00: mcpp builds xlings from source` log.
+
+## Follow-up: Default Index Freshness
+
+The final local xlings verification exposed a separate default-index freshness bug:
+when `~/.mcpp/registry/data` contained other xlings-managed index clones but no
+`mcpplibs` clone, `mcpp` treated the registry as fresh and skipped the default
+index update. `mcpp build` then failed before dependency resolution with:
+
+```text
+error: dependency 'compat.libarchive': index entry not found in local clone
+```
+
+Fix for `0.0.36`:
+
+- `is_index_fresh()` now requires `registry/data/mcpplibs/pkgs` specifically.
+- Regression coverage verifies that an unrelated `xim-pkgindex/pkgs` tree no
+  longer satisfies default `mcpplibs` freshness.
+- A fresh/mixed user cache will trigger the normal default-index update path
+  before searching or building `compat.*` dependencies.

--- a/.agents/docs/2026-05-30-package-owned-build-flags-plan.md
+++ b/.agents/docs/2026-05-30-package-owned-build-flags-plan.md
@@ -1,6 +1,6 @@
 # mcpp 0.0.35: Package-Owned Build Metadata Plan
 
-> 状态: in progress
+> 状态: complete
 > 分支: `codex/package-owned-build-flags`
 > 目标: 让依赖包在官方 mcpp-index 中携带自己的 C/C++ 编译 flags、include 优先级和配置头，从而让 xlings 不再把第三方 C 库的 configure 结果写在项目根 `mcpp.toml`。
 
@@ -73,5 +73,19 @@ cd /home/speak/workspace/github/openxlings/xlings
   - `mcpp build --target x86_64-linux-musl` -> `target/x86_64-linux-musl/7e48a312cd4dbb49/bin/xlings` static ELF.
 - [x] PR draft 创建: https://github.com/mcpp-community/mcpp/pull/88
 - [x] 版本 bump 到 `0.0.35`,并补充 `CHANGELOG.md` 发布说明。
-- [ ] CI 每 120s 检查一次直到完成。
-- [ ] CI 通过后发布 `0.0.35`。
+- [x] CI 每 120s 检查一次直到完成。
+- [x] CI 通过后发布 `0.0.35`。
+
+## Final Outcome
+
+- PR: https://github.com/mcpp-community/mcpp/pull/88
+- Merge commit: `40c51b93c0ce7f821533dc05ac0e2cbf535737bf`
+- Release: https://github.com/mcpp-community/mcpp/releases/tag/v0.0.35
+- CI evidence:
+  - Linux `build + test`: success.
+  - macOS ARM64 `xlings LLVM end-to-end`: success.
+  - Windows x64 `build + test`: success.
+- Downstream evidence:
+  - openxlings/xlings PR #314 used `mcpp 0.0.35` with official `compat.libarchive`.
+  - Linux E2E `mcpp builds xlings from source` passed.
+  - xlings `v0.4.46` release was published after the migration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 > 本文件追踪 `mcpp-community/mcpp` 公开仓的版本演进。
 > 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [0.0.36] — 2026-05-31
+
+### 修复
+
+- 修复默认 `mcpplibs` 索引缺失时被其他 xlings 索引误判为 fresh 的问题。
+  `mcpp build/search` 现在会要求默认索引自身存在并处于 TTL 内,避免
+  `compat.*` 依赖在混合缓存状态下找不到。
+
 ## [0.0.35] — 2026-05-30
 
 ### 新增

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.35"
+version     = "0.0.36"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.35";
+inline constexpr std::string_view MCPP_VERSION = "0.0.36";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;

--- a/src/xlings.cppm
+++ b/src/xlings.cppm
@@ -232,7 +232,8 @@ void ensure_ninja(const Env& env, bool quiet,
 
 // ─── Index freshness ────────────────────────────────────────────────
 
-// Check whether local index data exists and is fresh (within ttlSeconds).
+// Check whether the default mcpplibs index data exists and is fresh
+// (within ttlSeconds).
 // Returns true if index is present and fresh, false otherwise.
 bool is_index_fresh(const Env& env, std::int64_t ttlSeconds);
 
@@ -930,23 +931,12 @@ void ensure_ninja(const Env& env, bool quiet,
 // ─── Index freshness ────────────────────────────────────────────────
 
 bool is_index_fresh(const Env& env, std::int64_t ttlSeconds) {
-    auto data = paths::index_data(env);
-    if (!std::filesystem::exists(data)) return false;
-
-    // Look for any directory under data/ that has a pkgs/ subdirectory —
-    // that's a cloned index repo.
     std::error_code ec;
-    bool hasIndex = false;
-    std::filesystem::file_time_type newest{};
-    for (auto& entry : std::filesystem::directory_iterator(data, ec)) {
-        if (!entry.is_directory()) continue;
-        auto pkgsDir = entry.path() / "pkgs";
-        if (!std::filesystem::exists(pkgsDir)) continue;
-        hasIndex = true;
-        auto t = std::filesystem::last_write_time(pkgsDir, ec);
-        if (!ec && t > newest) newest = t;
-    }
-    if (!hasIndex) return false;
+    auto pkgsDir = paths::index_data(env) / "mcpplibs" / "pkgs";
+    if (!std::filesystem::exists(pkgsDir)) return false;
+
+    auto newest = std::filesystem::last_write_time(pkgsDir, ec);
+    if (ec) return false;
 
     // Check TTL
     auto now = std::filesystem::file_time_type::clock::now();

--- a/tests/e2e/01_help_and_version.sh
+++ b/tests/e2e/01_help_and_version.sh
@@ -3,11 +3,17 @@
 # Verify --help and --version
 set -e
 
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
 out=$("$MCPP" --version)
 # Version must match `mcpp <SemVer>` — don't pin a specific version here
 # so this test doesn't break on every release bump.
 [[ "$out" =~ ^mcpp\ [0-9]+\.[0-9]+\.[0-9]+ ]] \
     || { echo "Bad version output: $out"; exit 1; }
+expected="$(awk -F '"' '/^version[[:space:]]*=/{print $2; exit}' "$ROOT/mcpp.toml")"
+[[ -n "$expected" ]] || { echo "Failed to read mcpp.toml package version"; exit 1; }
+[[ "$out" == "mcpp $expected"* ]] \
+    || { echo "Version mismatch: mcpp.toml=$expected, --version='$out'"; exit 1; }
 
 out=$("$MCPP" --help)
 [[ "$out" == *"Usage:"* ]] || { echo "--help missing 'Usage:' section"; exit 1; }

--- a/tests/unit/test_xlings.cpp
+++ b/tests/unit/test_xlings.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+
+import std;
+import mcpp.xlings;
+
+namespace {
+
+std::filesystem::path make_tempdir(std::string_view name) {
+    auto base = std::filesystem::temp_directory_path()
+              / std::format("{}-{}", name, std::chrono::steady_clock::now().time_since_epoch().count());
+    std::filesystem::create_directories(base);
+    return base;
+}
+
+}  // namespace
+
+TEST(XlingsIndexFreshness, RequiresDefaultMcpplibsIndex) {
+    auto home = make_tempdir("mcpp-xlings-index-freshness");
+    std::filesystem::create_directories(home / "data" / "xim-pkgindex" / "pkgs");
+
+    mcpp::xlings::Env env{.home = home};
+
+    EXPECT_FALSE(mcpp::xlings::is_index_fresh(env, 3600));
+
+    std::filesystem::remove_all(home);
+}
+
+TEST(XlingsIndexFreshness, AcceptsFreshDefaultMcpplibsIndex) {
+    auto home = make_tempdir("mcpp-xlings-index-freshness");
+    std::filesystem::create_directories(home / "data" / "mcpplibs" / "pkgs");
+
+    mcpp::xlings::Env env{.home = home};
+
+    EXPECT_TRUE(mcpp::xlings::is_index_fresh(env, 3600));
+
+    std::filesystem::remove_all(home);
+}


### PR DESCRIPTION
## Summary
- require the default `mcpplibs` index clone itself when checking index freshness
- add regression coverage for mixed-cache homes that contain other xlings indices but no `mcpplibs`
- bump release metadata to `0.0.36` and keep the binary `--version` source in sync
- add an e2e guard that compares `mcpp --version` with `mcpp.toml`

## Verification
- `mcpp build`
- `MCPP=<0.0.36 binary> bash tests/e2e/01_help_and_version.sh`
- `mcpp test`
- temporary mixed-cache repro: `MCPP_HOME=<tmp-with-xim-pkgindex-only> <0.0.36 mcpp> search libarchive` found `compat:compat.libarchive`
- current xlings project: `MCPP_HOME=/home/speak/.mcpp <0.0.36 mcpp> build`