### PR TITLE
fix(index): quiet refresh and canonical cache labels

### DIFF
--- a/.agents/docs/2026-05-31-index-refresh-cache-labels-plan.md
+++ b/.agents/docs/2026-05-31-index-refresh-cache-labels-plan.md
@@ -132,6 +132,22 @@ uses only the xlings NDJSON interface path for regular xpkg installs, while
 `mcpp.xlings::install_with_progress()` already documents the direct CLI path
 as more reliable for large package installs.
 
+### 6. Fresh mcpplibs marker does not imply fresh official xim index
+
+The direct-install fallback exposed the next failing layer in Linux CI:
+
+```text
+[error] package 'xim:musl-gcc@15.1.0' not found
+error: toolchain 'gcc@15.1.0-musl': xlings install of 'xim:musl-gcc@15.1.0' failed (interface exit 1, direct exit 1)
+```
+
+The same workflow's earlier e2e suite could install/build with musl-gcc in an
+isolated fresh home, so the package resource was available. The failing later
+step used the main mcpp sandbox, where `mcpplibs/.mcpp-index-updated` can be
+fresh while `xim-pkgindex/pkgs` is missing or stale. Toolchains are resolved
+from xlings' official `xim-pkgindex`, so mcpp must track that index separately
+from the default modular-library `mcpplibs` index.
+
 ## Implementation Plan
 
 - [x] Add focused regression coverage for default-index refresh quietness.
@@ -145,6 +161,8 @@ as more reliable for large package installs.
 - [x] Add a direct `xlings install <target> -y` fallback after interface
       install failure, preserving visible direct-install output for CI
       diagnostics.
+- [x] Track official `xim-pkgindex` freshness independently and refresh it
+      before auto-installing `xim:` toolchain packages.
 - [x] Validate with the local xlings checkout using the new mcpp binary.
 - [x] Push a draft PR and use it as the multi-commit checkpoint.
 
@@ -198,3 +216,20 @@ as more reliable for large package installs.
     `src/pm/package_fetcher.cppm`.
   - Re-ran local `mcpp build --no-cache`, `mcpp test --
     --gtest_filter=XlingsIndexFreshness.*`, and the three related e2e tests.
+  - The fallback made the hidden root cause visible on the second run:
+    the main sandbox could not find `xim:musl-gcc@15.1.0` because the official
+    `xim-pkgindex` data was missing/stale even though mcpp's default
+    `mcpplibs` marker was fresh.
+  - Added `is_official_index_fresh()` / `ensure_official_index_fresh()` and
+    call it before `xim:` auto-installs.
+  - Added unit coverage for a fresh default index with a missing official
+    `xim-pkgindex`.
+  - Local verification after this fix:
+    - `mcpp build --no-cache` passed.
+    - `mcpp test -- --gtest_filter=XlingsIndexFreshness.*` passed with 6
+      matching `test_xlings` cases.
+    - e2e `49_bmi_cache_nested_custom_index.sh`,
+      `52_local_path_namespaced_index.sh`, and `53_namespaced_cache_label.sh`
+      passed.
+    - `/tmp/mcpp-fresh-codex clean && /tmp/mcpp-fresh-codex build --target
+      x86_64-linux-musl` passed and resolved `gcc@15.1.0-musl`.

--- a/.agents/docs/2026-05-31-index-refresh-cache-labels-plan.md
+++ b/.agents/docs/2026-05-31-index-refresh-cache-labels-plan.md
@@ -15,6 +15,8 @@ The current work is intentionally limited to build-tool behavior:
 - make automatic package-index refresh quiet from the mcpp user's perspective;
 - make index freshness use a reliable mcpp-owned timestamp marker;
 - make dependency cache status use canonical dependency identities;
+- make large xpkg/toolchain installs retry through direct `xlings install`
+  when the NDJSON interface path fails;
 - keep local xlings validation as the integration proof.
 
 ## Findings
@@ -103,6 +105,33 @@ deps/mcpplibs/xpkg@0.0.39
 
 while the consumer dependency remains `mcpplibs.xpkg v0.0.41`.
 
+### 5. Cold Linux CI can fail musl-gcc via xlings interface install
+
+PR #91 inherited a main-branch Linux CI failure in:
+
+```text
+Toolchain: musl-gcc - build mcpp (--target)
+```
+
+The failing command was:
+
+```text
+mcpp build --target x86_64-linux-musl
+```
+
+The visible error was only:
+
+```text
+xlings install of 'xim:musl-gcc@15.1.0' failed (exit 1)
+```
+
+The same workflow's e2e suite had already proven that fresh-home musl-gcc
+installation can work, and recent CI history showed this as a cold-cache
+failure on main too. The weak point is that `Fetcher::resolve_xpkg_path()`
+uses only the xlings NDJSON interface path for regular xpkg installs, while
+`mcpp.xlings::install_with_progress()` already documents the direct CLI path
+as more reliable for large package installs.
+
 ## Implementation Plan
 
 - [x] Add focused regression coverage for default-index refresh quietness.
@@ -113,8 +142,11 @@ while the consumer dependency remains `mcpplibs.xpkg v0.0.41`.
 - [x] Avoid using stale embedded package version as the user-facing resolved
       dependency version when the index resolution already knows the requested
       version.
+- [x] Add a direct `xlings install <target> -y` fallback after interface
+      install failure, preserving visible direct-install output for CI
+      diagnostics.
 - [x] Validate with the local xlings checkout using the new mcpp binary.
-- [ ] Push a draft PR and use it as the multi-commit checkpoint.
+- [x] Push a draft PR and use it as the multi-commit checkpoint.
 
 ## Verification Plan
 
@@ -126,7 +158,7 @@ while the consumer dependency remains `mcpplibs.xpkg v0.0.41`.
       while the marker is inside TTL.
 - [x] Confirm cached dependencies display as `Cached` when their artifacts are
       staged.
-- [ ] Record CI status on the PR.
+- [ ] Record CI status on the PR after the second checkpoint commit.
 
 ## Dynamic Notes
 
@@ -157,3 +189,12 @@ while the consumer dependency remains `mcpplibs.xpkg v0.0.41`.
     `mcpplibs.tinyhttps` / `mcpplibs.xpkg` displayed as `Cached`.
   - Marker was written at
     `~/.mcpp/registry/data/mcpplibs/.mcpp-index-updated`.
+- CI follow-up:
+  - Linux CI on PR #91 failed in `Toolchain: musl-gcc - build mcpp
+    (--target)`.
+  - The same step had already failed on `origin/main` run `26691717542`, so
+    this is not introduced solely by PR #91.
+  - Added direct-install fallback in `src/xlings.cppm` and
+    `src/pm/package_fetcher.cppm`.
+  - Re-ran local `mcpp build --no-cache`, `mcpp test --
+    --gtest_filter=XlingsIndexFreshness.*`, and the three related e2e tests.

--- a/.agents/docs/2026-05-31-index-refresh-cache-labels-plan.md
+++ b/.agents/docs/2026-05-31-index-refresh-cache-labels-plan.md
@@ -148,6 +148,28 @@ fresh while `xim-pkgindex/pkgs` is missing or stale. Toolchains are resolved
 from xlings' official `xim-pkgindex`, so mcpp must track that index separately
 from the default modular-library `mcpplibs` index.
 
+### 7. Fresh official index marker does not imply the target package exists
+
+The third PR checkpoint still failed in the same Linux musl step. The package
+lookup error remained:
+
+```text
+[error] package 'xim:musl-gcc@15.1.0' not found
+```
+
+That means a restored CI cache can still satisfy the coarse check
+`xim-pkgindex/pkgs + .mcpp-index-updated` while missing the package file added
+later:
+
+```text
+xim-pkgindex/pkgs/m/musl-gcc.lua
+```
+
+For `xim:` auto-installs, the freshness guard must therefore check the target
+package's index file, not just the official index directory. If the package
+file is absent, mcpp should silently run `xlings update` before calling either
+the NDJSON interface install path or the direct CLI fallback.
+
 ## Implementation Plan
 
 - [x] Add focused regression coverage for default-index refresh quietness.
@@ -163,6 +185,8 @@ from the default modular-library `mcpplibs` index.
       diagnostics.
 - [x] Track official `xim-pkgindex` freshness independently and refresh it
       before auto-installing `xim:` toolchain packages.
+- [x] Require the target package file to exist before treating an official
+      `xim:` index as fresh.
 - [x] Validate with the local xlings checkout using the new mcpp binary.
 - [x] Push a draft PR and use it as the multi-commit checkpoint.
 
@@ -228,6 +252,22 @@ from the default modular-library `mcpplibs` index.
     - `mcpp build --no-cache` passed.
     - `mcpp test -- --gtest_filter=XlingsIndexFreshness.*` passed with 6
       matching `test_xlings` cases.
+    - e2e `49_bmi_cache_nested_custom_index.sh`,
+      `52_local_path_namespaced_index.sh`, and `53_namespaced_cache_label.sh`
+      passed.
+    - `/tmp/mcpp-fresh-codex clean && /tmp/mcpp-fresh-codex build --target
+      x86_64-linux-musl` passed and resolved `gcc@15.1.0-musl`.
+  - The next CI run still failed at the same musl step, proving the remaining
+    stale-cache shape is target-package-level, not just official-index-level.
+  - Added `is_official_package_index_fresh()` /
+    `ensure_official_package_index_fresh()` and wired `xim:` auto-installs to
+    check the concrete package file (for example `pkgs/m/musl-gcc.lua`).
+  - Added two more unit tests for a fresh official index marker with a missing
+    target package file.
+  - Local verification after this package-file fix:
+    - `mcpp test -- --gtest_filter=XlingsIndexFreshness.*` passed with 8
+      matching `test_xlings` cases.
+    - `mcpp build --no-cache` passed.
     - e2e `49_bmi_cache_nested_custom_index.sh`,
       `52_local_path_namespaced_index.sh`, and `53_namespaced_cache_label.sh`
       passed.

--- a/.agents/docs/2026-05-31-index-refresh-cache-labels-plan.md
+++ b/.agents/docs/2026-05-31-index-refresh-cache-labels-plan.md
@@ -1,0 +1,159 @@
+# Index Refresh And Dependency Cache Label Fix
+
+> Date: 2026-05-31 | Status: active | Branch:
+> `codex/quiet-index-refresh-cache-labels`
+
+Tracking issue: https://github.com/mcpp-community/mcpp/issues/90
+
+## Scope
+
+This document tracks the mcpp-side fixes found while validating `mcpp build`
+against the `xlings` project.
+
+The current work is intentionally limited to build-tool behavior:
+
+- make automatic package-index refresh quiet from the mcpp user's perspective;
+- make index freshness use a reliable mcpp-owned timestamp marker;
+- make dependency cache status use canonical dependency identities;
+- keep local xlings validation as the integration proof.
+
+## Findings
+
+### 1. Auto-refresh leaks xlings update output
+
+`mcpp build` calls `ensure_index_fresh()` when a project has version-source
+dependencies. That path currently calls `xlings update` with `quiet=false`.
+
+Observed output:
+
+```text
+Updating package index (auto-refresh)
+[1/7] awesome::/home/speak/.mcpp/registry/data/xim-index-repos/...
+...
+index updated
+```
+
+The `[N/M] awesome::...` lines are xlings internals. mcpp users should only see
+the mcpp-level status line unless they explicitly run a verbose/manual index
+update command.
+
+### 2. Freshness check uses an unstable directory mtime
+
+`is_index_fresh()` currently checks:
+
+```text
+~/.mcpp/registry/data/mcpplibs/pkgs
+```
+
+Local evidence showed:
+
+```text
+mcpplibs/pkgs             2026-05-31 01:55:40
+mcpplibs/.git/FETCH_HEAD  2026-05-31 04:31:24
+xim-indexrepos.json       2026-05-31 04:31:27
+```
+
+So `xlings update` can refresh the repository without updating the `pkgs/`
+directory mtime. Once the TTL expires, every full `prepare_build()` can decide
+that the index is stale again.
+
+### 3. Dependency status labels can say `Compiling` for cached deps
+
+For xlings:
+
+```toml
+[dependencies.mcpplibs]
+xpkg = "0.0.41"
+tinyhttps = "0.2.3"
+```
+
+The UI prints dependency names as `mcpplibs.xpkg` and `mcpplibs.tinyhttps`.
+The cache hit label is currently built from the dependency package's own
+`mcpp.toml` name. For tinyhttps that manifest uses:
+
+```toml
+namespace = "mcpplibs"
+name = "tinyhttps"
+version = "0.2.3"
+```
+
+The cache directory is therefore:
+
+```text
+~/.mcpp/bmi/<fingerprint>/deps/mcpplibs/tinyhttps@0.2.3
+```
+
+The UI compares `tinyhttps` against `mcpplibs.tinyhttps`, so it can print
+`Compiling mcpplibs.tinyhttps` even when the cache entry exists.
+
+### 4. libxpkg 0.0.41 has stale embedded mcpp metadata
+
+The installed `mcpplibs.xpkg@0.0.41` archive contains:
+
+```toml
+name = "xpkg"
+version = "0.0.39"
+```
+
+This causes mcpp to cache the resolved package as:
+
+```text
+deps/mcpplibs/xpkg@0.0.39
+```
+
+while the consumer dependency remains `mcpplibs.xpkg v0.0.41`.
+
+## Implementation Plan
+
+- [x] Add focused regression coverage for default-index refresh quietness.
+- [x] Add a reliable mcpp-owned index freshness marker after successful update.
+- [x] Make automatic refresh call `update_index(..., quiet=true)`.
+- [x] Keep explicit/manual index update output available for diagnostics.
+- [x] Canonicalize dependency identity used for cache-hit labels.
+- [x] Avoid using stale embedded package version as the user-facing resolved
+      dependency version when the index resolution already knows the requested
+      version.
+- [x] Validate with the local xlings checkout using the new mcpp binary.
+- [ ] Push a draft PR and use it as the multi-commit checkpoint.
+
+## Verification Plan
+
+- [x] Run targeted unit/e2e coverage in mcpp.
+- [x] Build mcpp itself.
+- [x] Run `mcpp build` in `/home/speak/test/tmp/xlings` with the new binary.
+- [x] Confirm auto-refresh no longer prints xlings `[N/M] index::path` lines.
+- [x] Confirm repeated xlings full prepare does not refresh the index again
+      while the marker is inside TTL.
+- [x] Confirm cached dependencies display as `Cached` when their artifacts are
+      staged.
+- [ ] Record CI status on the PR.
+
+## Dynamic Notes
+
+- `mcpp build` has a 0.01s fast path when `build.ninja` is newer than source
+  files; the noisy path happens when full `prepare_build()` runs.
+- A no-change `ninja -C target/... -n` in the local xlings checkout reported
+  `ninja: no work to do`, so the status-line issue is partly UI/cache identity
+  rather than always an actual compiler invocation.
+- Added regression tests:
+  - `tests/unit/test_xlings.cpp` now requires `.mcpp-index-updated` for a
+    fresh default index.
+  - `tests/e2e/53_namespaced_cache_label.sh` verifies quiet auto-refresh,
+    marker creation, and canonical `Cached compat.widget v1.0.0` output.
+- Local mcpp verification:
+  - `mcpp test -- --gtest_filter=XlingsIndexFreshness.*` passed; the command
+    built and ran all 16 test binaries, with `test_xlings` covering the filter.
+  - `mcpp build --no-cache` passed and produced
+    `target/x86_64-linux-gnu/4d24c8b57fdbbbb4/bin/mcpp`.
+  - `MCPP=.../bin/mcpp bash tests/e2e/49_bmi_cache_nested_custom_index.sh`
+    passed.
+  - `MCPP=.../bin/mcpp bash tests/e2e/52_local_path_namespaced_index.sh`
+    passed.
+  - `MCPP=.../bin/mcpp bash tests/e2e/53_namespaced_cache_label.sh` passed.
+- Local xlings verification with the new mcpp binary:
+  - First `build --print-fingerprint`: exit `0`, displayed only
+    `Updating package index (auto-refresh)` with no xlings `[N/M]` lines.
+  - Second `build --print-fingerprint`: exit `0`, no index refresh line, and
+    `mcpplibs.tinyhttps` / `mcpplibs.xpkg` displayed as `Cached`.
+  - Marker was written at
+    `~/.mcpp/registry/data/mcpplibs/.mcpp-index-updated`.

--- a/.agents/docs/2026-05-31-index-refresh-cache-labels-plan.md
+++ b/.agents/docs/2026-05-31-index-refresh-cache-labels-plan.md
@@ -1,6 +1,6 @@
 # Index Refresh And Dependency Cache Label Fix
 
-> Date: 2026-05-31 | Status: active | Branch:
+> Date: 2026-05-31 | Status: awaiting required review | Branch:
 > `codex/quiet-index-refresh-cache-labels`
 
 Tracking issue: https://github.com/mcpp-community/mcpp/issues/90
@@ -232,7 +232,7 @@ does not point at the current sandbox's package file.
       while the marker is inside TTL.
 - [x] Confirm cached dependencies display as `Cached` when their artifacts are
       staged.
-- [ ] Record CI status on the PR after the second checkpoint commit.
+- [x] Record CI status on the PR after the final checkpoint commit.
 
 ## Dynamic Notes
 
@@ -321,3 +321,13 @@ does not point at the current sandbox's package file.
       passed.
     - `/tmp/mcpp-fresh-codex clean && /tmp/mcpp-fresh-codex build --target
       x86_64-linux-musl` passed and resolved `gcc@15.1.0-musl`.
+  - Final CI on PR #91 at commit
+    `f93f3179331ad87434d6643a88ed526677b1e4e5` passed on all required
+    platforms:
+    - Linux `ci-linux`, run `26697058042`, job `78683273931`.
+    - macOS `ci-macos`, run `26697058049`, job `78683273992`.
+    - Windows `ci-windows`, run `26697058053`, job `78683274017`.
+  - PR #91 is ready for review and mergeable, but branch protection currently
+    reports `reviewDecision=REVIEW_REQUIRED`. A normal squash merge was
+    rejected by base-branch policy, and repository auto-merge is disabled. Do
+    not use `--admin`; wait for maintainer approval before squash merging.

--- a/.agents/docs/2026-05-31-index-refresh-cache-labels-plan.md
+++ b/.agents/docs/2026-05-31-index-refresh-cache-labels-plan.md
@@ -170,6 +170,36 @@ package's index file, not just the official index directory. If the package
 file is absent, mcpp should silently run `xlings update` before calling either
 the NDJSON interface install path or the direct CLI fallback.
 
+### 8. xlings index cache can be poisoned by temp-home symlinked indexes
+
+The fourth PR checkpoint still failed in the same Linux musl step. Local
+inspection revealed an additional xlings cache layer:
+
+```text
+xim-pkgindex/.xlings-index-cache.json
+```
+
+That cache stores absolute `path` values for each xpkg file. mcpp e2e tests
+inherit the global `xim-pkgindex` into temp `MCPP_HOME` directories, often via
+symlink. When xlings rebuilds the cache from that temp home, it can write paths
+like:
+
+```text
+/tmp/tmp.X.../mcpp-home/registry/data/xim-pkgindex/pkgs/m/musl-gcc.lua
+```
+
+into the shared global index directory. Later, the main sandbox loads that
+cache and `PackageCatalog::build_match_()` calls `load_package()` on the stale
+temp path. The load fails, the match is discarded, and the user-facing error is
+still:
+
+```text
+package 'xim:musl-gcc@15.1.0' not found
+```
+
+So the mcpp guard must also reject a package cache whose target package entry
+does not point at the current sandbox's package file.
+
 ## Implementation Plan
 
 - [x] Add focused regression coverage for default-index refresh quietness.
@@ -187,6 +217,8 @@ the NDJSON interface install path or the direct CLI fallback.
       before auto-installing `xim:` toolchain packages.
 - [x] Require the target package file to exist before treating an official
       `xim:` index as fresh.
+- [x] Reject xlings index caches whose target package path points at a foreign
+      temp/home directory.
 - [x] Validate with the local xlings checkout using the new mcpp binary.
 - [x] Push a draft PR and use it as the multi-commit checkpoint.
 
@@ -266,6 +298,22 @@ the NDJSON interface install path or the direct CLI fallback.
     target package file.
   - Local verification after this package-file fix:
     - `mcpp test -- --gtest_filter=XlingsIndexFreshness.*` passed with 8
+      matching `test_xlings` cases.
+    - `mcpp build --no-cache` passed.
+    - e2e `49_bmi_cache_nested_custom_index.sh`,
+      `52_local_path_namespaced_index.sh`, and `53_namespaced_cache_label.sh`
+      passed.
+    - `/tmp/mcpp-fresh-codex clean && /tmp/mcpp-fresh-codex build --target
+      x86_64-linux-musl` passed and resolved `gcc@15.1.0-musl`.
+  - The next CI run still failed at the same musl step. The remaining issue is
+    xlings' `.xlings-index-cache.json` using absolute package-file paths that
+    can be written from e2e temp homes into the shared index directory.
+  - Added cache-path validation for the target package file in
+    `is_official_package_index_fresh()`.
+  - Added two unit tests for foreign/current package paths inside
+    `.xlings-index-cache.json`.
+  - Local verification after this cache-path fix:
+    - `mcpp test -- --gtest_filter=XlingsIndexFreshness.*` passed with 10
       matching `test_xlings` cases.
     - `mcpp build --no-cache` passed.
     - e2e `49_bmi_cache_nested_custom_index.sh`,

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -1514,11 +1514,16 @@ prepare_build(bool print_fingerprint,
     // unique_ptr is not load-bearing for liveness — it's a leftover from
     // an earlier design and harmless).
     std::vector<std::unique_ptr<mcpp::manifest::Manifest>> dep_manifests;
-    std::vector<std::string> dep_cache_indices;
     auto cache_index_name = [](std::string_view ns) {
         if (ns.empty()) return std::string(mcpp::pm::kDefaultNamespace);
         return std::string(ns);
     };
+    struct DepCacheIdentity {
+        std::string indexName;
+        std::string packageName;
+        std::string version;
+    };
+    std::vector<DepCacheIdentity> dep_cache_identities;
 
     struct ResolvedKey {
         std::string ns;
@@ -2049,7 +2054,11 @@ prepare_build(bool print_fingerprint,
 
                     dep_manifests.push_back(
                         std::make_unique<mcpp::manifest::Manifest>(std::move(stagedManifest)));
-                    dep_cache_indices.push_back(cache_index_name(key.ns));
+                    dep_cache_identities.push_back({
+                        .indexName   = cache_index_name(key.ns),
+                        .packageName = mangled,
+                        .version     = spec.version,
+                    });
                     packages.push_back({secStage, *dep_manifests.back()});
                     auto added = propagateIncludeDirs(secStage, *dep_manifests.back());
 
@@ -2134,6 +2143,8 @@ prepare_build(bool print_fingerprint,
 
                 it->second.version            = *merged;
                 it->second.includeDirsAdded   = std::move(added);
+                if (it->second.depIndex < dep_cache_identities.size())
+                    dep_cache_identities[it->second.depIndex].version = *merged;
 
                 // Walk the *new* manifest's deps so their constraints feed
                 // future merges. Already-resolved children dedup via the
@@ -2274,7 +2285,13 @@ prepare_build(bool print_fingerprint,
         // by depIndex (the SemVer merger needs to overwrite the slot).
         dep_manifests.push_back(
             std::make_unique<mcpp::manifest::Manifest>(std::move(*dep_manifest)));
-        dep_cache_indices.push_back(cache_index_name(key.ns));
+        dep_cache_identities.push_back({
+            .indexName   = cache_index_name(key.ns),
+            .packageName = name,
+            .version     = sourceKind == "version"
+                ? spec.version
+                : dep_manifests.back()->package.version,
+        });
         packages.push_back({dep_root, *dep_manifests.back()});
 
         // Record this dep as resolved so future encounters of the same
@@ -2433,8 +2450,17 @@ prepare_build(bool print_fingerprint,
         };
         for (std::size_t i = 1; i < packages.size(); ++i) {  // skip [0] = main
             const auto& pkgRoot   = packages[i];
-            const auto& depName   = pkgRoot.manifest.package.name;
-            const auto& depVer    = pkgRoot.manifest.package.version;
+            const auto* depIdent  = i - 1 < dep_cache_identities.size()
+                ? &dep_cache_identities[i - 1]
+                : nullptr;
+            const auto fallbackName = pkgRoot.manifest.package.namespace_.empty()
+                ? pkgRoot.manifest.package.name
+                : std::format("{}.{}", pkgRoot.manifest.package.namespace_,
+                              pkgRoot.manifest.package.name);
+            const auto& depName   = depIdent ? depIdent->packageName : fallbackName;
+            const auto& depVer    = depIdent && !depIdent->version.empty()
+                ? depIdent->version
+                : pkgRoot.manifest.package.version;
 
             // Find this dep's spec from the consumer manifest to know
             // if it's path-based or version-based.
@@ -2455,8 +2481,8 @@ prepare_build(bool print_fingerprint,
             mcpp::bmi_cache::CacheKey key {
                 .mcppHome    = (*cfg2)->mcppHome,
                 .fingerprint = fp.hex,
-                .indexName   = i - 1 < dep_cache_indices.size()
-                    ? dep_cache_indices[i - 1]
+                .indexName   = depIdent
+                    ? depIdent->indexName
                     : (*cfg2)->defaultIndex,
                 .packageName = depName,
                 .version     = depVer,

--- a/src/pm/package_fetcher.cppm
+++ b/src/pm/package_fetcher.cppm
@@ -694,8 +694,8 @@ Fetcher::resolve_xpkg_path(std::string_view target,
     if (autoInstall) {
         if (parsed.indexName == "xim") {
             mcpp::xlings::Env xlEnv{ cfg_.xlingsBinary, cfg_.xlingsHome() };
-            mcpp::xlings::ensure_official_index_fresh(
-                xlEnv, cfg_.searchTtlSeconds, /*quiet=*/true);
+            mcpp::xlings::ensure_official_package_index_fresh(
+                xlEnv, parsed.packageName, cfg_.searchTtlSeconds, /*quiet=*/true);
         }
 
         std::vector<std::string> targets {

--- a/src/pm/package_fetcher.cppm
+++ b/src/pm/package_fetcher.cppm
@@ -725,15 +725,39 @@ Fetcher::resolve_xpkg_path(std::string_view target,
             mcpp::fallback::clean_incomplete_install(verdir);
         }
         if (inst->exitCode != 0) {
-            // xlings install actually failed (network, missing package,
-            // half-extracted, etc.). Do NOT try copy fallback: the global
-            // ~/.xlings/ state may itself be residue from the same failure,
-            // and looks_complete_legacy() can't tell residue from complete.
+            // xlings interface install actually failed (network, missing
+            // package, extraction subprocess issue, etc.). Retry once through
+            // direct `xlings install`: xlings' own CLI path is more reliable
+            // for large toolchain packages and keeps the real failure output
+            // visible to CI/users when it still fails.
             mcpp::fallback::clean_incomplete_install(verdir);
+            mcpp::log::verbose("fetcher",
+                std::format("interface install failed for {}; retrying direct xlings install",
+                            targets[0]));
+            mcpp::xlings::Env directEnv{ cfg_.xlingsBinary, cfg_.xlingsHome() };
+            int directRc = mcpp::xlings::install_direct(directEnv, targets[0]);
+            if (directRc == 0 && std::filesystem::exists(verdir)) {
+                mcpp::fallback::mark_install_complete(verdir);
+                return make_payload();
+            }
+            if (directRc == 0 && !std::filesystem::exists(verdir)) {
+                bool copyOk = mcpp::fallback::copy_xpkg_from_global(verdir);
+                if (copyOk && mcpp::fallback::looks_complete_legacy(verdir)) {
+                    mcpp::fallback::mark_install_complete(verdir);
+                    mcpp::log::verbose("fetcher", "resolved via copy fallback after direct install");
+                    return make_payload();
+                }
+                mcpp::fallback::clean_incomplete_install(verdir);
+            }
+
+            // If both interface and direct install failed, do NOT try copy
+            // fallback: the global ~/.xlings/ state may itself be residue from
+            // the same failure, and looks_complete_legacy() can't tell residue
+            // from complete.
             std::string installError = std::format(
-                "xlings install of '{}:{}@{}' failed (exit {})",
+                "xlings install of '{}:{}@{}' failed (interface exit {}, direct exit {})",
                 parsed.indexName, parsed.packageName, parsed.version,
-                inst->exitCode);
+                inst->exitCode, directRc);
             if (inst->error)
                 installError += ": " + inst->error->message;
             return std::unexpected(CallError{std::format(

--- a/src/pm/package_fetcher.cppm
+++ b/src/pm/package_fetcher.cppm
@@ -692,6 +692,12 @@ Fetcher::resolve_xpkg_path(std::string_view target,
 
     // 3. Install via xlings (primary path).
     if (autoInstall) {
+        if (parsed.indexName == "xim") {
+            mcpp::xlings::Env xlEnv{ cfg_.xlingsBinary, cfg_.xlingsHome() };
+            mcpp::xlings::ensure_official_index_fresh(
+                xlEnv, cfg_.searchTtlSeconds, /*quiet=*/true);
+        }
+
         std::vector<std::string> targets {
             std::format("{}:{}@{}", parsed.indexName, parsed.packageName, parsed.version)
         };

--- a/src/xlings.cppm
+++ b/src/xlings.cppm
@@ -317,6 +317,33 @@ std::filesystem::path official_package_file(const Env& env, std::string_view pac
     return official_index_dir(env) / "pkgs" / std::string(1, name[0]) / (name + ".lua");
 }
 
+std::string json_escaped_path_probe(std::filesystem::path path) {
+    auto value = path.string();
+    std::string escaped;
+    escaped.reserve(value.size() * 2);
+    for (char c : value) {
+        if (c == '\\') escaped += "\\\\";
+        else escaped.push_back(c);
+    }
+    return escaped;
+}
+
+bool official_index_cache_matches_package_file(const Env& env,
+                                               std::string_view packageName) {
+    auto cache = official_index_dir(env) / ".xlings-index-cache.json";
+    if (!std::filesystem::exists(cache)) return true;
+
+    auto pkg = official_package_file(env, packageName);
+    if (pkg.empty()) return false;
+
+    std::ifstream is(cache);
+    if (!is) return false;
+    std::string body((std::istreambuf_iterator<char>(is)), {});
+    auto rawPath = pkg.string();
+    return body.find(rawPath) != std::string::npos
+        || body.find(json_escaped_path_probe(pkg)) != std::string::npos;
+}
+
 void mark_index_refreshed(const std::filesystem::path& indexDir) {
     if (!std::filesystem::exists(index_pkgs_dir(indexDir))) return;
     std::error_code ec;
@@ -1040,7 +1067,9 @@ bool is_official_package_index_fresh(const Env& env,
                                      std::int64_t ttlSeconds) {
     if (!is_official_index_fresh(env, ttlSeconds)) return false;
     auto pkg = official_package_file(env, packageName);
-    return !pkg.empty() && std::filesystem::exists(pkg);
+    return !pkg.empty()
+        && std::filesystem::exists(pkg)
+        && official_index_cache_matches_package_file(env, packageName);
 }
 
 int update_index(const Env& env, bool quiet) {

--- a/src/xlings.cppm
+++ b/src/xlings.cppm
@@ -246,6 +246,13 @@ bool is_index_fresh(const Env& env, std::int64_t ttlSeconds);
 // toolchains live in xim-pkgindex, while modular libraries live in mcpplibs.
 bool is_official_index_fresh(const Env& env, std::int64_t ttlSeconds);
 
+// Check whether a specific package file exists in xlings' official xim index
+// and the index is fresh. This catches restored CI caches that have an index
+// directory and marker but predate a package added later.
+bool is_official_package_index_fresh(const Env& env,
+                                     std::string_view packageName,
+                                     std::int64_t ttlSeconds);
+
 // Run `xlings update` to refresh all index repos. Streams output to stdout.
 // Returns the xlings exit code.
 int update_index(const Env& env, bool quiet = false);
@@ -257,6 +264,12 @@ void ensure_index_fresh(const Env& env, std::int64_t ttlSeconds, bool quiet = fa
 
 // Ensure xlings' official xim index is present and fresh.
 void ensure_official_index_fresh(const Env& env, std::int64_t ttlSeconds, bool quiet = false);
+
+// Ensure a specific package file exists in xlings' official xim index.
+void ensure_official_package_index_fresh(const Env& env,
+                                         std::string_view packageName,
+                                         std::int64_t ttlSeconds,
+                                         bool quiet = false);
 
 // ─── run_capture utility ────────────────────────────────────────────
 
@@ -296,6 +309,12 @@ std::filesystem::path index_pkgs_dir(const std::filesystem::path& indexDir) {
 
 std::filesystem::path index_refresh_marker(const std::filesystem::path& indexDir) {
     return indexDir / ".mcpp-index-updated";
+}
+
+std::filesystem::path official_package_file(const Env& env, std::string_view packageName) {
+    if (packageName.empty()) return {};
+    std::string name(packageName);
+    return official_index_dir(env) / "pkgs" / std::string(1, name[0]) / (name + ".lua");
 }
 
 void mark_index_refreshed(const std::filesystem::path& indexDir) {
@@ -1016,6 +1035,14 @@ bool is_official_index_fresh(const Env& env, std::int64_t ttlSeconds) {
     return is_index_dir_fresh(official_index_dir(env), ttlSeconds);
 }
 
+bool is_official_package_index_fresh(const Env& env,
+                                     std::string_view packageName,
+                                     std::int64_t ttlSeconds) {
+    if (!is_official_index_fresh(env, ttlSeconds)) return false;
+    auto pkg = official_package_file(env, packageName);
+    return !pkg.empty() && std::filesystem::exists(pkg);
+}
+
 int update_index(const Env& env, bool quiet) {
     std::string cmd = build_command_prefix(env) + " update 2>&1";
     int rc = mcpp::platform::process::run_streaming(cmd,
@@ -1035,6 +1062,16 @@ void ensure_index_fresh(const Env& env, std::int64_t ttlSeconds, bool quiet) {
 
 void ensure_official_index_fresh(const Env& env, std::int64_t ttlSeconds, bool quiet) {
     if (is_official_index_fresh(env, ttlSeconds)) return;
+    if (!quiet)
+        print_status("Updating", "package index (auto-refresh)");
+    update_index(env, /*quiet=*/true);
+}
+
+void ensure_official_package_index_fresh(const Env& env,
+                                         std::string_view packageName,
+                                         std::int64_t ttlSeconds,
+                                         bool quiet) {
+    if (is_official_package_index_fresh(env, packageName, ttlSeconds)) return;
     if (!quiet)
         print_status("Updating", "package index (auto-refresh)");
     update_index(env, /*quiet=*/true);

--- a/src/xlings.cppm
+++ b/src/xlings.cppm
@@ -270,6 +270,34 @@ void print_status(std::string_view verb, std::string_view msg) {
     }
 }
 
+std::filesystem::path default_index_dir(const Env& env) {
+    return paths::index_data(env) / "mcpplibs";
+}
+
+std::filesystem::path default_index_pkgs_dir(const Env& env) {
+    return default_index_dir(env) / "pkgs";
+}
+
+std::filesystem::path default_index_refresh_marker(const Env& env) {
+    return default_index_dir(env) / ".mcpp-index-updated";
+}
+
+void mark_default_index_refreshed(const Env& env) {
+    if (!env.projectDir.empty()) return;
+    if (!std::filesystem::exists(default_index_pkgs_dir(env))) return;
+
+    std::error_code ec;
+    std::filesystem::create_directories(default_index_dir(env), ec);
+    auto marker = default_index_refresh_marker(env);
+    {
+        std::ofstream os(marker, std::ios::trunc);
+        if (!os) return;
+        os << "ok\n";
+    }
+    std::filesystem::last_write_time(
+        marker, std::filesystem::file_time_type::clock::now(), ec);
+}
+
 void write_file(const std::filesystem::path& p, std::string_view content) {
     std::error_code ec;
     std::filesystem::create_directories(p.parent_path(), ec);
@@ -932,10 +960,13 @@ void ensure_ninja(const Env& env, bool quiet,
 
 bool is_index_fresh(const Env& env, std::int64_t ttlSeconds) {
     std::error_code ec;
-    auto pkgsDir = paths::index_data(env) / "mcpplibs" / "pkgs";
+    auto pkgsDir = default_index_pkgs_dir(env);
     if (!std::filesystem::exists(pkgsDir)) return false;
 
-    auto newest = std::filesystem::last_write_time(pkgsDir, ec);
+    auto marker = default_index_refresh_marker(env);
+    if (!std::filesystem::exists(marker)) return false;
+
+    auto newest = std::filesystem::last_write_time(marker, ec);
     if (ec) return false;
 
     // Check TTL
@@ -946,17 +977,19 @@ bool is_index_fresh(const Env& env, std::int64_t ttlSeconds) {
 
 int update_index(const Env& env, bool quiet) {
     std::string cmd = build_command_prefix(env) + " update 2>&1";
-    return mcpp::platform::process::run_streaming(cmd,
+    int rc = mcpp::platform::process::run_streaming(cmd,
         [quiet](std::string_view line) {
             if (!quiet) std::println("{}", line);
         });
+    if (rc == 0) mark_default_index_refreshed(env);
+    return rc;
 }
 
 void ensure_index_fresh(const Env& env, std::int64_t ttlSeconds, bool quiet) {
     if (is_index_fresh(env, ttlSeconds)) return;
     if (!quiet)
         print_status("Updating", "package index (auto-refresh)");
-    update_index(env, quiet);
+    update_index(env, /*quiet=*/true);
 }
 
 } // namespace mcpp::xlings

--- a/src/xlings.cppm
+++ b/src/xlings.cppm
@@ -194,6 +194,10 @@ using BootstrapProgressCallback = std::function<void(const BootstrapProgress&)>;
 int install_with_progress(const Env& env, std::string_view target,
                           const BootstrapProgressCallback& cb);
 
+// Run direct `xlings install <target> -y`.
+// Used as a fallback when the NDJSON interface install path fails.
+int install_direct(const Env& env, std::string_view target, bool quiet = false);
+
 // ─── Sandbox lifecycle ──────────────────────────────────────────────
 
 // Write .xlings.json seed file.
@@ -833,6 +837,21 @@ int install_with_progress(const Env& env, std::string_view target,
 
     int closeRc = mcpp::platform::process::run_streaming(cmd, handle_line);
     return (resultExitCode != -1) ? resultExitCode : closeRc;
+}
+
+int install_direct(const Env& env, std::string_view target, bool quiet) {
+    auto cmd = build_command_prefix(env)
+        + std::format(" install {} -y", shq(target));
+    if (quiet) {
+        cmd += " ";
+        cmd += std::string(mcpp::platform::shell::silent_redirect);
+    }
+    if constexpr (mcpp::platform::is_windows) {
+        cmd += " <NUL";
+    } else {
+        cmd += " </dev/null";
+    }
+    return mcpp::platform::process::extract_exit_code(std::system(cmd.c_str()));
 }
 
 // ─── Sandbox lifecycle ──────────────────────────────────────────────

--- a/src/xlings.cppm
+++ b/src/xlings.cppm
@@ -241,6 +241,11 @@ void ensure_ninja(const Env& env, bool quiet,
 // Returns true if index is present and fresh, false otherwise.
 bool is_index_fresh(const Env& env, std::int64_t ttlSeconds);
 
+// Check whether xlings' official xim index data exists and is fresh.
+// This is separate from mcpp's default mcpplibs index because xlings
+// toolchains live in xim-pkgindex, while modular libraries live in mcpplibs.
+bool is_official_index_fresh(const Env& env, std::int64_t ttlSeconds);
+
 // Run `xlings update` to refresh all index repos. Streams output to stdout.
 // Returns the xlings exit code.
 int update_index(const Env& env, bool quiet = false);
@@ -249,6 +254,9 @@ int update_index(const Env& env, bool quiet = false);
 // the index is missing or older than ttlSeconds. Idempotent and quiet
 // when no update is needed.
 void ensure_index_fresh(const Env& env, std::int64_t ttlSeconds, bool quiet = false);
+
+// Ensure xlings' official xim index is present and fresh.
+void ensure_official_index_fresh(const Env& env, std::int64_t ttlSeconds, bool quiet = false);
 
 // ─── run_capture utility ────────────────────────────────────────────
 
@@ -278,21 +286,23 @@ std::filesystem::path default_index_dir(const Env& env) {
     return paths::index_data(env) / "mcpplibs";
 }
 
-std::filesystem::path default_index_pkgs_dir(const Env& env) {
-    return default_index_dir(env) / "pkgs";
+std::filesystem::path official_index_dir(const Env& env) {
+    return paths::index_data(env) / "xim-pkgindex";
 }
 
-std::filesystem::path default_index_refresh_marker(const Env& env) {
-    return default_index_dir(env) / ".mcpp-index-updated";
+std::filesystem::path index_pkgs_dir(const std::filesystem::path& indexDir) {
+    return indexDir / "pkgs";
 }
 
-void mark_default_index_refreshed(const Env& env) {
-    if (!env.projectDir.empty()) return;
-    if (!std::filesystem::exists(default_index_pkgs_dir(env))) return;
+std::filesystem::path index_refresh_marker(const std::filesystem::path& indexDir) {
+    return indexDir / ".mcpp-index-updated";
+}
 
+void mark_index_refreshed(const std::filesystem::path& indexDir) {
+    if (!std::filesystem::exists(index_pkgs_dir(indexDir))) return;
     std::error_code ec;
-    std::filesystem::create_directories(default_index_dir(env), ec);
-    auto marker = default_index_refresh_marker(env);
+    std::filesystem::create_directories(indexDir, ec);
+    auto marker = index_refresh_marker(indexDir);
     {
         std::ofstream os(marker, std::ios::trunc);
         if (!os) return;
@@ -300,6 +310,27 @@ void mark_default_index_refreshed(const Env& env) {
     }
     std::filesystem::last_write_time(
         marker, std::filesystem::file_time_type::clock::now(), ec);
+}
+
+void mark_known_indexes_refreshed(const Env& env) {
+    if (!env.projectDir.empty()) return;
+    mark_index_refreshed(default_index_dir(env));
+    mark_index_refreshed(official_index_dir(env));
+}
+
+bool is_index_dir_fresh(const std::filesystem::path& indexDir, std::int64_t ttlSeconds) {
+    std::error_code ec;
+    if (!std::filesystem::exists(index_pkgs_dir(indexDir))) return false;
+
+    auto marker = index_refresh_marker(indexDir);
+    if (!std::filesystem::exists(marker)) return false;
+
+    auto newest = std::filesystem::last_write_time(marker, ec);
+    if (ec) return false;
+
+    auto now = std::filesystem::file_time_type::clock::now();
+    auto age = std::chrono::duration_cast<std::chrono::seconds>(now - newest);
+    return age.count() < ttlSeconds;
 }
 
 void write_file(const std::filesystem::path& p, std::string_view content) {
@@ -978,20 +1009,11 @@ void ensure_ninja(const Env& env, bool quiet,
 // ─── Index freshness ────────────────────────────────────────────────
 
 bool is_index_fresh(const Env& env, std::int64_t ttlSeconds) {
-    std::error_code ec;
-    auto pkgsDir = default_index_pkgs_dir(env);
-    if (!std::filesystem::exists(pkgsDir)) return false;
+    return is_index_dir_fresh(default_index_dir(env), ttlSeconds);
+}
 
-    auto marker = default_index_refresh_marker(env);
-    if (!std::filesystem::exists(marker)) return false;
-
-    auto newest = std::filesystem::last_write_time(marker, ec);
-    if (ec) return false;
-
-    // Check TTL
-    auto now = std::filesystem::file_time_type::clock::now();
-    auto age = std::chrono::duration_cast<std::chrono::seconds>(now - newest);
-    return age.count() < ttlSeconds;
+bool is_official_index_fresh(const Env& env, std::int64_t ttlSeconds) {
+    return is_index_dir_fresh(official_index_dir(env), ttlSeconds);
 }
 
 int update_index(const Env& env, bool quiet) {
@@ -1000,12 +1022,19 @@ int update_index(const Env& env, bool quiet) {
         [quiet](std::string_view line) {
             if (!quiet) std::println("{}", line);
         });
-    if (rc == 0) mark_default_index_refreshed(env);
+    if (rc == 0) mark_known_indexes_refreshed(env);
     return rc;
 }
 
 void ensure_index_fresh(const Env& env, std::int64_t ttlSeconds, bool quiet) {
     if (is_index_fresh(env, ttlSeconds)) return;
+    if (!quiet)
+        print_status("Updating", "package index (auto-refresh)");
+    update_index(env, /*quiet=*/true);
+}
+
+void ensure_official_index_fresh(const Env& env, std::int64_t ttlSeconds, bool quiet) {
+    if (is_official_index_fresh(env, ttlSeconds)) return;
     if (!quiet)
         print_status("Updating", "package index (auto-refresh)");
     update_index(env, /*quiet=*/true);

--- a/tests/e2e/53_namespaced_cache_label.sh
+++ b/tests/e2e/53_namespaced_cache_label.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# requires: gcc fresh-sandbox
+# Cached dependency status must use the canonical dependency key, not only the
+# short package name embedded in the dependency's own mcpp.toml.
+set -e
+
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+
+export MCPP_HOME="$TMP/mcpp-home"
+source "$(dirname "$0")/_inherit_toolchain.sh"
+
+INDEX_DIR="$TMP/local-index"
+mkdir -p "$INDEX_DIR/pkgs/c"
+cat > "$INDEX_DIR/pkgs/c/compat.widget.lua" <<'EOF'
+package = {
+    spec = "1",
+    namespace = "compat",
+    name = "compat.widget",
+    description = "Namespaced cache label package",
+    licenses = {"MIT"},
+    type = "package",
+    xpm = {
+        linux = {
+            ["1.0.0"] = {
+                url = "https://example.invalid/widget-1.0.0.tar.gz",
+                sha256 = "0000000000000000000000000000000000000000000000000000000000000000",
+            },
+        },
+    },
+}
+EOF
+
+mkdir -p "$TMP/project/app/src" \
+         "$TMP/project/app/.mcpp/.xlings/data/xpkgs/compat.widget/1.0.0/widget-1.0.0/src"
+cd "$TMP/project/app"
+
+cat > .mcpp/.xlings/data/xpkgs/compat.widget/1.0.0/widget-1.0.0/mcpp.toml <<'EOF'
+[package]
+namespace = "compat"
+name = "widget"
+version = "1.0.0"
+
+[build]
+sources = ["src/*.c"]
+
+[targets.widget]
+kind = "lib"
+EOF
+
+cat > .mcpp/.xlings/data/xpkgs/compat.widget/1.0.0/widget-1.0.0/src/widget.c <<'EOF'
+int widget_value(void) {
+    return 7;
+}
+EOF
+
+cat > src/main.cpp <<'EOF'
+extern "C" int widget_value(void);
+int main() {
+    return widget_value() == 7 ? 0 : 1;
+}
+EOF
+
+cat > mcpp.toml <<EOF
+[package]
+name = "app"
+version = "0.1.0"
+
+[indices]
+compat = { path = "$INDEX_DIR" }
+
+[dependencies.compat]
+widget = "1.0.0"
+
+[targets.app]
+kind = "bin"
+main = "src/main.cpp"
+EOF
+
+"$MCPP" build > build.log 2>&1 || {
+    cat build.log
+    exit 1
+}
+
+if grep -Eq '^\[[0-9]+/[0-9]+\] ' build.log; then
+    echo "FAIL: automatic index refresh should not expose xlings update output"
+    cat build.log
+    exit 1
+fi
+
+[[ -f "$MCPP_HOME/registry/data/mcpplibs/.mcpp-index-updated" ]] || {
+    echo "FAIL: automatic index refresh should write mcpp freshness marker"
+    find "$MCPP_HOME/registry/data" -maxdepth 3 -type f | sort
+    cat build.log
+    exit 1
+}
+
+rm -rf target
+"$MCPP" build > build2.log 2>&1 || {
+    cat build2.log
+    exit 1
+}
+
+grep -q "Cached compat.widget v1.0.0" build2.log || {
+    echo "FAIL: cached namespaced dependency should be reported as compat.widget"
+    cat build2.log
+    exit 1
+}
+
+echo "OK"

--- a/tests/unit/test_xlings.cpp
+++ b/tests/unit/test_xlings.cpp
@@ -28,10 +28,37 @@ TEST(XlingsIndexFreshness, RequiresDefaultMcpplibsIndex) {
 TEST(XlingsIndexFreshness, AcceptsFreshDefaultMcpplibsIndex) {
     auto home = make_tempdir("mcpp-xlings-index-freshness");
     std::filesystem::create_directories(home / "data" / "mcpplibs" / "pkgs");
+    std::ofstream(home / "data" / "mcpplibs" / ".mcpp-index-updated") << "ok\n";
 
     mcpp::xlings::Env env{.home = home};
 
     EXPECT_TRUE(mcpp::xlings::is_index_fresh(env, 3600));
+
+    std::filesystem::remove_all(home);
+}
+
+TEST(XlingsIndexFreshness, RequiresRefreshMarkerForDefaultMcpplibsIndex) {
+    auto home = make_tempdir("mcpp-xlings-index-freshness");
+    std::filesystem::create_directories(home / "data" / "mcpplibs" / "pkgs");
+
+    mcpp::xlings::Env env{.home = home};
+
+    EXPECT_FALSE(mcpp::xlings::is_index_fresh(env, 3600));
+
+    std::filesystem::remove_all(home);
+}
+
+TEST(XlingsIndexFreshness, RejectsStaleRefreshMarker) {
+    auto home = make_tempdir("mcpp-xlings-index-freshness");
+    std::filesystem::create_directories(home / "data" / "mcpplibs" / "pkgs");
+    auto marker = home / "data" / "mcpplibs" / ".mcpp-index-updated";
+    std::ofstream(marker) << "ok\n";
+    std::filesystem::last_write_time(
+        marker, std::filesystem::file_time_type::clock::now() - std::chrono::seconds(7200));
+
+    mcpp::xlings::Env env{.home = home};
+
+    EXPECT_FALSE(mcpp::xlings::is_index_fresh(env, 3600));
 
     std::filesystem::remove_all(home);
 }

--- a/tests/unit/test_xlings.cpp
+++ b/tests/unit/test_xlings.cpp
@@ -62,3 +62,27 @@ TEST(XlingsIndexFreshness, RejectsStaleRefreshMarker) {
 
     std::filesystem::remove_all(home);
 }
+
+TEST(XlingsIndexFreshness, RequiresOfficialXimIndexEvenWhenDefaultIndexIsFresh) {
+    auto home = make_tempdir("mcpp-xlings-index-freshness");
+    std::filesystem::create_directories(home / "data" / "mcpplibs" / "pkgs");
+    std::ofstream(home / "data" / "mcpplibs" / ".mcpp-index-updated") << "ok\n";
+
+    mcpp::xlings::Env env{.home = home};
+
+    EXPECT_FALSE(mcpp::xlings::is_official_index_fresh(env, 3600));
+
+    std::filesystem::remove_all(home);
+}
+
+TEST(XlingsIndexFreshness, AcceptsFreshOfficialXimIndex) {
+    auto home = make_tempdir("mcpp-xlings-index-freshness");
+    std::filesystem::create_directories(home / "data" / "xim-pkgindex" / "pkgs");
+    std::ofstream(home / "data" / "xim-pkgindex" / ".mcpp-index-updated") << "ok\n";
+
+    mcpp::xlings::Env env{.home = home};
+
+    EXPECT_TRUE(mcpp::xlings::is_official_index_fresh(env, 3600));
+
+    std::filesystem::remove_all(home);
+}

--- a/tests/unit/test_xlings.cpp
+++ b/tests/unit/test_xlings.cpp
@@ -111,3 +111,35 @@ TEST(XlingsIndexFreshness, AcceptsFreshOfficialPackageFile) {
 
     std::filesystem::remove_all(home);
 }
+
+TEST(XlingsIndexFreshness, RejectsOfficialPackageCacheWithForeignPath) {
+    auto home = make_tempdir("mcpp-xlings-index-freshness");
+    auto pkg = home / "data" / "xim-pkgindex" / "pkgs" / "m" / "musl-gcc.lua";
+    std::filesystem::create_directories(pkg.parent_path());
+    std::ofstream(home / "data" / "xim-pkgindex" / ".mcpp-index-updated") << "ok\n";
+    std::ofstream(pkg) << "package = {}\n";
+    std::ofstream(home / "data" / "xim-pkgindex" / ".xlings-index-cache.json")
+        << R"({"entries":{"musl-gcc":{"path":"/tmp/foreign/xim-pkgindex/pkgs/m/musl-gcc.lua"}}})";
+
+    mcpp::xlings::Env env{.home = home};
+
+    EXPECT_FALSE(mcpp::xlings::is_official_package_index_fresh(env, "musl-gcc", 3600));
+
+    std::filesystem::remove_all(home);
+}
+
+TEST(XlingsIndexFreshness, AcceptsOfficialPackageCacheWithCurrentPath) {
+    auto home = make_tempdir("mcpp-xlings-index-freshness");
+    auto pkg = home / "data" / "xim-pkgindex" / "pkgs" / "m" / "musl-gcc.lua";
+    std::filesystem::create_directories(pkg.parent_path());
+    std::ofstream(home / "data" / "xim-pkgindex" / ".mcpp-index-updated") << "ok\n";
+    std::ofstream(pkg) << "package = {}\n";
+    std::ofstream(home / "data" / "xim-pkgindex" / ".xlings-index-cache.json")
+        << std::format(R"({{"entries":{{"musl-gcc":{{"path":"{}"}}}}}})", pkg.string());
+
+    mcpp::xlings::Env env{.home = home};
+
+    EXPECT_TRUE(mcpp::xlings::is_official_package_index_fresh(env, "musl-gcc", 3600));
+
+    std::filesystem::remove_all(home);
+}

--- a/tests/unit/test_xlings.cpp
+++ b/tests/unit/test_xlings.cpp
@@ -86,3 +86,28 @@ TEST(XlingsIndexFreshness, AcceptsFreshOfficialXimIndex) {
 
     std::filesystem::remove_all(home);
 }
+
+TEST(XlingsIndexFreshness, RequiresOfficialPackageFileEvenWhenOfficialIndexIsFresh) {
+    auto home = make_tempdir("mcpp-xlings-index-freshness");
+    std::filesystem::create_directories(home / "data" / "xim-pkgindex" / "pkgs");
+    std::ofstream(home / "data" / "xim-pkgindex" / ".mcpp-index-updated") << "ok\n";
+
+    mcpp::xlings::Env env{.home = home};
+
+    EXPECT_FALSE(mcpp::xlings::is_official_package_index_fresh(env, "musl-gcc", 3600));
+
+    std::filesystem::remove_all(home);
+}
+
+TEST(XlingsIndexFreshness, AcceptsFreshOfficialPackageFile) {
+    auto home = make_tempdir("mcpp-xlings-index-freshness");
+    std::filesystem::create_directories(home / "data" / "xim-pkgindex" / "pkgs" / "m");
+    std::ofstream(home / "data" / "xim-pkgindex" / ".mcpp-index-updated") << "ok\n";
+    std::ofstream(home / "data" / "xim-pkgindex" / "pkgs" / "m" / "musl-gcc.lua") << "package = {}\n";
+
+    mcpp::xlings::Env env{.home = home};
+
+    EXPECT_TRUE(mcpp::xlings::is_official_package_index_fresh(env, "musl-gcc", 3600));
+
+    std::filesystem::remove_all(home);
+}


### PR DESCRIPTION
## Summary
- make automatic package-index refresh use mcpp-owned freshness markers and quiet xlings update output
- track official `xim-pkgindex` freshness separately, require target `xim:` package files, and reject xlings cache entries pointing at foreign temp homes
- use resolved dependency identity/version for BMI cache keys and cached-status labels
- retry failed xlings NDJSON interface installs through direct `xlings install <target> -y` for large xpkg/toolchain packages
- add regression coverage for default-index freshness, official-index freshness, target package metadata freshness, xlings cache path poisoning, and namespaced dependency cache labels
- document the xlings validation findings and CI follow-up under `.agents/docs`

Closes #90

## CI note
- Earlier PR runs exposed an inherited Linux failure in `Toolchain: musl-gcc — build mcpp (--target)`, caused by xlings catalog/cache state in the main mcpp sandbox after e2e temp-home index reuse.
- The final checkpoint rejects target package cache entries that do not point at the current sandbox and refreshes before `xim:` auto-install.
- CI is green on commit `f93f317`: Linux, macOS, and Windows all passed.
