### PR TITLE
chore(release): prepare mcpp 0.0.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 > 本文件追踪 `mcpp-community/mcpp` 公开仓的版本演进。
 > 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [0.0.37] — 2026-05-31
+
+### 修复
+
+- 修复 xlings 项目构建时自动索引刷新泄漏 xlings 内部 `[N/M] index::path`
+  输出的问题。mcpp 仍保留 `Updating package index (auto-refresh)` 状态行,
+  且该状态行走统一彩色 UI 输出；内部 `xlings update` 现在在自动刷新路径中
+  静默执行。
+- 修复自动索引 freshness 依赖不稳定目录 mtime 的问题,改用 mcpp-owned
+  `.mcpp-index-updated` marker,避免 full prepare 时重复刷新索引。
+- 修复命名空间依赖命中 BMI cache 后仍显示 `Compiling mcpplibs.*` 的问题,
+  cache key 与 UI 状态现在使用解析得到的 canonical dependency identity。
+- 修复 `xim:` 工具链自动安装时官方索引/目标包文件/`.xlings-index-cache.json`
+  可能陈旧或指向临时 sandbox 路径导致 `package not found` 的问题。
+
 ## [0.0.36] — 2026-05-31
 
 ### 修复

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.36"
+version     = "0.0.37"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -1459,7 +1459,11 @@ prepare_build(bool print_fingerprint,
             auto cfg2 = get_cfg();
             if (cfg2) {
                 auto xlEnv = mcpp::config::make_xlings_env(**cfg2);
-                mcpp::xlings::ensure_index_fresh(xlEnv, (*cfg2)->searchTtlSeconds);
+                if (!mcpp::xlings::is_index_fresh(xlEnv, (*cfg2)->searchTtlSeconds)) {
+                    mcpp::ui::status("Updating", "package index (auto-refresh)");
+                    mcpp::xlings::ensure_index_fresh(
+                        xlEnv, (*cfg2)->searchTtlSeconds, /*quiet=*/true);
+                }
             }
         }
     }
@@ -2995,7 +2999,10 @@ int cmd_search(const mcpplibs::cmdline::ParsedArgs& parsed) {
     if (!cfg) { mcpp::ui::error(cfg.error().message); return 4; }
 
     auto xlEnv = mcpp::config::make_xlings_env(*cfg);
-    mcpp::xlings::ensure_index_fresh(xlEnv, cfg->searchTtlSeconds);
+    if (!mcpp::xlings::is_index_fresh(xlEnv, cfg->searchTtlSeconds)) {
+        mcpp::ui::status("Updating", "package index (auto-refresh)");
+        mcpp::xlings::ensure_index_fresh(xlEnv, cfg->searchTtlSeconds, /*quiet=*/true);
+    }
 
     mcpp::fetcher::Fetcher f(*cfg);
     auto hits = f.search(keyword);

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.36";
+inline constexpr std::string_view MCPP_VERSION = "0.0.37";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;


### PR DESCRIPTION
## Summary

- Bump mcpp to 0.0.37.
- Keep auto-refresh status visible through the shared `mcpp::ui::status()` path so `Updating package index (auto-refresh)` uses the same colored UI handling as `Resolved` / `Cached`.
- Keep the underlying `xlings update` call quiet during automatic refresh so xlings internal `[N/M] index::path` output does not leak into `mcpp build`.
- Document the 0.0.37 fixes in `CHANGELOG.md`.

## Verification

- `mcpp build --no-cache`
- `mcpp test -- --gtest_filter=XlingsIndexFreshness.*`
- `MCPP=$MCPP_BIN bash tests/e2e/49_bmi_cache_nested_custom_index.sh`
- `MCPP=$MCPP_BIN bash tests/e2e/52_local_path_namespaced_index.sh`
- `MCPP=$MCPP_BIN bash tests/e2e/53_namespaced_cache_label.sh`
- Built `/home/speak/test/tmp/xlings` twice with the new local mcpp binary and confirmed `mcpplibs.tinyhttps` / `mcpplibs.xpkg` are reported as `Cached`, not rebuilt.
- Forced auto-refresh in a TTY with `NO_COLOR` unset and confirmed `Updating package index (auto-refresh)` is emitted through the colored shared UI path, with no xlings `[N/M]` index lines.
