### PR TITLE
[codex] expose xim tool deps for project indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 > 本文件追踪 `mcpp-community/mcpp` 公开仓的版本演进。
 > 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [0.0.40] — 2026-06-01
+
+### 修复
+
+- 修复 project-local index 包的 xpm hook 工具依赖无法解析官方 `xim`
+  索引的问题。项目级 xlings 配置现在会在 custom/local index 旁边显式暴露
+  官方 `xim` 索引,让 `xim:python` 等 hook 工具依赖可用。
+
 ## [0.0.39] — 2026-06-01
 
 ### 修复

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.39"
+version     = "0.0.40"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/config.cppm
+++ b/src/config.cppm
@@ -674,10 +674,24 @@ bool ensure_project_index_dir(
         customRepos.emplace_back(name, spec.url);
     }
 
+    auto officialIndex = cfg.xlingsHome() / "data" / "xim-pkgindex";
+    std::error_code ec;
+    if (!customRepos.empty() && std::filesystem::exists(officialIndex / "pkgs", ec)) {
+        bool hasXim = false;
+        for (auto const& [name, _] : customRepos) {
+            if (name == "xim") {
+                hasXim = true;
+                break;
+            }
+        }
+        if (!hasXim) {
+            customRepos.emplace_back("xim", officialIndex.generic_string());
+        }
+    }
+
     if (customRepos.empty()) return false;  // nothing to do
 
     auto dotMcpp = projectDir / ".mcpp";
-    std::error_code ec;
     std::filesystem::create_directories(dotMcpp, ec);
 
     // Seed .xlings.json with the custom index entries.
@@ -725,7 +739,6 @@ bool ensure_project_index_dir(
     // project data dir. Expose the global official xim index there too, so
     // package deps like `xim:python@latest` can resolve without falling back
     // to unrelated remote index updates or system tools.
-    auto officialIndex = cfg.xlingsHome() / "data" / "xim-pkgindex";
     if (std::filesystem::exists(officialIndex / "pkgs", ec)) {
         auto projectData = dotMcpp / ".xlings" / "data";
         auto projectOfficial = projectData / "xim-pkgindex";

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.39";
+inline constexpr std::string_view MCPP_VERSION = "0.0.40";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;

--- a/tests/e2e/52_local_path_namespaced_index.sh
+++ b/tests/e2e/52_local_path_namespaced_index.sh
@@ -89,6 +89,21 @@ FAKE_REGISTRY="$TMP/fake-registry"
 FAKE_LOG="$TMP/fake-xlings.log"
 FAKE_DIRECT_LOG="$TMP/fake-xlings-direct.log"
 mkdir -p "$FAKE_REGISTRY/data"
+mkdir -p "$FAKE_REGISTRY/data/xim-pkgindex/pkgs/p"
+cat > "$FAKE_REGISTRY/data/xim-pkgindex/pkgs/p/python.lua" <<'EOF'
+package = {
+    spec = "1",
+    name = "python",
+    xpm = {
+        linux = {
+            ["3"] = {
+                url = "https://example.invalid/python.tar.gz",
+                sha256 = "0000000000000000000000000000000000000000000000000000000000000000",
+            },
+        },
+    },
+}
+EOF
 if [[ -d "$USER_MCPP/registry/data/xpkgs" ]]; then
     ln -s "$USER_MCPP/registry/data/xpkgs" "$FAKE_REGISTRY/data/xpkgs"
 fi
@@ -121,6 +136,11 @@ fi
 
 if [[ "${1:-}" == "install" ]]; then
     printf '%s\n' "$*" > "${FAKE_XLINGS_DIRECT_LOG:?}"
+    if ! grep -q '"name": "xim"' "${XLINGS_PROJECT_DIR:?}/.xlings.json"; then
+        echo "missing official xim index in project .xlings.json" >&2
+        cat "${XLINGS_PROJECT_DIR:?}/.xlings.json" >&2 2>/dev/null || true
+        exit 24
+    fi
     if [[ ! -d "${XLINGS_PROJECT_DIR:?}/.xlings/data/compat/pkgs" \
        && ! -d "${XLINGS_PROJECT_DIR:?}/data/compat/pkgs" ]]; then
         echo "missing project local path index link" >&2


### PR DESCRIPTION
## Summary

- seed the official xim index into project .xlings.json when project-local/custom indices are used
- keep the existing project data exposure so hook-time xpm deps like xim:python can resolve without relying on system tools
- prepare mcpp 0.0.40 for the hotfix release

## Validation

- mcpp build
- mcpp --version => 0.0.40
- MCPP=... bash tests/e2e/01_help_and_version.sh
- MCPP=... bash tests/e2e/52_local_path_namespaced_index.sh
- MCPP=... bash tests/e2e/58_preinstall_mcpp_deps_for_hooks.sh
- git diff --check
