### PR TITLE
Fix Objective-C source routing in Ninja backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 > 本文件追踪 `mcpp-community/mcpp` 公开仓的版本演进。
 > 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [0.0.41] — 2026-06-01
+
+### 修复
+
+- 修复 Objective-C `.m` 源文件在 Ninja 后端被路由到 C++ 编译规则的问题。
+  `.m` 现在与 `.c` 一样使用 C/Objective-C 编译器与 `cflags`,避免 macOS
+  GLFW 等上游 Objective-C 源被错误附加 `-std=c++23`。
+
 ## [0.0.40] — 2026-06-01
 
 ### 修复

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.40"
+version     = "0.0.41"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/build/ninja_backend.cppm
+++ b/src/build/ninja_backend.cppm
@@ -445,7 +445,7 @@ std::string emit_ninja_string(const BuildPlan& plan) {
         auto ext = src.extension();
         if (ext == ".cppm")
             return "cxx_module";
-        if (ext == ".c")
+        if (ext == ".c" || ext == ".m")
             return "c_object";
         return "cxx_object";
     };

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.40";
+inline constexpr std::string_view MCPP_VERSION = "0.0.41";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;

--- a/tests/unit/test_ninja_backend.cpp
+++ b/tests/unit/test_ninja_backend.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+
+import std;
+import mcpp.build.ninja;
+import mcpp.build.plan;
+import mcpp.manifest;
+import mcpp.toolchain.model;
+
+using namespace mcpp::build;
+
+namespace {
+
+BuildPlan minimal_plan() {
+    BuildPlan plan;
+    plan.projectRoot = "/tmp/mcpp-ninja-test";
+    plan.outputDir = plan.projectRoot / "target" / "test";
+    plan.manifest.package.name = "objc_rule_test";
+    plan.manifest.buildConfig.cStandard = "c11";
+    plan.toolchain.compiler = mcpp::toolchain::CompilerId::GCC;
+    plan.toolchain.version = "test";
+    plan.toolchain.binaryPath = "/usr/bin/g++";
+    plan.toolchain.targetTriple = "x86_64-linux-gnu";
+    return plan;
+}
+
+}  // namespace
+
+TEST(NinjaBackend, ObjectiveCSourceUsesCObjectRuleAndCFlags) {
+    auto plan = minimal_plan();
+    plan.compileUnits.push_back({
+        .source = "src/cocoa.m",
+        .object = "obj/cocoa.o",
+        .packageName = "objc_rule_test",
+        .packageCflags = {"-DOBJ_C_BUILD=1"},
+        .packageCxxflags = {"-DWRONG_CXX_FLAG=1"},
+    });
+
+    auto ninja = emit_ninja_string(plan);
+
+    EXPECT_NE(ninja.find("build obj/cocoa.o : c_object src/cocoa.m"), std::string::npos)
+        << ninja;
+    EXPECT_EQ(ninja.find("build obj/cocoa.o : cxx_object src/cocoa.m"), std::string::npos)
+        << ninja;
+    EXPECT_NE(ninja.find("unit_cflags = -DOBJ_C_BUILD=1"), std::string::npos)
+        << ninja;
+    EXPECT_EQ(ninja.find("unit_cxxflags = -DWRONG_CXX_FLAG=1"), std::string::npos)
+        << ninja;
+}


### PR DESCRIPTION
## Summary
- route `.m` Objective-C sources through the C/Objective-C ninja rule instead of `cxx_object`
- add a focused ninja backend regression test that verifies `.m` uses `c_object` and package-owned `cflags`
- bump mcpp to `0.0.41` and document the fix

## Validation
- `mcpp test -- --gtest_filter=NinjaBackend.ObjectiveCSourceUsesCObjectRuleAndCFlags` (red before the fix, green after)
- `MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)") timeout 600 bash tests/e2e/26_c_language_support.sh`
- `mcpp test`
- `git diff --check`
