### PR TITLE
chore: bump mcpp to 0.0.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 > 本文件追踪 `mcpp-community/mcpp` 公开仓的版本演进。
 > 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [0.0.44] — 2026-06-02
+
+### 修复
+
+- 修复 git branch 依赖的缓存身份和 lockfile source 元数据。branch 依赖现在会先
+  解析到具体 commit,缓存 key 会随远端 branch 更新而变化,lockfile 也会记录
+  `git+<url>#branch=<name>@<sha>` 而不是错误落到 `index+mcpplibs@`。
+
 ## [0.0.43] — 2026-06-02
 
 ### 新增

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.43"
+version     = "0.0.44"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.43";
+inline constexpr std::string_view MCPP_VERSION = "0.0.44";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;

--- a/tests/e2e/42_custom_local_index.sh
+++ b/tests/e2e/42_custom_local_index.sh
@@ -10,6 +10,7 @@ TMP=$(mktemp -d)
 trap "rm -rf $TMP" EXIT
 
 export MCPP_HOME="$TMP/mcpp-home"
+"$MCPP" self config --mirror "${MCPP_E2E_TOOLCHAIN_MIRROR:-GLOBAL}" >/dev/null
 
 # ── 1. Create a fake local index directory ──────────────────────────────
 INDEX_DIR="$TMP/my-local-index"

--- a/tests/e2e/43_indices_lockfile.sh
+++ b/tests/e2e/43_indices_lockfile.sh
@@ -9,6 +9,7 @@ TMP=$(mktemp -d)
 trap "rm -rf $TMP" EXIT
 
 export MCPP_HOME="$TMP/mcpp-home"
+"$MCPP" self config --mirror "${MCPP_E2E_TOOLCHAIN_MIRROR:-GLOBAL}" >/dev/null
 
 # ── 1. Create a fake local index directory ──────────────────────────────
 INDEX_DIR="$TMP/my-local-index"

--- a/tests/e2e/44_indices_e2e_integration.sh
+++ b/tests/e2e/44_indices_e2e_integration.sh
@@ -12,6 +12,7 @@ trap "rm -rf $TMP" EXIT
 
 export MCPP_HOME="$TMP/mcpp-home"
 export MCPP_NO_AUTO_INSTALL=1
+"$MCPP" self config --mirror "${MCPP_E2E_TOOLCHAIN_MIRROR:-GLOBAL}" >/dev/null
 
 # ── 1. Local path index with real xpkg.lua ────────────────────────────
 INDEX_DIR="$TMP/my-local-index"


### PR DESCRIPTION
## Summary
- Bump mcpp package version and BMI fingerprint version to 0.0.44.
- Add changelog entry for the git branch dependency cache/lock fix merged after 0.0.43.

## Test Plan
- git diff --check
- mcpp clean && mcpp build && mcpp test, bootstrapped with released mcpp 0.0.43
- MCPP=<rebuilt mcpp> bash tests/e2e/24_git_dependency.sh
- <rebuilt mcpp> --version reports mcpp 0.0.44
