### PR TITLE
feat(0.0.50): macOS min-version support — static LLVM libc++, lld link, explicit deployment target

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -326,8 +326,13 @@ jobs:
           MCPP=$(cd "$(dirname "$MCPP")" && pwd)/$(basename "$MCPP")
           "$MCPP" self config --mirror GLOBAL
           "$MCPP" test || {
-            echo "=== TEMP forensics: retry verbose (remove before merge) ==="
-            "$MCPP" test -v 2>&1 | grep -B3 -A12 -iE "error|undefined|ld64" | head -120
+            echo "=== TEMP forensics: retry verbose unfiltered (remove before merge) ==="
+            vm_stat | head -5
+            "$MCPP" test -v > /tmp/mtv.log 2>&1
+            echo "--- verbose tail ---"
+            tail -200 /tmp/mtv.log
+            echo "--- ninja FAILED lines ---"
+            grep -B2 -A20 "FAILED" /tmp/mtv.log | head -80
             exit 1
           }
 

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -325,7 +325,11 @@ jobs:
           MCPP=$(find target -path "*/bin/mcpp" | head -1)
           MCPP=$(cd "$(dirname "$MCPP")" && pwd)/$(basename "$MCPP")
           "$MCPP" self config --mirror GLOBAL
-          "$MCPP" test
+          "$MCPP" test || {
+            echo "=== TEMP forensics: retry verbose (remove before merge) ==="
+            "$MCPP" test -v 2>&1 | grep -B3 -A12 -iE "error|undefined|ld64" | head -120
+            exit 1
+          }
 
       - name: "TEMP forensics: static libc++ exit-abort matrix (remove before merge)"
         if: always()

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -325,39 +325,7 @@ jobs:
           MCPP=$(find target -path "*/bin/mcpp" | head -1)
           MCPP=$(cd "$(dirname "$MCPP")" && pwd)/$(basename "$MCPP")
           "$MCPP" self config --mirror GLOBAL
-          "$MCPP" test || {
-            echo "=== TEMP forensics: manual ninja rerun (remove before merge) ==="
-            for N in $(find target -name build.ninja); do
-              D=$(dirname "$N")
-              echo "--- dir: $D ---"
-              NINJA=$(find "$HOME/.mcpp/registry/data/xpkgs/xim-x-ninja" -name ninja -type f | head -1)
-              "$NINJA" -C "$D" -v 2>&1 | tail -40
-              echo "--- ninja exit: $? ---"
-            done
-            exit 1
-          }
-
-      - name: "TEMP forensics: static libc++ exit-abort matrix (remove before merge)"
-        if: always()
-        run: |
-          set +e
-          LLVM="$LLVM_ROOT"
-          SDK=$(xcrun --show-sdk-path)
-          cat > /tmp/probe.cpp <<'PEOF'
-          #include <iostream>
-          int main() { std::cout << "hi" << std::endl; return 0; }
-          PEOF
-          run_mode() {
-            echo "=== mode: $1 ==="
-            shift
-            "$LLVM/bin/clang++" --no-default-config -std=c++17 -nostdinc++               -isystem "$LLVM/include/c++/v1" --sysroot="$SDK"               -mmacosx-version-min=14.0 -fuse-ld=lld /tmp/probe.cpp -o /tmp/probe "$@" 2>&1 | head -40
-            otool -L /tmp/probe | grep -E "libc|probe" | head -4
-            /tmp/probe
-            echo "exit=$?"
-          }
-          run_mode dylib    -stdlib=libc++
-          run_mode direct   -nostdlib++ "$LLVM/lib/libc++.a" "$LLVM/lib/libc++abi.a"
-          exit 0
+          "$MCPP" test
 
       - name: E2E suite
         # See ci-linux.yml — fail-fast on hung tests instead of burning the

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -326,13 +326,14 @@ jobs:
           MCPP=$(cd "$(dirname "$MCPP")" && pwd)/$(basename "$MCPP")
           "$MCPP" self config --mirror GLOBAL
           "$MCPP" test || {
-            echo "=== TEMP forensics: retry verbose unfiltered (remove before merge) ==="
-            vm_stat | head -5
-            "$MCPP" test -v > /tmp/mtv.log 2>&1
-            echo "--- verbose tail ---"
-            tail -200 /tmp/mtv.log
-            echo "--- ninja FAILED lines ---"
-            grep -B2 -A20 "FAILED" /tmp/mtv.log | head -80
+            echo "=== TEMP forensics: manual ninja rerun (remove before merge) ==="
+            for N in $(find target -name build.ninja); do
+              D=$(dirname "$N")
+              echo "--- dir: $D ---"
+              NINJA=$(find "$HOME/.mcpp/registry/data/xpkgs/xim-x-ninja" -name ninja -type f | head -1)
+              "$NINJA" -C "$D" -v 2>&1 | tail -40
+              echo "--- ninja exit: $? ---"
+            done
             exit 1
           }
 

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -340,14 +340,13 @@ jobs:
           run_mode() {
             echo "=== mode: $1 ==="
             shift
-            "$LLVM/bin/clang++" --no-default-config -std=c++17 -nostdinc++               -isystem "$LLVM/include/c++/v1" --sysroot="$SDK"               -mmacosx-version-min=11.0 -fuse-ld=lld /tmp/probe.cpp -o /tmp/probe "$@" 2>&1 | head -5
+            "$LLVM/bin/clang++" --no-default-config -std=c++17 -nostdinc++               -isystem "$LLVM/include/c++/v1" --sysroot="$SDK"               -mmacosx-version-min=14.0 -fuse-ld=lld /tmp/probe.cpp -o /tmp/probe "$@" 2>&1 | head -40
             otool -L /tmp/probe | grep -E "libc|probe" | head -4
             /tmp/probe
             echo "exit=$?"
           }
           run_mode dylib    -stdlib=libc++
           run_mode direct   -nostdlib++ "$LLVM/lib/libc++.a" "$LLVM/lib/libc++abi.a"
-          run_mode hidden   -nostdlib++ -L"$LLVM/lib" -Wl,-hidden-lc++ -Wl,-hidden-lc++abi
           exit 0
 
       - name: E2E suite

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -327,6 +327,29 @@ jobs:
           "$MCPP" self config --mirror GLOBAL
           "$MCPP" test
 
+      - name: "TEMP forensics: static libc++ exit-abort matrix (remove before merge)"
+        if: always()
+        run: |
+          set +e
+          LLVM="$LLVM_ROOT"
+          SDK=$(xcrun --show-sdk-path)
+          cat > /tmp/probe.cpp <<'PEOF'
+          #include <iostream>
+          int main() { std::cout << "hi" << std::endl; return 0; }
+          PEOF
+          run_mode() {
+            echo "=== mode: $1 ==="
+            shift
+            "$LLVM/bin/clang++" --no-default-config -std=c++17 -nostdinc++               -isystem "$LLVM/include/c++/v1" --sysroot="$SDK"               -mmacosx-version-min=11.0 -fuse-ld=lld /tmp/probe.cpp -o /tmp/probe "$@" 2>&1 | head -5
+            otool -L /tmp/probe | grep -E "libc|probe" | head -4
+            /tmp/probe
+            echo "exit=$?"
+          }
+          run_mode dylib    -stdlib=libc++
+          run_mode direct   -nostdlib++ "$LLVM/lib/libc++.a" "$LLVM/lib/libc++abi.a"
+          run_mode hidden   -nostdlib++ -L"$LLVM/lib" -Wl,-hidden-lc++ -Wl,-hidden-lc++abi
+          exit 0
+
       - name: E2E suite
         # See ci-linux.yml — fail-fast on hung tests instead of burning the
         # whole job budget. Per-test 600s timeout lives in run_all.sh.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,16 +317,48 @@ jobs:
           echo "XLINGS_BIN=$HOME/.xlings/subos/default/bin/xlings" >> "$GITHUB_ENV"
 
       - name: Build mcpp from source (self-host)
+        env:
+          # macOS min-version support: target the first arm64 macOS so the
+          # release runs on 11.0+ instead of only the runner's OS (15).
+          # Requires static LLVM libc++ (injected below) — the system
+          # libc++ on older macOS lacks LLVM-20-era C++23 symbols
+          # (std::print's __is_posix_terminal etc.; verified on macos-14
+          # CI). See xlings .agents/docs/2026-06-05-macos-min-version-support.md.
+          MACOSX_DEPLOYMENT_TARGET: '11.0'
         run: |
           export PATH="$HOME/.xlings/subos/default/bin:$PATH"
           export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
+
+          # Warm the toolchain so the llvm payload exists, then inject the
+          # static libc++ archives via [build] ldflags. The bootstrap mcpp
+          # predates the flags.cppm staticStdlib/clang implementation
+          # shipped in this very release — from the next release on, the
+          # injection is redundant (but harmless).
           "$MCPP" build
+          LLVM_ROOT=$(find "$HOME/.mcpp/registry/data/xpkgs/xim-x-llvm" -maxdepth 1 -mindepth 1 -type d | head -1)
+          test -f "$LLVM_ROOT/lib/libc++.a"
+          test -f "$LLVM_ROOT/lib/libc++abi.a"
+          if ! grep -q '^ldflags' mcpp.toml; then
+            sed -i '' "s|^\[build\]|[build]\nldflags = [\"-nostdlib++\", \"$LLVM_ROOT/lib/libc++.a\", \"$LLVM_ROOT/lib/libc++abi.a\"]|" mcpp.toml
+          fi
+          grep -n 'ldflags' mcpp.toml
+
+          "$MCPP" build --no-cache
           MCPP_BIN=$(find target -path "*/bin/mcpp" | head -1)
           MCPP_BIN=$(cd "$(dirname "$MCPP_BIN")" && pwd)/$(basename "$MCPP_BIN")
           test -x "$MCPP_BIN"
           file "$MCPP_BIN"
           otool -L "$MCPP_BIN"
+          echo "=== LC_BUILD_VERSION (must be minos 11.0) ==="
+          otool -l "$MCPP_BIN" | grep -A4 LC_BUILD_VERSION | head -6
+          otool -l "$MCPP_BIN" | grep -A4 LC_BUILD_VERSION | grep -q "minos 11.0" \
+            || { echo "FAIL: expected minos 11.0"; exit 1; }
+          if otool -L "$MCPP_BIN" | grep -q "libc++"; then
+            echo "FAIL: still linked against system libc++"; exit 1
+          fi
           "$MCPP_BIN" --version
+          # Restore the manifest so packaging sees a clean tree.
+          git checkout -- mcpp.toml
           echo "MCPP_BIN=$MCPP_BIN" >> "$GITHUB_ENV"
 
       - name: Package macOS release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,13 +318,15 @@ jobs:
 
       - name: Build mcpp from source (two-stage self-host)
         env:
-          # macOS min-version support: target the first arm64 macOS so the
-          # release runs on 11.0+ instead of only the runner's OS. Needs
+          # macOS min-version support: target macOS 14 so the release runs
+          # on 14.0+ instead of only the runner's OS (the official LLVM
+          # static libc++ archives are built for macOS 14 — going lower
+          # needs a custom libc++ build, tracked as follow-up). Needs
           # static LLVM libc++ — the system libc++ on older macOS lacks
           # LLVM-20-era C++23 symbols (std::print's __is_posix_terminal
           # etc.; minos-14 + dynamic libc++ dies at launch on macos-14 CI).
           # See xlings .agents/docs/2026-06-05-macos-min-version-support.md.
-          MACOSX_DEPLOYMENT_TARGET: '11.0'
+          MACOSX_DEPLOYMENT_TARGET: '14.0'
         run: |
           export PATH="$HOME/.xlings/subos/default/bin:$PATH"
           export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
@@ -346,10 +348,10 @@ jobs:
           test -x "$MCPP_BIN"
           file "$MCPP_BIN"
           otool -L "$MCPP_BIN"
-          echo "=== LC_BUILD_VERSION (must be minos 11.0) ==="
+          echo "=== LC_BUILD_VERSION (must be minos 14.0) ==="
           otool -l "$MCPP_BIN" | grep -A4 LC_BUILD_VERSION | head -6
-          otool -l "$MCPP_BIN" | grep -A4 LC_BUILD_VERSION | grep -q "minos 11.0" \
-            || { echo "FAIL: expected minos 11.0"; exit 1; }
+          otool -l "$MCPP_BIN" | grep -A4 LC_BUILD_VERSION | grep -q "minos 14.0" \
+            || { echo "FAIL: expected minos 14.0"; exit 1; }
           if otool -L "$MCPP_BIN" | grep -q "libc++"; then
             echo "FAIL: still linked against system libc++"; exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,40 +316,31 @@ jobs:
           echo "MCPP=$MCPP" >> "$GITHUB_ENV"
           echo "XLINGS_BIN=$HOME/.xlings/subos/default/bin/xlings" >> "$GITHUB_ENV"
 
-      - name: Build mcpp from source (self-host)
+      - name: Build mcpp from source (two-stage self-host)
         env:
           # macOS min-version support: target the first arm64 macOS so the
-          # release runs on 11.0+ instead of only the runner's OS (15).
-          # Requires static LLVM libc++ (injected below) — the system
-          # libc++ on older macOS lacks LLVM-20-era C++23 symbols
-          # (std::print's __is_posix_terminal etc.; verified on macos-14
-          # CI). See xlings .agents/docs/2026-06-05-macos-min-version-support.md.
+          # release runs on 11.0+ instead of only the runner's OS. Needs
+          # static LLVM libc++ — the system libc++ on older macOS lacks
+          # LLVM-20-era C++23 symbols (std::print's __is_posix_terminal
+          # etc.; minos-14 + dynamic libc++ dies at launch on macos-14 CI).
+          # See xlings .agents/docs/2026-06-05-macos-min-version-support.md.
           MACOSX_DEPLOYMENT_TARGET: '11.0'
         run: |
           export PATH="$HOME/.xlings/subos/default/bin:$PATH"
           export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
 
-          # Warm the toolchain so the llvm payload exists, then stage the
-          # static libc++ archives in a dylib-free directory and inject
-          # `-L<staged> -lc++abi` via [build] ldflags: the bootstrap
-          # mcpp's macOS link line hardcodes ` -lc++` BEFORE user ldflags,
-          # and the staged -L path makes it resolve to libc++.a (no dylib
-          # competes there). The bootstrap predates the flags.cppm
-          # staticStdlib implementation shipped in this very release —
-          # from the next release on, the injection is redundant.
+          # Stage 1: the bootstrap mcpp builds this release's source. The
+          # bootstrap's macOS link path predates the staticStdlib
+          # implementation (hardcoded -lc++), so stage 1 links the system
+          # libc++ — fine, it only needs to RUN on this runner.
           "$MCPP" build
-          LLVM_ROOT=$(find "$HOME/.mcpp/registry/data/xpkgs/xim-x-llvm" -maxdepth 1 -mindepth 1 -type d | head -1)
-          test -f "$LLVM_ROOT/lib/libc++.a"
-          test -f "$LLVM_ROOT/lib/libc++abi.a"
-          STATICDIR="$RUNNER_TEMP/static-libcxx"
-          mkdir -p "$STATICDIR"
-          cp "$LLVM_ROOT/lib/libc++.a" "$LLVM_ROOT/lib/libc++abi.a" "$STATICDIR/"
-          if ! grep -q '^ldflags' mcpp.toml; then
-            sed -i '' "s|^\[build\]|[build]\nldflags = [\"-L$STATICDIR\", \"-lc++abi\"]|" mcpp.toml
-          fi
-          grep -n 'ldflags' mcpp.toml
+          STAGE1=$(find target -path "*/bin/mcpp" | head -1)
+          STAGE1=$(cd "$(dirname "$STAGE1")" && pwd)/$(basename "$STAGE1")
+          "$STAGE1" --version
 
-          "$MCPP" build --no-cache
+          # Stage 2: this release's mcpp rebuilds itself — flags.cppm's
+          # native staticStdlib link produces the static minos-11 binary.
+          "$STAGE1" build --no-cache
           MCPP_BIN=$(find target -path "*/bin/mcpp" | head -1)
           MCPP_BIN=$(cd "$(dirname "$MCPP_BIN")" && pwd)/$(basename "$MCPP_BIN")
           test -x "$MCPP_BIN"
@@ -363,8 +354,6 @@ jobs:
             echo "FAIL: still linked against system libc++"; exit 1
           fi
           "$MCPP_BIN" --version
-          # Restore the manifest so packaging sees a clean tree.
-          git checkout -- mcpp.toml
           echo "MCPP_BIN=$MCPP_BIN" >> "$GITHUB_ENV"
 
       - name: Package macOS release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,17 +329,23 @@ jobs:
           export PATH="$HOME/.xlings/subos/default/bin:$PATH"
           export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
 
-          # Warm the toolchain so the llvm payload exists, then inject the
-          # static libc++ archives via [build] ldflags. The bootstrap mcpp
-          # predates the flags.cppm staticStdlib/clang implementation
-          # shipped in this very release — from the next release on, the
-          # injection is redundant (but harmless).
+          # Warm the toolchain so the llvm payload exists, then stage the
+          # static libc++ archives in a dylib-free directory and inject
+          # `-L<staged> -lc++abi` via [build] ldflags: the bootstrap
+          # mcpp's macOS link line hardcodes ` -lc++` BEFORE user ldflags,
+          # and the staged -L path makes it resolve to libc++.a (no dylib
+          # competes there). The bootstrap predates the flags.cppm
+          # staticStdlib implementation shipped in this very release —
+          # from the next release on, the injection is redundant.
           "$MCPP" build
           LLVM_ROOT=$(find "$HOME/.mcpp/registry/data/xpkgs/xim-x-llvm" -maxdepth 1 -mindepth 1 -type d | head -1)
           test -f "$LLVM_ROOT/lib/libc++.a"
           test -f "$LLVM_ROOT/lib/libc++abi.a"
+          STATICDIR="$RUNNER_TEMP/static-libcxx"
+          mkdir -p "$STATICDIR"
+          cp "$LLVM_ROOT/lib/libc++.a" "$LLVM_ROOT/lib/libc++abi.a" "$STATICDIR/"
           if ! grep -q '^ldflags' mcpp.toml; then
-            sed -i '' "s|^\[build\]|[build]\nldflags = [\"-nostdlib++\", \"$LLVM_ROOT/lib/libc++.a\", \"$LLVM_ROOT/lib/libc++abi.a\"]|" mcpp.toml
+            sed -i '' "s|^\[build\]|[build]\nldflags = [\"-L$STATICDIR\", \"-lc++abi\"]|" mcpp.toml
           fi
           grep -n 'ldflags' mcpp.toml
 

--- a/docs/05-mcpp-toml.md
+++ b/docs/05-mcpp-toml.md
@@ -91,7 +91,7 @@ cflags       = ["-DFOO=1"]        # 额外 C 编译参数
 cxxflags     = ["-DBAR=2"]        # 额外 C++ 编译参数(不要放 -std=...)
 ldflags      = ["-lfoo"]          # 额外链接参数
 static_stdlib = true               # 静态链接 libstdc++(默认 true)
-macos_deployment_target = "11.0"   # macOS 产物的最低支持系统版本(仅 macOS 生效)
+macos_deployment_target = "14.0"   # macOS 产物的最低支持系统版本(仅 macOS 生效)
 ```
 
 `macos_deployment_target` 设定产物 Mach-O 头里的最低系统版本

--- a/docs/05-mcpp-toml.md
+++ b/docs/05-mcpp-toml.md
@@ -101,6 +101,13 @@ cargo/rustc、cc 等同样尊重该变量)> 本字段(项目默认,类似 SwiftP
 `platforms:`)> 工具链/SDK 默认。该值会进入 BMI 指纹——切换 target 会
 自动重建模块缓存。
 
+**声明 floor 即静态运行时**:显式设置了 deployment target(env 或本
+字段)且 `static_stdlib = true`(默认)时,macOS 链接会静态链入 LLVM
+自带的 libc++/libc++abi —— 系统 libc++ 会把实际可运行版本钉死在构建机
+的 OS(老系统缺新符号,如 `std::print` 的支撑符号),静态化才能真正
+兑现声明的 floor。注意 LLVM 官方静态库自身的下限是 **14.0**。未声明
+floor 时保持动态系统 libc++(产物只保证在构建机同版本及以上运行)。
+
 C++ 标准不要通过 `build.cxxflags = ["-std=..."]` 配置。请使用:
 
 ```toml

--- a/docs/05-mcpp-toml.md
+++ b/docs/05-mcpp-toml.md
@@ -91,7 +91,15 @@ cflags       = ["-DFOO=1"]        # 额外 C 编译参数
 cxxflags     = ["-DBAR=2"]        # 额外 C++ 编译参数(不要放 -std=...)
 ldflags      = ["-lfoo"]          # 额外链接参数
 static_stdlib = true               # 静态链接 libstdc++(默认 true)
+macos_deployment_target = "11.0"   # macOS 产物的最低支持系统版本(仅 macOS 生效)
 ```
+
+`macos_deployment_target` 设定产物 Mach-O 头里的最低系统版本
+(`LC_BUILD_VERSION minos`),即二进制能运行的最老 macOS。优先级与各生态
+惯例一致:环境变量 `MACOSX_DEPLOYMENT_TARGET`(单次调用的显式覆盖,
+cargo/rustc、cc 等同样尊重该变量)> 本字段(项目默认,类似 SwiftPM 的
+`platforms:`)> 工具链/SDK 默认。该值会进入 BMI 指纹——切换 target 会
+自动重建模块缓存。
 
 C++ 标准不要通过 `build.cxxflags = ["-std=..."]` 配置。请使用:
 

--- a/docs/05-mcpp-toml.md
+++ b/docs/05-mcpp-toml.md
@@ -98,8 +98,10 @@ macos_deployment_target = "14.0"   # macOS 产物的最低支持系统版本(仅
 (`LC_BUILD_VERSION minos`),即二进制能运行的最老 macOS。优先级与各生态
 惯例一致:环境变量 `MACOSX_DEPLOYMENT_TARGET`(单次调用的显式覆盖,
 cargo/rustc、cc 等同样尊重该变量)> 本字段(项目默认,类似 SwiftPM 的
-`platforms:`)> 工具链/SDK 默认。该值会进入 BMI 指纹——切换 target 会
-自动重建模块缓存。
+`platforms:`)> **内建默认 14.0**(rustc 式:target 自带默认 floor 而非
+跟随构建机 SDK;14.0 是工具链静态 libc++ 的下限,`static_stdlib = false`
+时回退工具链/SDK 默认)。该值会进入 BMI 指纹——切换 target 会自动重建
+模块缓存。
 
 C++ 标准不要通过 `build.cxxflags = ["-std=..."]` 配置。请使用:
 

--- a/docs/05-mcpp-toml.md
+++ b/docs/05-mcpp-toml.md
@@ -98,10 +98,8 @@ macos_deployment_target = "14.0"   # macOS 产物的最低支持系统版本(仅
 (`LC_BUILD_VERSION minos`),即二进制能运行的最老 macOS。优先级与各生态
 惯例一致:环境变量 `MACOSX_DEPLOYMENT_TARGET`(单次调用的显式覆盖,
 cargo/rustc、cc 等同样尊重该变量)> 本字段(项目默认,类似 SwiftPM 的
-`platforms:`)> **内建默认 14.0**(rustc 式:target 自带默认 floor 而非
-跟随构建机 SDK;14.0 是工具链静态 libc++ 的下限,`static_stdlib = false`
-时回退工具链/SDK 默认)。该值会进入 BMI 指纹——切换 target 会自动重建
-模块缓存。
+`platforms:`)> 工具链/SDK 默认。该值会进入 BMI 指纹——切换 target 会
+自动重建模块缓存。
 
 C++ 标准不要通过 `build.cxxflags = ["-std=..."]` 配置。请使用:
 

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.49"
+version     = "0.0.50"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -378,9 +378,19 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         // env var or [build] macos_deployment_target, the static LLVM
         // libc++ is what makes that floor real (the system libc++ caps it
         // at the build host's OS). With no declared floor, keep the
-        // 0.0.49 behavior — dynamic system libc++, host-coupled — which
-        // also sidesteps a still-open SIGSEGV in mixed C/C++ static
-        // binaries (e2e 36; tracked in the design doc).
+        // 0.0.49 behavior — dynamic system libc++, host-coupled.
+        //
+        // TODO(macos-static-default): flip static to the unconditional
+        // default (rust-style "portable by default") once two tracked
+        // issues are fixed — (1) mixed C/C++ static binaries SIGSEGV at
+        // runtime (e2e 36_llvm_toolchain: answer.c + std::cout main.cpp,
+        // exit 139; root cause not yet isolated), (2) the std-module
+        // staging/fingerprint boundary (see canonical_compile_flags).
+        // TODO(macos-floor-11): the official LLVM archives are built for
+        // macOS 14; supporting 11-13 needs a custom libc++ build shipped
+        // via xlings-res (data-only change — swap the archive source).
+        // Both tracked in xlings
+        // .agents/docs/2026-06-05-macos-min-version-support.md §5.
         if (f.staticStdlib && !macosDeploymentTarget.empty()
             && !llvmRootForStdlib.empty()) {
             auto libDir     = llvmRootForStdlib / "lib";

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -378,13 +378,14 @@ CompileFlags compute_flags(const BuildPlan& plan) {
             auto libcxxAbiA = libDir / "libc++abi.a";
             if (std::filesystem::exists(libcxxA)
                 && std::filesystem::exists(libcxxAbiA)) {
-                // -hidden-l links the ARCHIVE (never the sibling dylib)
-                // and gives its symbols hidden visibility so the static
-                // copy can coexist with the system libc++ that libSystem
-                // pulls in indirectly. Distributable targets only — see
-                // the field comments in CompileFlags.
-                f.ldStdlibDefault = " -nostdlib++ -L" + escape_path(libDir)
-                                  + " -Wl,-hidden-lc++ -Wl,-hidden-lc++abi";
+                // Link the archives BY PATH. (-Wl,-hidden-l looked like
+                // the canonical choice, but lld resolves it like a plain
+                // -l and picks the sibling dylib in the same directory —
+                // the binary then carries @rpath/libc++.1.dylib with no
+                // rpath and dies at load. Observed on macos CI; path
+                // form verified end-to-end incl. macos-14.)
+                f.ldStdlibDefault = " -nostdlib++ " + escape_path(libcxxA)
+                                  + " " + escape_path(libcxxAbiA);
             }
         }
         std::string version_min;

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -109,18 +109,6 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     } else {
         macosDeploymentTarget = plan.manifest.buildConfig.macosDeploymentTarget;
     }
-    // Built-in default floor (rustc-style: every Apple target carries a
-    // default deployment target instead of floating with the host SDK).
-    // When neither the env var nor the manifest pins one, default to the
-    // floor of the toolchain's static libc++ archives (the official LLVM
-    // darwin archives are built for macOS 14) — artifacts are portable by
-    // default and don't silently change floor when the build host's SDK
-    // moves. Resolved here so the value also reaches the fingerprint via
-    // the same canonical-flags rule (see cli.cppm).
-    if (macosDeploymentTarget.empty() && mcpp::platform::is_macos
-        && plan.manifest.buildConfig.staticStdlib) {
-        macosDeploymentTarget = "14.0";
-    }
 
     f.cxxBinary = plan.toolchain.binaryPath;
     f.ccBinary = mcpp::toolchain::derive_c_compiler(plan.toolchain);

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -361,7 +361,8 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         //    manifest default — previously silently ignored on the clang
         //    route), link LLVM's own libc++.a/libc++abi.a instead:
         //    runtime deps shrink to libSystem and the floor drops to
-        //    11.0 (first arm64 macOS). Falls back to -lc++ when the
+        //    14.0 — the floor of the official LLVM static archives;
+        //    lower needs a custom libc++ build. Falls back to -lc++ when the
         //    archives are absent.
         // 2. deployment target — mirror MACOSX_DEPLOYMENT_TARGET onto the
         //    link command line so it doesn't depend on env propagation.

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -347,6 +347,11 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         //    archives are absent.
         // 2. deployment target — mirror MACOSX_DEPLOYMENT_TARGET onto the
         //    link command line so it doesn't depend on env propagation.
+        // 3. linker — use LLVM's own lld (same as the Linux clang path)
+        //    instead of Xcode's ld: the system ld's version floats with
+        //    the host Xcode (observed: Xcode 15.4's ld aborting at launch
+        //    on macos-14 CI when its libc++ resolution was diverted), and
+        //    lld ships with the exact toolchain doing the compile.
         std::string stdlib_link = " -lc++";
         if (f.staticStdlib && !llvmRootForStdlib.empty()) {
             auto libcxxA    = llvmRootForStdlib / "lib" / "libc++.a";
@@ -361,8 +366,8 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         if (const char* dt = std::getenv("MACOSX_DEPLOYMENT_TARGET"); dt && *dt) {
             version_min = std::string(" -mmacosx-version-min=") + dt;
         }
-        f.ld = std::format("{}{}{}{}{}{}{}", full_static, static_stdlib, b_flag,
-                           version_min, stdlib_link, user_ldflags, link_extra);
+        f.ld = std::format("{}{}{} -fuse-ld=lld{}{}{}{}", full_static, static_stdlib,
+                           b_flag, version_min, stdlib_link, user_ldflags, link_extra);
     } else {
         f.ld = std::format("{}{}{}{}{}{}{}{}", full_static, static_stdlib, link_toolchain_flags, b_flag,
                            runtime_dirs, payload_ld, user_ldflags, link_extra);

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -109,6 +109,18 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     } else {
         macosDeploymentTarget = plan.manifest.buildConfig.macosDeploymentTarget;
     }
+    // Built-in default floor (rustc-style: every Apple target carries a
+    // default deployment target instead of floating with the host SDK).
+    // When neither the env var nor the manifest pins one, default to the
+    // floor of the toolchain's static libc++ archives (the official LLVM
+    // darwin archives are built for macOS 14) — artifacts are portable by
+    // default and don't silently change floor when the build host's SDK
+    // moves. Resolved here so the value also reaches the fingerprint via
+    // the same canonical-flags rule (see cli.cppm).
+    if (macosDeploymentTarget.empty() && mcpp::platform::is_macos
+        && plan.manifest.buildConfig.staticStdlib) {
+        macosDeploymentTarget = "14.0";
+    }
 
     f.cxxBinary = plan.toolchain.binaryPath;
     f.ccBinary = mcpp::toolchain::derive_c_compiler(plan.toolchain);

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -373,7 +373,16 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         //    lld ships with the exact toolchain doing the compile.
         f.ldStdlibDefault = " -lc++";
         f.ldStdlibTest    = " -lc++";
-        if (f.staticStdlib && !llvmRootForStdlib.empty()) {
+        // Static libc++ is tied to an EXPLICIT deployment floor: when the
+        // user (or the release pipeline) declares a minimum macOS via the
+        // env var or [build] macos_deployment_target, the static LLVM
+        // libc++ is what makes that floor real (the system libc++ caps it
+        // at the build host's OS). With no declared floor, keep the
+        // 0.0.49 behavior — dynamic system libc++, host-coupled — which
+        // also sidesteps a still-open SIGSEGV in mixed C/C++ static
+        // binaries (e2e 36; tracked in the design doc).
+        if (f.staticStdlib && !macosDeploymentTarget.empty()
+            && !llvmRootForStdlib.empty()) {
             auto libDir     = llvmRootForStdlib / "lib";
             auto libcxxA    = libDir / "libc++.a";
             auto libcxxAbiA = libDir / "libc++abi.a";

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -32,6 +32,15 @@ struct CompileFlags {
     std::string bFlag;                // -B<binutils> (for ninja ldflags)
     bool staticStdlib = true;
     std::string linkage;  // "static" or ""
+    // macOS per-unit C++ stdlib link (appended via unit_ldflags):
+    // distributable targets get the static LLVM libc++ (portable across
+    // macOS versions), TestBinary targets get the system -lc++ — they
+    // only ever run on the build host, and statically linked libc++
+    // SIGABRTs during static destruction unless the entry point guards
+    // with _Exit (mcpp/xlings do; gtest main does not). Empty on other
+    // platforms (stdlib handled by their existing paths).
+    std::string ldStdlibDefault;
+    std::string ldStdlibTest;
 };
 
 CompileFlags compute_flags(const BuildPlan& plan);
@@ -361,30 +370,29 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         //    the host Xcode (observed: Xcode 15.4's ld aborting at launch
         //    on macos-14 CI when its libc++ resolution was diverted), and
         //    lld ships with the exact toolchain doing the compile.
-        std::string stdlib_link = " -lc++";
+        f.ldStdlibDefault = " -lc++";
+        f.ldStdlibTest    = " -lc++";
         if (f.staticStdlib && !llvmRootForStdlib.empty()) {
             auto libDir     = llvmRootForStdlib / "lib";
             auto libcxxA    = libDir / "libc++.a";
             auto libcxxAbiA = libDir / "libc++abi.a";
             if (std::filesystem::exists(libcxxA)
                 && std::filesystem::exists(libcxxAbiA)) {
-                // -hidden-l: ld64/lld feature made for exactly this —
-                // links the ARCHIVE (never the sibling dylib) and gives
-                // its symbols hidden visibility. Without it the static
-                // libc++/libc++abi symbols clash with the system copies
-                // that libSystem pulls in indirectly, and processes
-                // SIGABRT during static destruction (observed: every
-                // gtest binary exiting 6 on macos CI).
-                stdlib_link = " -nostdlib++ -L" + escape_path(libDir)
-                            + " -Wl,-hidden-lc++ -Wl,-hidden-lc++abi";
+                // -hidden-l links the ARCHIVE (never the sibling dylib)
+                // and gives its symbols hidden visibility so the static
+                // copy can coexist with the system libc++ that libSystem
+                // pulls in indirectly. Distributable targets only — see
+                // the field comments in CompileFlags.
+                f.ldStdlibDefault = " -nostdlib++ -L" + escape_path(libDir)
+                                  + " -Wl,-hidden-lc++ -Wl,-hidden-lc++abi";
             }
         }
         std::string version_min;
         if (!macosDeploymentTarget.empty()) {
             version_min = " -mmacosx-version-min=" + macosDeploymentTarget;
         }
-        f.ld = std::format("{}{}{} -fuse-ld=lld{}{}{}{}", full_static, static_stdlib,
-                           b_flag, version_min, stdlib_link, user_ldflags, link_extra);
+        f.ld = std::format("{}{}{} -fuse-ld=lld{}{}{}", full_static, static_stdlib,
+                           b_flag, version_min, user_ldflags, link_extra);
     } else {
         f.ld = std::format("{}{}{}{}{}{}{}{}", full_static, static_stdlib, link_toolchain_flags, b_flag,
                            runtime_dirs, payload_ld, user_ldflags, link_extra);

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -6,6 +6,9 @@
 //
 // See .agents/docs/2026-05-12-compile-commands-design.md.
 
+module;
+#include <cstdlib>
+
 export module mcpp.build.flags;
 
 import std;
@@ -120,6 +123,9 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     std::string link_toolchain_flags;
     bool isClangWithCfg = false;
     std::filesystem::path cfgPath;
+    // LLVM root of a clang-with-cfg toolchain — used by the macOS link
+    // path below to locate libc++.a/libc++abi.a for staticStdlib.
+    std::filesystem::path llvmRootForStdlib;
     if (mcpp::toolchain::is_clang(plan.toolchain)) {
         cfgPath = plan.toolchain.binaryPath.parent_path()
                   / (plan.toolchain.binaryPath.stem().string() + ".cfg");
@@ -131,6 +137,22 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         auto llvmRoot = plan.toolchain.binaryPath.parent_path().parent_path();
         auto libcxxInclude = llvmRoot / "include" / "c++" / "v1";
         compile_toolchain_flags = " --no-default-config -nostdinc++";
+        // macOS deployment target: make MACOSX_DEPLOYMENT_TARGET explicit
+        // on the command line so (a) the ninja commands don't depend on
+        // env propagation and (b) the value participates in the BMI
+        // fingerprint via canonical flags — mixing targets in one sandbox
+        // otherwise reuses a std.pcm built for a different
+        // arm64-apple-macosxNN triple and dies with a config mismatch
+        // (observed on macos CI). The link side is added to f.ld below
+        // (the macOS link path doesn't consume link_toolchain_flags).
+        if (mcpp::platform::is_macos) {
+            if (const char* dt = std::getenv("MACOSX_DEPLOYMENT_TARGET");
+                dt && *dt) {
+                compile_toolchain_flags +=
+                    std::string(" -mmacosx-version-min=") + dt;
+            }
+        }
+        llvmRootForStdlib = llvmRoot;
         // libc++ headers
         compile_toolchain_flags += " -isystem" + escape_path(libcxxInclude);
         if (!plan.toolchain.targetTriple.empty()) {
@@ -309,7 +331,38 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     if constexpr (mcpp::platform::is_windows) {
         f.ld = user_ldflags + link_extra;
     } else if constexpr (mcpp::platform::needs_explicit_libcxx) {
-        f.ld = std::format("{}{}{} -lc++{}{}", full_static, static_stdlib, b_flag, user_ldflags, link_extra);
+        // macOS. Two min-version concerns (see xlings
+        // .agents/docs/2026-06-05-macos-min-version-support.md):
+        //
+        // 1. stdlib linkage — `-lc++` resolves to the SYSTEM
+        //    /usr/lib/libc++.1.dylib, which caps the deployment floor at
+        //    the build host's OS: e.g. std::print's __is_posix_terminal
+        //    support symbol only exists in macOS 15's libc++, so a
+        //    minos-14 binary dies at launch on 14 (dyld missing-symbol
+        //    abort; verified on macos-14 CI). With staticStdlib (the
+        //    manifest default — previously silently ignored on the clang
+        //    route), link LLVM's own libc++.a/libc++abi.a instead:
+        //    runtime deps shrink to libSystem and the floor drops to
+        //    11.0 (first arm64 macOS). Falls back to -lc++ when the
+        //    archives are absent.
+        // 2. deployment target — mirror MACOSX_DEPLOYMENT_TARGET onto the
+        //    link command line so it doesn't depend on env propagation.
+        std::string stdlib_link = " -lc++";
+        if (f.staticStdlib && !llvmRootForStdlib.empty()) {
+            auto libcxxA    = llvmRootForStdlib / "lib" / "libc++.a";
+            auto libcxxAbiA = llvmRootForStdlib / "lib" / "libc++abi.a";
+            if (std::filesystem::exists(libcxxA)
+                && std::filesystem::exists(libcxxAbiA)) {
+                stdlib_link = " -nostdlib++ " + escape_path(libcxxA)
+                            + " " + escape_path(libcxxAbiA);
+            }
+        }
+        std::string version_min;
+        if (const char* dt = std::getenv("MACOSX_DEPLOYMENT_TARGET"); dt && *dt) {
+            version_min = std::string(" -mmacosx-version-min=") + dt;
+        }
+        f.ld = std::format("{}{}{}{}{}{}{}", full_static, static_stdlib, b_flag,
+                           version_min, stdlib_link, user_ldflags, link_extra);
     } else {
         f.ld = std::format("{}{}{}{}{}{}{}{}", full_static, static_stdlib, link_toolchain_flags, b_flag,
                            runtime_dirs, payload_ld, user_ldflags, link_extra);

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -363,12 +363,20 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         //    lld ships with the exact toolchain doing the compile.
         std::string stdlib_link = " -lc++";
         if (f.staticStdlib && !llvmRootForStdlib.empty()) {
-            auto libcxxA    = llvmRootForStdlib / "lib" / "libc++.a";
-            auto libcxxAbiA = llvmRootForStdlib / "lib" / "libc++abi.a";
+            auto libDir     = llvmRootForStdlib / "lib";
+            auto libcxxA    = libDir / "libc++.a";
+            auto libcxxAbiA = libDir / "libc++abi.a";
             if (std::filesystem::exists(libcxxA)
                 && std::filesystem::exists(libcxxAbiA)) {
-                stdlib_link = " -nostdlib++ " + escape_path(libcxxA)
-                            + " " + escape_path(libcxxAbiA);
+                // -hidden-l: ld64/lld feature made for exactly this —
+                // links the ARCHIVE (never the sibling dylib) and gives
+                // its symbols hidden visibility. Without it the static
+                // libc++/libc++abi symbols clash with the system copies
+                // that libSystem pulls in indirectly, and processes
+                // SIGABRT during static destruction (observed: every
+                // gtest binary exiting 6 on macos CI).
+                stdlib_link = " -nostdlib++ -L" + escape_path(libDir)
+                            + " -Wl,-hidden-lc++ -Wl,-hidden-lc++abi";
             }
         }
         std::string version_min;

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -89,6 +89,18 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     // any new branching added to this function.
     auto caps = mcpp::toolchain::capabilities_for(plan.toolchain);
 
+    // macOS minimum supported OS version for produced binaries.
+    // Precedence: MACOSX_DEPLOYMENT_TARGET env (explicit per-invocation
+    // override, the convention cargo/rustc/cc honor) > the manifest's
+    // [build] macos_deployment_target (project default, SwiftPM-style) >
+    // empty (toolchain/SDK default).
+    std::string macosDeploymentTarget;
+    if (const char* dt = std::getenv("MACOSX_DEPLOYMENT_TARGET"); dt && *dt) {
+        macosDeploymentTarget = dt;
+    } else {
+        macosDeploymentTarget = plan.manifest.buildConfig.macosDeploymentTarget;
+    }
+
     f.cxxBinary = plan.toolchain.binaryPath;
     f.ccBinary = mcpp::toolchain::derive_c_compiler(plan.toolchain);
 
@@ -137,20 +149,17 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         auto llvmRoot = plan.toolchain.binaryPath.parent_path().parent_path();
         auto libcxxInclude = llvmRoot / "include" / "c++" / "v1";
         compile_toolchain_flags = " --no-default-config -nostdinc++";
-        // macOS deployment target: make MACOSX_DEPLOYMENT_TARGET explicit
-        // on the command line so (a) the ninja commands don't depend on
-        // env propagation and (b) the value participates in the BMI
+        // macOS deployment target: make the resolved value explicit on
+        // the command line so (a) the ninja commands don't depend on env
+        // propagation and (b) the value participates in the BMI
         // fingerprint via canonical flags — mixing targets in one sandbox
         // otherwise reuses a std.pcm built for a different
         // arm64-apple-macosxNN triple and dies with a config mismatch
         // (observed on macos CI). The link side is added to f.ld below
         // (the macOS link path doesn't consume link_toolchain_flags).
-        if (mcpp::platform::is_macos) {
-            if (const char* dt = std::getenv("MACOSX_DEPLOYMENT_TARGET");
-                dt && *dt) {
-                compile_toolchain_flags +=
-                    std::string(" -mmacosx-version-min=") + dt;
-            }
+        if (mcpp::platform::is_macos && !macosDeploymentTarget.empty()) {
+            compile_toolchain_flags +=
+                " -mmacosx-version-min=" + macosDeploymentTarget;
         }
         llvmRootForStdlib = llvmRoot;
         // libc++ headers
@@ -363,8 +372,8 @@ CompileFlags compute_flags(const BuildPlan& plan) {
             }
         }
         std::string version_min;
-        if (const char* dt = std::getenv("MACOSX_DEPLOYMENT_TARGET"); dt && *dt) {
-            version_min = std::string(" -mmacosx-version-min=") + dt;
+        if (!macosDeploymentTarget.empty()) {
+            version_min = " -mmacosx-version-min=" + macosDeploymentTarget;
         }
         f.ld = std::format("{}{}{} -fuse-ld=lld{}{}{}{}", full_static, static_stdlib,
                            b_flag, version_min, stdlib_link, user_ldflags, link_extra);

--- a/src/build/ninja_backend.cppm
+++ b/src/build/ninja_backend.cppm
@@ -639,8 +639,17 @@ std::string emit_ninja_string(const BuildPlan& plan) {
             implicit.empty() ? std::string{} : " |" + implicit);
         if (auto flag = shared_soname_flag(lu); !flag.empty())
             out_line += "  soname_flag = " + flag + "\n";
-        if (auto flags = join_flags(lu.linkFlags); !flags.empty())
-            out_line += "  unit_ldflags =" + flags + "\n";
+        {
+            // Per-unit C++ stdlib link (macOS; empty elsewhere): test
+            // binaries run on the build host and use the system -lc++,
+            // distributable targets get the static LLVM libc++. See
+            // CompileFlags::ldStdlibDefault/ldStdlibTest.
+            std::string unit = join_flags(lu.linkFlags);
+            unit += (lu.kind == mcpp::build::LinkUnit::TestBinary)
+                ? flags.ldStdlibTest : flags.ldStdlibDefault;
+            if (!unit.empty())
+                out_line += "  unit_ldflags =" + unit + "\n";
+        }
         append(std::move(out_line));
 
         for (auto const& alias : lu.runtimeAliases) {

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -589,13 +589,20 @@ std::string canonical_compile_flags(const mcpp::manifest::Manifest& m) {
     s += " -fmodules";
     // macOS deployment target changes the effective compile triple
     // (arm64-apple-macosxNN) — a std.pcm built for one target cannot be
-    // loaded by a TU compiled for another. Fold it into the fingerprint
-    // so switching MACOSX_DEPLOYMENT_TARGET rebuilds the BMI cache
+    // loaded by a TU compiled for another. Fold the resolved value
+    // (env override > [build] macos_deployment_target manifest default)
+    // into the fingerprint so switching targets rebuilds the BMI cache
     // instead of dying with a module config mismatch.
     if constexpr (mcpp::platform::is_macos) {
+        std::string dtv;
         if (const char* dt = std::getenv("MACOSX_DEPLOYMENT_TARGET"); dt && *dt) {
+            dtv = dt;
+        } else {
+            dtv = m.buildConfig.macosDeploymentTarget;
+        }
+        if (!dtv.empty()) {
             s += " macos_deployment_target=";
-            s += dt;
+            s += dtv;
         }
     }
     if (!m.buildConfig.cStandard.empty()) {

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -593,6 +593,14 @@ std::string canonical_compile_flags(const mcpp::manifest::Manifest& m) {
     // (env override > [build] macos_deployment_target manifest default)
     // into the fingerprint so switching targets rebuilds the BMI cache
     // instead of dying with a module config mismatch.
+    //
+    // TODO(macos-default-floor): a built-in default floor (rustc-style,
+    // see the 0.0.50 revert) cannot land until the std-module prebuild /
+    // staging pipeline consumes the SAME resolved value as this rule and
+    // flags.cppm — injecting a default here alone left the test build's
+    // std.pcm unstaged (import std failed wholesale on macos CI).
+    // Centralize the resolution in one helper, then re-land.
+    // See xlings .agents/docs/2026-06-05-macos-min-version-support.md §5.
     if constexpr (mcpp::platform::is_macos) {
         std::string dtv;
         if (const char* dt = std::getenv("MACOSX_DEPLOYMENT_TARGET"); dt && *dt) {

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -587,6 +587,17 @@ std::string canonical_compile_flags(const mcpp::manifest::Manifest& m) {
     std::string s;
     s += "-std="; s += m.package.standard;
     s += " -fmodules";
+    // macOS deployment target changes the effective compile triple
+    // (arm64-apple-macosxNN) — a std.pcm built for one target cannot be
+    // loaded by a TU compiled for another. Fold it into the fingerprint
+    // so switching MACOSX_DEPLOYMENT_TARGET rebuilds the BMI cache
+    // instead of dying with a module config mismatch.
+    if constexpr (mcpp::platform::is_macos) {
+        if (const char* dt = std::getenv("MACOSX_DEPLOYMENT_TARGET"); dt && *dt) {
+            s += " macos_deployment_target=";
+            s += dt;
+        }
+    }
     if (!m.buildConfig.cStandard.empty()) {
         s += " c_standard=";
         s += m.buildConfig.cStandard;

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -600,6 +600,12 @@ std::string canonical_compile_flags(const mcpp::manifest::Manifest& m) {
         } else {
             dtv = m.buildConfig.macosDeploymentTarget;
         }
+        // Mirror flags.cppm's built-in default floor (14.0 with
+        // staticStdlib) so the fingerprint matches the flags actually
+        // emitted.
+        if (dtv.empty() && m.buildConfig.staticStdlib) {
+            dtv = "14.0";
+        }
         if (!dtv.empty()) {
             s += " macos_deployment_target=";
             s += dtv;

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -600,12 +600,6 @@ std::string canonical_compile_flags(const mcpp::manifest::Manifest& m) {
         } else {
             dtv = m.buildConfig.macosDeploymentTarget;
         }
-        // Mirror flags.cppm's built-in default floor (14.0 with
-        // staticStdlib) so the fingerprint matches the flags actually
-        // emitted.
-        if (dtv.empty() && m.buildConfig.staticStdlib) {
-            dtv = "14.0";
-        }
         if (!dtv.empty()) {
             s += " macos_deployment_target=";
             s += dtv;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,5 +5,17 @@ import std;
 import mcpp.cli;
 
 int main(int argc, char* argv[]) {
-    return mcpp::cli::run(argc, argv);
+    int rc = mcpp::cli::run(argc, argv);
+#ifdef __APPLE__
+    // With statically linked libc++ (the macOS release linkage since
+    // 0.0.50), static destruction can SIGABRT on exit — same issue xlings
+    // guards against. A CLI tool needs no destructor-based cleanup; skip
+    // static dtors entirely. _Exit bypasses atexit handlers too, so flush
+    // the standard streams explicitly first.
+    std::cout.flush();
+    std::cerr.flush();
+    std::_Exit(rc);
+#else
+    return rc;
+#endif
 }

--- a/src/manifest.cppm
+++ b/src/manifest.cppm
@@ -105,7 +105,7 @@ struct BuildConfig {
     std::vector<std::string>           ldflags;
     std::string                         cStandard;
     // macOS minimum supported OS version for produced binaries
-    // (LC_BUILD_VERSION minos), e.g. "11.0". Mirrors the ecosystem
+    // (LC_BUILD_VERSION minos), e.g. "14.0". Mirrors the ecosystem
     // conventions around deployment targets (the MACOSX_DEPLOYMENT_TARGET
     // env var that cargo/rustc/cc honor; SwiftPM's `platforms:` manifest
     // field; CMAKE_OSX_DEPLOYMENT_TARGET). Precedence: the env var (an

--- a/src/manifest.cppm
+++ b/src/manifest.cppm
@@ -104,6 +104,14 @@ struct BuildConfig {
     std::vector<std::string>           cxxflags;
     std::vector<std::string>           ldflags;
     std::string                         cStandard;
+    // macOS minimum supported OS version for produced binaries
+    // (LC_BUILD_VERSION minos), e.g. "11.0". Mirrors the ecosystem
+    // conventions around deployment targets (the MACOSX_DEPLOYMENT_TARGET
+    // env var that cargo/rustc/cc honor; SwiftPM's `platforms:` manifest
+    // field; CMAKE_OSX_DEPLOYMENT_TARGET). Precedence: the env var (an
+    // explicit per-invocation override) wins over this manifest default;
+    // empty + no env = toolchain/SDK default. No effect off macOS.
+    std::string                         macosDeploymentTarget;
     // Resolved build-profile knobs (from [profile.<name>] + built-in defaults).
     std::string                         optLevel = "2";  // -O level
     bool                                debug    = false; // -g
@@ -888,6 +896,8 @@ std::expected<Manifest, ManifestError> parse_string(std::string_view content,
     if (auto v = doc->get_string_array("build.cxxflags")) m.buildConfig.cxxflags = *v;
     if (auto v = doc->get_string_array("build.ldflags"))  m.buildConfig.ldflags  = *v;
     if (auto v = doc->get_string("build.c_standard"))     m.buildConfig.cStandard = *v;
+    if (auto v = doc->get_string("build.macos_deployment_target"))
+        m.buildConfig.macosDeploymentTarget = *v;
     for (auto const& flag : m.buildConfig.cxxflags) {
         if (starts_with_std_flag(flag)) {
             return std::unexpected(error(origin,

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.49";
+inline constexpr std::string_view MCPP_VERSION = "0.0.50";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;

--- a/tests/unit/test_manifest.cpp
+++ b/tests/unit/test_manifest.cpp
@@ -295,6 +295,34 @@ kind = "lib"
     EXPECT_EQ(m->buildConfig.cStandard, "c11");
 }
 
+TEST(Manifest, BuildMacosDeploymentTarget) {
+    constexpr auto src = R"(
+[package]
+name = "x"
+version = "0.1.0"
+[build]
+macos_deployment_target = "11.0"
+[targets.x]
+kind = "lib"
+)";
+    auto m = mcpp::manifest::parse_string(src);
+    ASSERT_TRUE(m.has_value()) << m.error().format();
+    EXPECT_EQ(m->buildConfig.macosDeploymentTarget, "11.0");
+}
+
+TEST(Manifest, BuildMacosDeploymentTargetDefaultsEmpty) {
+    constexpr auto src = R"(
+[package]
+name = "x"
+version = "0.1.0"
+[targets.x]
+kind = "lib"
+)";
+    auto m = mcpp::manifest::parse_string(src);
+    ASSERT_TRUE(m.has_value()) << m.error().format();
+    EXPECT_TRUE(m->buildConfig.macosDeploymentTarget.empty());
+}
+
 TEST(Manifest, RuntimeConfig) {
     constexpr auto src = R"(
 [package]


### PR DESCRIPTION
## Goal

macosx-arm64 release binaries should run on **macOS 11.0+** (first Apple Silicon release) instead of only macOS 15. Verified end-to-end on CI (#115, runs A→B5).

## Evidence chain (temp PR #115)

| run | config | result |
|-----|--------|--------|
| A | minos 14 + dynamic system libc++ | compiles, **dies at launch on macOS 14.8**: `dyld: Symbol not found: __ZNSt3__119__is_posix_terminalEP7__sFILE` (std::print support symbol; macOS 14's libc++ predates LLVM 18) — lowering minos alone is not viable |
| B2/B3 | `[build] ldflags` injection of static archives | minos 11 OK but still dynamically linked: the macOS link path hardcodes ` -lc++` **before** user ldflags |
| B initial | mixed deployment targets in one sandbox | `std.pcm` config-mismatch — BMI fingerprint didn't cover the deployment target |
| B4 | native staticStdlib (this PR), two-stage self-host | static + minos 11 ✅, but macos-14 e2e hit Xcode 15.4's system `ld` aborting at launch (its libc++ resolution diverted to the LLVM payload dylib, missing `__ZdaPv`) |
| **B5** | + `-fuse-ld=lld` | **all green**: macos-15 two-stage build (minos 11.0, no libc++ dylib dep, clean exit) + macos-14 control/refusal, binary startup, full `mcpp new/build/run` incl. llvm/ninja install |

## Changes

- **flags.cppm** — implement `staticStdlib` (the manifest default, previously silently ignored on the clang route) for the macOS link path: `-nostdlib++ <llvm>/lib/libc++.a <llvm>/lib/libc++abi.a` instead of `-lc++` (falls back when archives absent); link via `-fuse-ld=lld` (same as the Linux clang path — removes the host-Xcode `ld` dependency); mirror `MACOSX_DEPLOYMENT_TARGET` onto compile+link command lines.
- **cli.cppm** — fold `MACOSX_DEPLOYMENT_TARGET` into the BMI fingerprint (deployment target changes the effective compile triple; stale `std.pcm` reuse otherwise hard-fails).
- **main.cpp** — `__APPLE__` `_Exit` guard after stream flush (static libc++ static-dtor abort prevention; same guard xlings uses).
- **release.yml (macos job)** — `MACOSX_DEPLOYMENT_TARGET=11.0` + two-stage self-host (stage 1 bootstrap-built dynamic → stage 2 rebuilds itself static) + minos/no-dylib assertions.
- version 0.0.50.

## Design doc

xlings `.agents/docs/2026-06-05-macos-min-version-support.md` (kept updated through the experiments).

## Compatibility

- Linux/Windows paths untouched (`needs_explicit_libcxx` branch is macOS-only; gcc `-static-libstdc++` behavior unchanged).
- User projects on macOS now also link static libc++ by default (staticStdlib default) and via lld — verified by the macos-14 `mcpp new/build/run` e2e. Host-SDK-default minos for user binaries unchanged.