### PR TITLE
Release 0.0.51: robust sysroot payload discovery + deployment-target resolver

### DIFF
--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.50"
+version     = "0.0.51"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.50";
+inline constexpr std::string_view MCPP_VERSION = "0.0.51";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;


### PR DESCRIPTION
Version bump to 0.0.51. Changes since v0.0.50:

- #121 — payload discovery skips delegating-package husks (fixes #120): cold-start installs of the glibc toolchain no longer lose the kernel-header include path; CI/release sandbox caches now use disjoint lineages.
- #119 — single macOS deployment-target resolver shared by flags, fingerprint and stdmod (groundwork for the default-static flip).

Release flow after merge: tag v0.0.51 → release workflow (built-in Mach-O assertions) → xlings-res mirrors (GitHub + GitCode) → xim-pkgindex latest → 0.0.51.