### PR TITLE
Release 0.0.52: macOS portable-by-default (built-in 14.0 floor, static libc++)

### DIFF
--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.51"
+version     = "0.0.52"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.51";
+inline constexpr std::string_view MCPP_VERSION = "0.0.52";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;


### PR DESCRIPTION
Version bump to 0.0.52. Changes since v0.0.51:

- #124 — built-in 14.0 deployment floor + static libc++ by default on macOS: a fresh user's `mcpp new hello && mcpp run` now works on macOS 14 out of the box (previously died at dyld against the system libc++). Opt-out: `[build] static_stdlib = false`.

Release flow after merge: tag v0.0.52 → release workflow (built-in Mach-O assertions) → xlings-res mirrors (GitHub + GitCode) → xim-pkgindex latest → 0.0.52 → re-run the macos-14 fresh-install lane as the end-to-end user-flow proof (PR #123).