### PR TITLE
ci(fresh-install): add findutils to arch/tumbleweed distro legs

### DIFF
--- a/.github/workflows/ci-fresh-install.yml
+++ b/.github/workflows/ci-fresh-install.yml
@@ -173,7 +173,13 @@ jobs:
       - name: Install xlings + mcpp
         run: |
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash -s v0.4.38
-          echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
+          # Deliberately NOT writing to $GITHUB_PATH here. On container
+          # images that declare no PATH in their config (opensuse/
+          # tumbleweed), appending a single dir to GITHUB_PATH makes the
+          # runner exec later steps' `sh` with only that dir on PATH —
+          # `sh` (in /usr/bin) vanishes and the next step dies with
+          # `exec: "sh": ... not found` / exit 127. Each step below already
+          # exports PATH itself, so the append is redundant anyway.
 
       - name: Configure mcpp
         run: |

--- a/.github/workflows/ci-fresh-install.yml
+++ b/.github/workflows/ci-fresh-install.yml
@@ -136,16 +136,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # findutils (find) is mandatory on every leg: quick_install.sh
+        # locates the extracted xlings dir with `find`, so a missing find
+        # fails the install with exit 127 *before* mcpp ever runs. Minimal
+        # images (opensuse/tumbleweed) ship without it; arch's base merely
+        # bundles it by luck. List it explicitly everywhere — don't rely on
+        # the base image.
         include:
           - distro: fedora-latest
             image: fedora:latest
             setup: dnf -y install curl bash tar gzip xz git findutils binutils file glibc-langpack-en
           - distro: arch
             image: archlinux:latest
-            setup: pacman -Sy --noconfirm curl bash tar gzip xz git binutils file
+            setup: pacman -Sy --noconfirm curl bash tar gzip xz git findutils binutils file
           - distro: tumbleweed
             image: opensuse/tumbleweed:latest
-            setup: zypper -n install curl bash tar gzip xz git binutils file
+            setup: zypper -n install curl bash tar gzip xz git findutils binutils file
           - distro: debian-testing
             image: debian:testing
             setup: apt-get update && apt-get -y install curl bash tar gzip xz-utils git ca-certificates binutils findutils file


### PR DESCRIPTION
## Problem

The daily `ci-fresh-install` run failed on the **`Linux distro (tumbleweed)`** leg ([run 27796803895](https://github.com/mcpp-community/mcpp/actions/runs/27796803895)):

```
bash: line 148: find: command not found
Error: Process completed with exit code 127.
```

## Root cause

`quick_install.sh` is fetched from xlings `main` (unpinned). Its current version locates the extracted xlings directory with `find`:

```bash
EXTRACT_DIR=$(find "$WORK_DIR" -mindepth 1 -maxdepth 1 -type d -name "xlings-*" | head -1)
```

`opensuse/tumbleweed:latest` is a minimal image that ships **without findutils**, and our tumbleweed `setup` didn't install it — so the install dies at exit 127 *before mcpp ever runs*. Download and extraction both succeeded; it died on the post-extract directory probe.

The **arch** leg also omitted `findutils` and only passed by luck (arch base bundles it).

| distro | findutils in setup | image bundles find | result |
|---|---|---|---|
| fedora / debian* / ubuntu-2004 | ✅ | — | pass |
| arch | ❌ | ✅ (lucky) | pass |
| **tumbleweed** | ❌ | ❌ | **fail** |

## Fix

Add `findutils` explicitly to the arch and tumbleweed legs (matching fedora/debian/ubuntu) and a matrix note documenting the hard `find` dependency so it isn't dropped again.