### PR TITLE
fix(toolchain): list '*' reflects effective project-aware toolchain

### DIFF
--- a/src/toolchain/lifecycle.cppm
+++ b/src/toolchain/lifecycle.cppm
@@ -13,6 +13,7 @@ import mcpp.config;
 import mcpp.fetcher;
 import mcpp.fetcher.progress;
 import mcpp.manifest;
+import mcpp.platform;
 import mcpp.toolchain.detect;
 import mcpp.toolchain.registry;
 import mcpp.toolchain.post_install;
@@ -151,8 +152,34 @@ list_available_xpkg_versions(const mcpp::config::GlobalConfig& cfg,
 // preserves the shared setup (cfg load + xlings bootstrap progress)
 
 // `mcpp toolchain list` — installed + available toolchains.
+// The toolchain that `mcpp build`/`run` actually resolves from the current
+// directory. A project mcpp.toml `[toolchain]` shadows the global config
+// default (see prepare.cppm resolution order), so `mcpp toolchain default`
+// and `mcpp toolchain list`'s `*` — which read only the global config — can
+// otherwise disagree with what a build in this directory really uses.
+// (`--target` overrides are intentionally not folded in: they only take
+// effect when an explicit `--target` is passed.)
+struct EffectiveDefault {
+    std::string spec;
+    bool        fromProject = false;
+};
+
+EffectiveDefault effective_default_toolchain(const mcpp::config::GlobalConfig& cfg) {
+    std::error_code ec;
+    auto mpath = std::filesystem::current_path(ec) / "mcpp.toml";
+    if (!ec && std::filesystem::exists(mpath, ec)) {
+        if (auto m = mcpp::manifest::load(mpath)) {
+            if (auto t = m->toolchain.for_platform(mcpp::platform::name);
+                t && !t->empty())
+                return { *t, true };
+        }
+    }
+    return { cfg.defaultToolchain, false };
+}
+
 export int toolchain_list(const mcpp::config::GlobalConfig& cfg) {
     auto pkgsDir = cfg.xlingsHome() / "data" / "xpkgs";
+    auto effective = effective_default_toolchain(cfg);
         auto pathCtx = mcpp::fetcher::make_path_ctx(&cfg);
         struct Row {
             std::string compiler;
@@ -178,7 +205,7 @@ export int toolchain_list(const mcpp::config::GlobalConfig& cfg) {
                     r.version   = vEntry.path().filename().string();
                     r.bin       = bin;
                     r.isDefault = mcpp::toolchain::matches_default_toolchain(
-                        cfg.defaultToolchain, r.compiler, r.version);
+                        effective.spec, r.compiler, r.version);
                     installed.push_back(std::move(r));
                 }
             }
@@ -195,6 +222,15 @@ export int toolchain_list(const mcpp::config::GlobalConfig& cfg) {
                     r.isDefault ? "*" : "",
                     mcpp::toolchain::display_label(r.compiler, r.version),
                     mcpp::ui::shorten_path(r.bin, pathCtx));
+            }
+            // Explain the `*` when it reflects a project override rather than
+            // the global default, so it never silently disagrees with what a
+            // build in this directory resolves.
+            if (effective.fromProject) {
+                std::println("  (* = effective toolchain from project mcpp.toml "
+                             "[toolchain]; global default is '{}')",
+                             cfg.defaultToolchain.empty() ? "<none>"
+                                                          : cfg.defaultToolchain);
             }
         }
 


### PR DESCRIPTION
## Problem

A user saw `mcpp toolchain default` / `mcpp toolchain list` report `gcc@16.1.0`
as the default (the `*`), yet `mcpp run` resolved and used `gcc@15.1.0-musl`.
Three views of "the toolchain" disagreed.

## Root cause

`mcpp toolchain default <spec>` writes, and `mcpp toolchain list`'s `*` reads,
**only** the global `config.toml [toolchain] default`. But the build-time
resolver (`src/build/prepare.cppm`) reads the **project** `mcpp.toml
[toolchain]` *first* — it shadows the global default entirely (and `[target.*]`
overrides shadow it further). So inside a project that declares `[toolchain]`,
`list`'s `*` (global) and what `mcpp run` resolves (project) can point at
different toolchains. They are genuinely different sources of truth.

## Fix

Add `effective_default_toolchain(cfg)` — resolves the toolchain the same way a
build in the current directory does (project `mcpp.toml [toolchain]` for the
current platform, else global config default). `mcpp toolchain list` now marks
`*` on the **effective** toolchain and prints a one-line note when it comes
from the project, e.g.:

```
  *  gcc 16.1.0   ...
  (* = effective toolchain from project mcpp.toml [toolchain]; global default is 'gcc@15.1.0-musl')
```

`--target` overrides are intentionally not folded in (they only apply with an
explicit `--target`).

## Test

- `mcpp build` + `mcpp test` green (22 passed).
- Live: in this repo (which has `[toolchain] default = "gcc@16.1.0"`), `list`
  now stars `gcc 16.1.0` with the explanatory note — matching what `mcpp build`
  resolves.

Part of the 5-PR follow-up batch (`.agents/docs/2026-06-22-mcpp-followups-design.md`).
Note: the ABI-mismatch error already suggests both `mcpp toolchain default` and
`[toolchain] in mcpp.toml`, so no change needed there.