### PR TITLE
fix(build): self-heal stale build.ninja + bump 0.0.58

### DIFF
--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.57"
+version     = "0.0.58"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/build/execute.cppm
+++ b/src/build/execute.cppm
@@ -155,7 +155,14 @@ bool is_stale_ninja_failure(std::string_view output) {
     return output.find("loading 'build.ninja'") != std::string_view::npos
         || output.find("loading build.ninja") != std::string_view::npos
         || output.find("unknown target") != std::string_view::npos
-        || output.find("manifest 'build.ninja' still dirty") != std::string_view::npos;
+        || output.find("manifest 'build.ninja' still dirty") != std::string_view::npos
+        // A cached build.ninja can reference an input (e.g. a dependency
+        // source under the registry) that moved or was reinstalled since the
+        // graph was generated — the build fingerprint does not yet cover
+        // registry dep state, so the stale graph is reused. Ninja then aborts
+        // with this signature. Treat it as stale → drop to a full regen
+        // instead of hard-failing and forcing the user to `mcpp clean`.
+        || output.find("missing and no known rule to make") != std::string_view::npos;
 }
 
 // Compile a prepared BuildContext. Shared between `mcpp build` and `mcpp run`

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.57";
+inline constexpr std::string_view MCPP_VERSION = "0.0.58";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;


### PR DESCRIPTION
## Problem

After a dependency package under `~/.mcpp/registry/data/xpkgs/` is
reinstalled/moved but keeps the **same version string**, `mcpp build` fails:

```
ninja: error: '.../cmdline-0.0.1/src/parse.cppm', needed by 'obj/parse.m.o',
       missing and no known rule to make it
```

The file actually exists — the cached `build.ninja` is **stale**. The build
fingerprint doesn't cover registry dep state (`dependencyLockHash` is empty),
so `fp.hex`/`outputDir` are unchanged and `try_fast_build` reuses the old
graph. That ninja error isn't recognized as "stale", so it hard-fails and the
user has to run `mcpp clean` by hand.

## Fix

Add `"missing and no known rule to make"` to `is_stale_ninja_failure`
(`src/build/execute.cppm`). On that signature, `try_fast_build` returns
`nullopt` → the same `mcpp build` invocation drops to a full graph
regeneration, rewrites `build.ninja` against the current dep state, and
proceeds. No more manual `mcpp clean`.

Folding registry dep state into the fingerprint (to skip the regen entirely)
is a larger, riskier follow-up — tracked in
`.agents/docs/2026-06-22-mcpp-followups-design.md` §T-j.

## Version bump → 0.0.58

This is the **last PR of the 5-PR follow-up batch**, so it carries the version
bump (`fingerprint.cppm` `MCPP_VERSION` + `mcpp.toml`) for the release that
ships:
- #138 scanner raw-string fix
- #139 first-run progress visibility
- #140 toolchain effective-resolution
- #141 doctor runtime-dep check
- this build.ninja self-heal

**Merge this PR last.**

## Test

`mcpp build` + `mcpp test` green (22 passed), v0.0.58 compiles clean.