### PR TITLE
feat(aarch64): cross-build to aarch64-linux-musl + Android-capable CI

### DIFF
--- a/.agents/docs/2026-06-22-aarch64-android-mvp-design.md
+++ b/.agents/docs/2026-06-22-aarch64-android-mvp-design.md
@@ -1,0 +1,232 @@
+# aarch64 / Android 支持 —— 跨仓库 MVP 顶层设计方案
+
+> 北极星目标:**让 mcpp 在 Android 手机(Termux)上原生运行,并能在手机上构建出 C++ 程序**,全程不依赖 Android 的 bionic libc。
+> 本文是**顶层执行方案**(phases / 跨仓库协调 / 验收门)。逐点 file:line 适配清单见 [`todos/2026-06-22-aarch64-linux-ecosystem-support-analysis.md`](todos/2026-06-22-aarch64-linux-ecosystem-support-analysis.md)。
+> 日期:2026-06-22。起因:[mcpp#143](https://github.com/mcpp-community/mcpp/issues/143)。
+
+---
+
+## 1. 战略决策(已在分析中定型)
+
+| 决策 | 选择 | 理由 |
+|---|---|---|
+| **路线** | **musl-static 全静态** | 全静态 = 无 PT_INTERP、无 glibc payload、无 sysroot patch、不碰 bionic;同时绕开 "glibc 能否在 Android 内核跑" 这个变量 |
+| **arch token** | `arm64`(非 `aarch64`) | 引擎 `detect_arch_()` 强制;XLINGS_RES 资产必须叫 `…-linux-arm64.tar.gz` |
+| **分发** | 复用 `XLINGS_RES` 哨兵 | 引擎自动按 `detect_arch_()` 拼 arch,`.lua` 的 `linux={}` 块**不需改**,只上传资产 |
+| **arch 系统** | **暂不做完整三元组** | 现在靠 XLINGS_RES 自动 arch 足够;`abi` 轴(glibc/musl/bionic)比 arch 轴更关键,留到 Android/多 abi 阶段再上 `(os,arch,abi)` target 概念 |
+| **toolchain** | `aarch64-linux-musl` gcc-15 | `import std` 需要 gcc≥15;`musl-cross-make.lua` 已支持 15.1.0 + loader 派生已 arch-generic |
+
+### 关键技术事实(支撑可行性)
+- `mcpp build` / `pack` **不执行产物**(执行只在 `run`/`test`)→ **交叉编译可行**;代价:x86_64 上不能 `test/run` aarch64 产物。
+- musl-static 链接路径 **arch-干净**:`-static` 无 INTERP,glibc loader 硬编码(`flags.cppm:336`、`pack.cppm:648`)都不在此路径上。
+- 显式 `--target aarch64-linux-musl` 绕开 `pipeline.cppm:37,61` 的 x86_64 默认 fallback。
+- `targetTriple` 来自编译器 `-dumpmachine` → 指向真 `aarch64-linux-musl-g++` 即自动产 aarch64。
+- **自举无捷径**:必须先有"第 0 个 aarch64 mcpp"(连 Nix 也需 per-platform bootstrap seed)。
+
+---
+
+## 1b. 工具链包模型(2026-06-22 细化,已部分落地)
+
+把"原生"和"交叉"切成**两个独立的 xim 包**,mcpp 按 host 感知二选一:
+
+| 包 | 语义 | host / target | XLINGS_RES 资产 | 谁用 |
+|---|---|---|---|---|
+| `musl-gcc`(已存在,需泛化) | **原生** target=host | host=target | `musl-gcc-<ver>-linux-<hostarch>.tar.gz`(host 自动) | 设备端(aarch64→aarch64 在 ARM 上) |
+| `aarch64-linux-musl-gcc`(**新增**) | **交叉** target≠host | host=x86_64 / target=aarch64 | `aarch64-linux-musl-gcc-<ver>-linux-x86_64.tar.gz` | x86 上交叉构建 aarch64 |
+
+**mcpp 的 host 感知选择**(`src/build/prepare.cppm` `*-musl` 约定分支,已实现):
+- target arch == `mcpp::platform::host_arch` → 原生 → `gcc@15.1.0-musl` → `xim:musl-gcc`
+- target arch != host_arch → 交叉 → `<triple>-gcc@15.1.0` → `xim:<triple>-gcc`
+
+配套已实现的 mcpp 改动:
+- `src/platform/common.cppm`:新增 `host_arch` 常量(GNU 拼写 `aarch64`,非 xlings 资产用的 `arm64`)。
+- `src/toolchain/registry.cppm`:识别目标命名工具链 spec(`*-linux-musl-gcc`)→ 包名即 triple,前端 `<triple>-g++`;`frontend_candidates_for`/`archive_tool` 按 triple 派生。
+- `mcpp.toml`:`[target.aarch64-linux-musl]` 不写死 toolchain,交给 host 感知约定。
+
+**Canadian-cross 两步产出序列**(都入 xlings 生态):
+```
+A. build=x86 host=x86 target=aarch64  → 交叉编译器 → 包 aarch64-linux-musl-gcc
+                                         (musl-cross-make,gcc 15.1.0)
+B. 基于 A,build=x86 host=aarch64 target=aarch64 → 原生 → musl-gcc 的 arm64 资产
+                                         (Canadian-cross,或在 ARM 上原生构建)
+```
+- A 解决 x86 CI 交叉构建(也用于引导第 0 个 aarch64 mcpp)。
+- B 解决设备端原生构建(#143 端用户),产出 `musl-gcc-<ver>-linux-arm64.tar.gz`,经 `musl-gcc.lua` 泛化后由 XLINGS_RES 在 aarch64 host 自动选中。
+
+> 命名要点:交叉包 **必须** 把 target 写进包名(host 维度交给 XLINGS_RES);原生包沿用 `musl-gcc`(host=target,XLINGS_RES 按 host arch 自动区分)。
+
+## 1c. 进展记录(2026-06-22)
+
+**✅ G0 达成 + mcpp 自身交叉编译成功** —— mcpp 在 x86_64 上交叉构建出可运行的 aarch64 静态 ELF,**并交叉编译出 mcpp 本身**(`mcpp-0.0.58-linux-aarch64`,15M 全静态;`qemu-aarch64 mcpp --version` → `mcpp 0.0.58`)。这就是 #143 的可交付二进制(musl 全静态 → 可在 Android/Termux 原生运行,不依赖 bionic)。
+
+验证链:
+- 交叉工具链 `aarch64-linux-musl` gcc-15.1.0 经 musl-cross-make 构建成功;直接编译 + `import std` 均产出 `ELF aarch64, statically linked`。
+- `mcpp build --target aarch64-linux-musl` 端到端:解析 cross 工具链 → 跨编 std BMI → 静态链接 → `target/aarch64-linux-musl/.../aatest` 为 aarch64 ELF。
+- **qemu-aarch64 实际运行通过**;`x86_64-linux-musl` 原生路径回归正常(未破坏)。
+
+落地的代码改动(mcpp):
+- `src/platform/common.cppm`:`host_arch` 常量。
+- `src/build/prepare.cppm`:host 感知 native/cross 选择。
+- `src/toolchain/registry.cppm`:目标命名 spec(`*-linux-musl-gcc`)识别 + triple 派生前端/ar。
+- `mcpp.toml`:`[target.aarch64-linux-musl]`(host 感知,无写死 toolchain)。
+
+发现并修复的**交叉正确性 bug**(mcpp 此前把 glibc-gcc 模型套用到 musl 自包含工具链):
+- `src/toolchain/gcc.cppm`:std 构建对 musl 跳过外部 binutils `-B`(否则 x86 `as` 报 `unrecognized option '-EL'`)。
+- `src/toolchain/stdmod.cppm` + `src/build/flags.cppm`:对 musl 跳过外部 linux-headers `-isystem`(self-contained sysroot 自带,且交叉时 host 头是错 arch)。
+
+xlings 生态侧:
+- `xim-pkgindex/pkgs/a/aarch64-linux-musl-gcc.lua`:cross 包(长命令 + gcc-flavor `15.1.0-aarch64-musl` 版本标识)。
+- `xim-pkgindex/pkgs/m/musl-cross-make.lua`:target_list 加 `aarch64-linux-musl`。
+
+**已知限制 / 待办**:
+- 本次端到端测试用"预装到 xpkgs(`.mcpp_ok`)"绕过下载,因为 **xlings 下载器仅支持 HTTPS,不支持 `file://`**。生产路径 = 把 `aarch64-linux-musl-gcc-15.1.0-linux-x86_64.tar.gz`(411MB,已打包)发到 `https://xlings-res`(GLOBAL github + CN gitcode)。
+  - 可选改进:给 xlings downloader 加 `file://` 本地资源支持,利于离线/本地包开发。
+- 步骤 B(Canadian-cross 产 host=aarch64 原生 `musl-gcc` arm64 资产)尚未做。
+- libcc1 在 install 阶段失败(可选的 GDB 插件,非编译必需);打包时建议 `--disable-libcc1` 去噪。
+
+## 2. 三个根本难题与解法
+
+```mermaid
+graph TD
+    P1["难题1: 鸡生蛋<br/>(mcpp 自己编自己,但没有 aarch64 引导二进制)"]
+    P2["难题2: 设备上要原生 aarch64 编译器<br/>(交叉 gcc 只解决构建主机,不解决设备)"]
+    P3["难题3: Android 不是标准 Linux<br/>(bionic / W^X / SELinux / $PREFIX 布局)"]
+
+    P1 --> S1["交叉编译第0个 mcpp<br/>(x86_64 → aarch64-linux-musl static)"]
+    P2 --> S2["Canadian-cross 造原生 aarch64 gcc<br/>(build=x86_64, host=aarch64, target=aarch64)<br/>或 ARM runner 原生构建"]
+    P3 --> S3["全静态绕开 bionic ABI<br/>+ 适配 Termux $PREFIX/exec 限制"]
+```
+
+---
+
+## 3. 分阶段执行方案(MVP → Android)
+
+### 阶段总览
+
+```mermaid
+flowchart LR
+    A["P0<br/>交叉出 aarch64 mcpp"] --> B["P1<br/>aarch64-Linux 原生跑通"]
+    B --> C["P2<br/>xlings aarch64 + 分发闭环"]
+    C --> D["P3<br/>Android/Termux 原生构建"]
+    A -.最快验证.-> V["给 #143 试用<br/>(proot 或真机)"]
+```
+
+---
+
+### P0 — 交叉构建第 0 个 aarch64 mcpp(打破鸡生蛋)
+
+**目标**:在 x86_64 主机上产出一个 `aarch64-linux-musl` 全静态 mcpp 二进制。
+
+| # | 仓库 | 交付物 |
+|---|---|---|
+| P0-1 | `xim-pkgindex` | `musl-cross-make.lua` 的 `target_list` 加 `aarch64-linux-musl`(上游原生支持,loader 派生已 arch-generic) |
+| P0-2 | (本地) | 用 `xlings run musl-cross-make --target aarch64-linux-musl --gcc 15.1.0` 造出交叉 gcc-15 |
+| P0-3 | `mcpp` | 摸清/打通"消费本地交叉工具链"的接法(见 §5 风险①);`mcpp.toml` 加 `[target.aarch64-linux-musl] linkage=static` |
+| P0-4 | `mcpp` | `mcpp build --target aarch64-linux-musl` + `mcpp pack --target aarch64-linux-musl` |
+
+**验收门 G0**:`file <out>` → `ELF 64-bit LSB, ARM aarch64, statically linked`;QEMU-user 或 aarch64 box 上能 `--version`。
+
+> 🚀 **此处即可给 #143 报告人最快验证**:把 G0 产物丢进 Termux(原生或 proot)跑 `--version`,证明 self-contained 在 ARM 成立。
+
+---
+
+### P1 — aarch64-Linux 标准发行版原生跑通
+
+**目标**:在真 aarch64 Linux(ARM 服务器 / RPi64 / QEMU / Termux-proot-Ubuntu)上,mcpp 能 `build` 出 hello-world。
+
+| # | 仓库 | 交付物 |
+|---|---|---|
+| P1-1 | (构建) | **原生 aarch64 gcc-15**:Canadian-cross(build=x86_64,host=aarch64,target=aarch64)或 ARM runner 原生构建 —— 因为编译器要在设备上跑 |
+| P1-2 | `mcpp` | 修阻塞运行时的 arch 硬编码:`pipeline.cppm:37,61` 默认 target 按 host 派生;`install.sh:28-38` 加 `Linux-aarch64→linux-arm64` |
+| P1-3 | `mcpp` | (建议)`src/platform/common.cppm` 加 `host_arch` 抽象 + `arch→loader` 映射,统一收编散落硬编码 |
+| P1-4 | `mcpp` | 顺手修 `doctor.cppm:106`(只认 `std.gcm`,Clang 产 `std.pcm` 误报) |
+
+**验收门 G1**:aarch64 Linux 上 `mcpp build` + 运行一个 `import std` 的 hello-world 成功。
+
+---
+
+### P2 — xlings aarch64 + 分发闭环
+
+**目标**:`xlings install mcpp` 在 aarch64-Linux 上一键拉通完整工具链。
+
+| # | 仓库 | 交付物 |
+|---|---|---|
+| P2-1 | `xlings` | CI 产出 `xlings-<ver>-linux-arm64.tar.gz`(`ubuntu-24.04-arm` 原生或交叉);`linux_release.sh` 参数化 `ARCH`/`MCPP_TARGET`;`setup_musl_runtime.sh` musl loader 参数化;`installer.cppm:779` os.arch stub 修正 |
+| P2-2 | `xlings-res` | 上架 arm64 资产:`mcpp-<ver>-linux-arm64` + 原生 aarch64 musl 工具链(GLOBAL=github + CN=gitcode 双端) |
+| P2-3 | `xim-pkgindex` | 各包 `archs={}` 加 `arm64`;走 XLINGS_RES 的包 **块不改**(macOS 已是活证据);仅 `musl-gcc.lua` 需把 `x86_64-linux-musl-*` 程序名泛化 |
+| P2-4 | `libxpkg` | `elfpatch.lua` + `xpkg-lua-stdlib.cppm:1181` 加 aarch64 loader 路径(`ld-musl-aarch64.so.1`)—— 供非全静态包用;纯静态可后置 |
+| P2-5 | `mcpp` | `release.yml` 加 aarch64 job;`.xlings.json` pin 无需改 arch;README 状态 🔄→✅ |
+| P2-6 | (引导) | 把 P0 的引导产物注册成 xim-x-mcpp 的 arm64 资产,完成自举闭环 |
+
+**验收门 G2**:干净 aarch64 Linux 上 `curl install.sh | bash` → `mcpp build` 全程自动,无手工干预。
+
+---
+
+### P3 — Android / Termux 原生构建(北极星)
+
+**目标**:真 Android 手机的 Termux 里,**不进 proot**,mcpp 原生 build + run 出程序。
+
+| # | 仓库 | 交付物 / 攻关点 |
+|---|---|---|
+| P3-1 | (构建) | **设备上的编译器**:原生 aarch64 musl gcc 要能在 Android 内核跑。优先 **musl-static gcc**(无 loader);退路 musl-dynamic + bundle 极简 `ld-musl-aarch64.so.1` + patch INTERP |
+| P3-2 | `mcpp`/`xlings` | Termux 环境适配:`$PREFIX` 路径、`PATH`、Android 10+ 的 **W^X / SELinux exec 限制**(Termux home 可执行,验证下载二进制的 exec 权限链) |
+| P3-3 | `mcpp` | std module BMI 在 musl-libstdc++ 上的设备内生成验证(编译期,不需执行) |
+| P3-4 | (验证) | 真机:`mcpp new` → `mcpp build` → `mcpp run` 一个 `import std` 程序 |
+
+**验收门 G3**:Android 手机 Termux 原生(无 proot)跑通 `mcpp build && mcpp run`。
+
+> Android **bionic 原生 target**(`android` 平台维度 + NDK 工具链)**不在本方案** —— 那是再大一个量级的独立工程。本方案用 musl-static **在 Android 上但不依赖 bionic** 达成目标。
+
+---
+
+## 4. 跨仓库职责矩阵
+
+| 仓库 | P0 | P1 | P2 | P3 |
+|---|---|---|---|---|
+| `mcpp` | target 配置 + 工具链消费 | arch 硬编码 + install.sh | release CI | Termux 环境适配 |
+| `xim-pkgindex` | musl-cross-make target | — | archs 元数据 + musl-gcc 泛化 | — |
+| `xlings` | — | — | CI 产 arm64 + os.arch 修正 | — |
+| `xlings-res` | — | — | 上架 arm64 资产 | (设备工具链资产) |
+| `libxpkg` | — | — | elfpatch aarch64 loader | (musl loader 验证) |
+| (构建基建) | 交叉 gcc | 原生 gcc(canadian-cross) | — | 设备可跑的静态 gcc |
+
+---
+
+## 5. 风险与待确认(决定 P0/P3 成败)
+
+1. **🔴 mcpp 消费"非索引本地工具链"的接法**(P0 阻塞项)
+   `[target].toolchain` 走 `to_xim_package` 解析成 xim 包名。本地自建交叉 gcc 怎么喂给 mcpp?——选项:`$CXX`/PATH 让 probe 探到(probe 支持 `$CXX`)/ 包一层薄 xpkg / 临时注册。**P0 第一步先确认这条。**
+
+2. **🟡 import std 跨/原生 BMI**
+   gcc-15 musl 必须带 libstdc++ 的 `bits/std.cc` + `include/c++/15/aarch64-linux-musl/` 目标头(musl-cross-make 会编 libstdc++,应有,需实测)。
+
+3. **🟡 设备上 gcc 可跑性**(P3 核心)
+   musl-static gcc 最稳;若只能 musl-dynamic,需 bundle loader + 验证 Android exec 限制。这是 P3 唯一的真不确定点。
+
+4. **🟢 abi 校验**
+   mcpp 唯一依赖 `mcpplibs.cmdline` 无 `abi:glibc`,musl-static 不冲突。
+
+5. **🟢 ARM runner 可用性**
+   GitHub `ubuntu-24.04-arm` 是否对本 org 可用,决定 P1/P2 走原生还是交叉。
+
+---
+
+## 6. 最小关键路径(MVP 主线)
+
+```
+P0(交叉 mcpp)→ G0 给 #143 验证
+   └─ 阻塞先解:风险①(工具链消费接法)
+P1(原生 aarch64-Linux 跑通)→ G1
+P2(xlings + 分发闭环)→ G2  ← 标准 aarch64-Linux 用户可用
+P3(Android 原生)→ G3        ← 北极星达成
+```
+
+**建议节奏**:先做 P0 的 P0-1 + 风险①探路(轻量),确认接法后再启动耗时的 gcc 构建;G0 一旦达成立即给 #143 闭环反馈,再推 P1→P3。
+
+---
+
+## 7. 关联文档
+- 逐点 file:line 适配清单 + 拓扑图:[`todos/2026-06-22-aarch64-linux-ecosystem-support-analysis.md`](todos/2026-06-22-aarch64-linux-ecosystem-support-analysis.md)
+- 既有平台支持参考:`2026-05-16-macos-support-design.md`、`platform-abstraction-plan.md`
+- 发布闭环:记忆 [[release-publish-pipeline]]
+</content>

--- a/.agents/docs/todos/2026-06-22-aarch64-linux-ecosystem-support-analysis.md
+++ b/.agents/docs/todos/2026-06-22-aarch64-linux-ecosystem-support-analysis.md
@@ -1,0 +1,306 @@
+# aarch64-linux 生态适配分析报告
+
+> 起因:[mcpp#143](https://github.com/mcpp-community/mcpp/issues/143) —— 用户在 Android/Termux (aarch64) 上无法编译 mcpp。
+> 范围:让 mcpp 及其工具链生态在 **aarch64-linux** 上可安装、可自举、可构建。
+> 状态:分析 / 方案(未动代码)。日期:2026-06-22。
+
+---
+
+## 1. 背景与结论速览
+
+mcpp 是一个 **self-host**(自己编译自己)的 C++ 构建/包管理工具。它本身不携带 LLVM,而是通过 bundled 的 **xlings** 包管理器下载托管的 sandbox 工具链(gcc/glibc/llvm 等),并用 patchelf 把 loader/RUNPATH 重写成 sandbox 内的绝对路径。因此 mcpp 的正常工作流 **不依赖宿主 OS 的 libc**。
+
+### 1.1 issue #143 的误区澄清
+
+用户在 Termux 上遇到的 `import std` / Bionic 头冲突(`sigcontext`/`sigaction` 重定义),是因为他 **绕开 mcpp、直接用系统 clang** `-fmodules` 去啃 Bionic 头 —— 那不是 mcpp 的执行路径。mcpp 如果正常跑,Bionic 根本不参与。
+
+### 1.2 核心结论
+
+| 目标 | 难度 | 本质 |
+|---|---|---|
+| **A. aarch64-linux (glibc/musl)** | 中等、可控 | mcpp 的 triple 检测本就架构无关;真正阻塞 = 少量硬编码 loader + CI 矩阵 + **外部需产出 aarch64 工具链二进制并上架** |
+| **B. Termux/Android (bionic)** | 大一个量级 | 全生态零 Android 处理;`__linux__` 与 glibc 强绑定。**取巧路线**:走 `aarch64-linux-musl` 全静态,绕开 bionic ABI 与 "glibc 能否在 Android 内核运行" 两个变量 |
+
+本报告聚焦 **目标 A**;目标 B 在 §7 单列。
+
+### 1.3 三条决定形态的机制(务必先理解)
+
+1. **xlings 按 OS 解析依赖,不按 arch 解析。** 包选择 key 是 `linux/macosx/windows`,`archs={...}` 字段引擎根本不读(纯元数据)。
+2. **arch 只在两处真正参与:**
+   - `XLINGS_RES` sentinel → 下载 URL 的 arch token 拼接(`xlings/src/core/xim/installer.cppm:146` `build_xlings_res_url_`,按 `detect_arch_()` 自动带);
+   - `libxpkg` 的 `elfpatch.lua` 给 ELF 打 INTERP/rpath 时的 loader 选择。
+3. **`XLINGS_RES` 包的 per-arch 已天然工作** —— 引擎已自动把 arch 拼进 URL。所以走 sentinel 的工具链包 **无需改 DSL**,只需上架 arm64 资产。DSL "不支持同平台 per-arch URL"(`xim-pkgindex/docs/spec/url-template.md:69`)只卡 **写显式上游 URL** 的包(如 fish/jq)。
+
+### 1.4 命名决策(贯穿全局,必须统一)
+
+引擎 `detect_arch_()`(`xlings/src/core/xim/installer.cppm:123-133`)对 aarch64 返回 **`arm64`**(不是 `aarch64`)。
+→ **所有 XLINGS_RES 资产必须命名 `<pkg>-<ver>-linux-arm64.tar.gz`**,内层目录同名。
+→ install.sh 的 PLAT 也映射成 `linux-arm64`。
+> 注意:mcpp 内部的 **target triple**(由编译器 `-dumpmachine` 产出)仍是 `aarch64-linux-gnu` / `aarch64-linux-musl` —— 这是工具链三元组,与 xlings 资产 token `arm64` 是两套命名,不要混淆。
+
+---
+
+## 2. 涉及的仓库地图
+
+| 仓库 | 角色 | 适配性质 |
+|---|---|---|
+| `mcpp-community/mcpp` | 本体(self-host 构建工具) | 代码 + CI + 配置 |
+| `openxlings/xlings` | 包管理器引擎(C++23,由 mcpp 编译) | 主要是 CI 产出 aarch64 二进制 |
+| `mcpplibs/libxpkg` | xlings 的 ELF patch / xpkg 执行库 | 代码(loader 路径) |
+| `openxlings/xim-pkgindex` | 包索引(每包一个 .lua) | 元数据 + 硬编码 loader + (可选)DSL 扩展 |
+| `xlings-res/*` | 资产托管(GitHub GLOBAL + gitcode CN) | 上架 arm64 二进制 |
+| (横切) 工具链构建 | gcc/glibc/llvm/musl 的 aarch64 产出 | **最重的底层活** |
+
+---
+
+## 3. 适配依赖拓扑图(mermaid)
+
+### 3.1 全景:仓库/产物级依赖
+
+```mermaid
+graph TD
+    subgraph build["① 工具链构建 [最底层]"]
+        TC_LLVM["llvm/clang aarch64<br/>(LLVM 官方有 Linux-ARM64,可镜像)"]
+        TC_GCC["gcc@16 + glibc payload aarch64<br/>(crosstool-ng / 原生构建)"]
+        TC_MUSL["musl-cross aarch64-linux-musl<br/>(全静态路线)"]
+        TC_AUX["patchelf / ninja aarch64<br/>(上游现成)"]
+    end
+
+    subgraph res["② xlings-res 资产上架 (arm64 命名)"]
+        RES["github.com/xlings-res/*<br/>gitcode.com/xlings-res/*"]
+    end
+
+    subgraph engine["③ 引擎/库代码"]
+        XLINGS["xlings: CI 产出 arm64 二进制<br/>+ os.arch stub 修正"]
+        LIBXPKG["libxpkg: elfpatch 加<br/>aarch64 loader 路径"]
+    end
+
+    subgraph index["④ xim-pkgindex"]
+        IDX_META["各包 archs 元数据 + arm64"]
+        IDX_HC["硬编码 loader/triple 修正<br/>(glibc/gcc/llvm/musl-gcc)"]
+        IDX_DSL["(可选) DSL per-arch URL 扩展"]
+    end
+
+    subgraph mcpp["⑤ mcpp 本体"]
+        MCPP_CODE["loader/triple 硬编码 4 处<br/>+ host_arch 抽象"]
+        MCPP_INSTALL["install.sh 加 Linux-aarch64"]
+        MCPP_CI["release.yml aarch64 job"]
+        MCPP_TOML["mcpp.toml [target.aarch64-linux-musl]"]
+    end
+
+    BOOT0["⓪ 第 0 个 aarch64 mcpp<br/>(一次性引导:交叉/ARM runner)"]
+
+    TC_LLVM --> RES
+    TC_GCC --> RES
+    TC_MUSL --> RES
+    TC_AUX --> RES
+
+    BOOT0 --> XLINGS
+    XLINGS --> RES
+    LIBXPKG --> XLINGS
+
+    RES --> IDX_META
+    IDX_HC --> IDX_META
+    IDX_DSL -.可选.-> IDX_META
+
+    IDX_META --> MCPP_INSTALL
+    MCPP_CODE --> MCPP_CI
+    MCPP_TOML --> MCPP_CI
+    LIBXPKG --> IDX_HC
+    XLINGS --> MCPP_CI
+    RES --> MCPP_CI
+
+    MCPP_INSTALL --> DONE["✅ xlings install mcpp<br/>在 aarch64-linux 闭环"]
+    MCPP_CI --> DONE
+```
+
+### 3.2 自举链路:打破鸡生蛋
+
+```mermaid
+flowchart LR
+    A["⓪ 现成编译器<br/>(ARM runner / 交叉)"] -->|引导| B["第 0 个<br/>aarch64 mcpp"]
+    B -->|编译| C["xlings aarch64<br/>(静态 musl)"]
+    D["aarch64 工具链资产<br/>(优先复用 LLVM 官方)"] -->|上架 arm64| E["xlings-res"]
+    F["libxpkg + glibc.lua<br/>aarch64 loader 修正"] --> G
+    C --> G["xlings install mcpp<br/>正常拉取"]
+    E --> G
+    G -->|self-host| H["✅ aarch64 闭环<br/>(后续版本自动滚动)"]
+```
+
+### 3.3 工具链包安装依赖顺序(gcc 主链)
+
+```mermaid
+graph LR
+    LH["linux-headers"] --> GLIBC["glibc"]
+    GLIBC --> BINUTILS["binutils"]
+    GLIBC --> GSC["gcc-specs-config"]
+    GLIBC --> GRT["gcc-runtime"]
+    BINUTILS --> GCC["gcc"]
+    GSC --> GCC
+    GRT --> GCC
+    GLIBC --> NINJA["ninja"]
+    GRT --> NINJA
+    GCC --> MCPP["mcpp"]
+    NINJA --> MCPP
+    PATCHELF["patchelf"] -.musl路线.-> MUSL["musl-gcc"]
+    GLIBC -.clang路线.-> LLVM["llvm / llvm-tools"]
+```
+
+---
+
+## 4. 按依赖关系排序的适配点清单
+
+> 图例:`[构建]` 需为 aarch64 重新编译 · `[资产]` 需上架二进制 · `[代码]` 源码改动 · `[CI]` 流水线 · `[决策]` 需拍板
+
+### 阶段 ⓪ — 自举引导(打破鸡生蛋)
+
+- [ ] `[构建]` 在 aarch64 上(`ubuntu-24.04-arm` 原生 runner 或 x86_64 交叉)用现成编译器引导出 **第 0 个 aarch64 mcpp**。参考已有 `scripts/bootstrap-macos.sh` + `.github/workflows/bootstrap-macos.yml` 的 xmake "Plan B" 思路。
+
+### 阶段 ① — 工具链构建(最底层,横切)
+
+- [ ] `[构建]` **llvm/clang aarch64-linux** —— LLVM 官方有 `…-Linux-ARM64` release,**直接镜像最省事**;走此路 `import std` 也通。
+- [ ] `[构建]` **gcc@16(glibc)+ glibc payload aarch64** —— crosstool-ng / 原生构建。
+- [ ] `[构建]` **musl-cross `aarch64-linux-musl`** —— 全静态路线关键(也是 Termux 取巧路线的基础)。
+- [ ] `[构建]` **patchelf / ninja aarch64** —— 上游现成,镜像即可。
+
+### 阶段 ② — xlings-res 资产上架(`arm64` 命名)
+
+向 `github.com/xlings-res/<pkg>`(GLOBAL)+ `gitcode.com/xlings-res/<pkg>`(CN)各上传 `<pkg>-<ver>-linux-arm64.tar.gz`(内层目录同名,布局对齐 x86_64):
+
+- [ ] `[资产]` **最小主链**:`linux-headers` → `glibc` → `binutils` → `gcc-specs-config` → `gcc-runtime` → `gcc` → `ninja` → `mcpp`
+- [ ] `[资产]` **补充**:`llvm` / `llvm-tools`(clang / `import std` 路线)、`patchelf`、`musl-gcc` / `musl-cross-make`(musl 路线)
+
+### 阶段 ③ — 引擎/库代码
+
+**`mcpplibs/libxpkg`**(ELF 安装后能否运行的关键)
+
+- [ ] `[代码]` `src/lua-stdlib/xim/libxpkg/elfpatch.lua` —— ELF class 检测已支持 aarch64(`_EM_AARCH64`,:153)✓;但 `_detect_system_loader`(:287-289)与 subos `_resolve_loader`(:315-317)**只列 x86_64 loader** → 补 `ld-linux-aarch64.so.1` / `ld-musl-aarch64.so.1`。
+- [ ] `[代码]` `src/xpkg-lua-stdlib.cppm:1181` —— 同逻辑的**内嵌副本**,同步改。
+
+**`openxlings/xlings`**(几乎不阻塞)
+
+- [ ] `[代码]` `src/core/xim/installer.cppm:779` —— Lua `os.arch` stub 硬编码 `'arm64'`,既存疑点,改为反映 `detect_arch_()` 真值。
+- [ ] `[CI]` `tools/linux_release.sh:26,45` —— `ARCH` / `MCPP_TARGET` 参数化(`arm64` / `aarch64-linux-musl`)。
+- [ ] `[CI]` `.github/workflows/release.yml` —— 新增 `build-linux-arm64` job(`runs-on: ubuntu-24.04-arm`),加进 release `files:`。
+- [ ] `[CI]` `tools/setup_musl_runtime.sh:7-26` —— musl loader/SDK 路径参数化(`ld-musl-aarch64.so.1`)。
+- [ ] `[CI]` `xlings-ci-linux*.yml` —— 可选 aarch64 矩阵。
+
+### 阶段 ④ — xim-pkgindex(包索引)
+
+**D-1. 必改的硬编码 loader/triple**(install/config 钩子,被 elfpatch 直接消费)
+
+- [ ] `[代码]` `pkgs/g/glibc.lua:33,40-42` —— `loader=lib64/ld-linux-x86-64.so.2`、`abi=linux-x86_64-glibc`、库清单 → aarch64 版(`lib/ld-linux-aarch64.so.1` / `linux-arm64-glibc`)。**不改会打错 INTERP。**
+- [ ] `[代码]` `pkgs/g/gcc.lua:81,106-108,169` —— `x86_64-linux-gnu-*` triple + `ld-linux-x86-64.so.2` → arch 派生 `aarch64-linux-gnu-*`。
+- [ ] `[代码]` `pkgs/g/gcc-specs-config.lua:48,76-77,87` —— `old_dynamic_linker` 表加 aarch64 项,消除 `:87` 的 `multi-arch?` TODO。
+- [ ] `[代码]` `pkgs/g/gcc-runtime.lua:67` —— 内层目录名 arch 化。
+- [ ] `[代码]` `pkgs/l/llvm.lua:117,124,142-143,165,256` —— 内层目录 + triple `x86_64-unknown-linux-gnu` + 链接器 → aarch64。
+- [ ] `[代码]` `pkgs/l/llvm-tools.lua:24-25` —— url 表 arch 化。
+- [ ] `[代码]` `pkgs/m/musl-gcc.lua:59-79,83,162-167,225` —— **改动最大**,整套 `x86_64-linux-musl-*` + `ld-musl-x86_64.so.1` → `aarch64-linux-musl-*`。
+- [ ] `[代码]` `pkgs/m/mcpp.lua:41`、`pkgs/p/patchelf.lua:39` —— `url_template` 写死 x86_64,**仅影响 CI version-check**,install 走 XLINGS_RES。
+
+**D-2. 元数据**
+
+- [ ] `[代码]` 各包 `archs={...}` 加 `arm64`(gcc/glibc/binutils/ninja/patchelf/linux-headers/gcc-runtime/llvm-tools 当前只 `{x86_64}`)。
+
+**D-3. 委托型**
+
+- [ ] `[构建]` `pkgs/l/linux-headers.lua` —— 委托 `scode:linux-headers`,需源包提供 aarch64 内核头(`asm/`)。
+
+**D-0. (可选/长期)DSL 引擎扩展 per-arch URL**
+
+- [ ] `[决策]``[代码]` `xim-pkgindex/docs/spec/url-template.md:69` 列为 TODO。两种形态择一:
+  - 形态 A(推荐):让显式 URL 也支持 `{arch}` 占位 + 引擎按 `detect_arch_()` 填(与 XLINGS_RES 同源)。
+  - 形态 B:新增平台 key `linux-aarch64`(沿用 `ubuntu={ref="linux"}` 继承哲学),引擎识别。
+  - 注:mcpp 工具链链几乎全走 XLINGS_RES,此项主要为将来镜像上游显式 URL 的包铺路,**非主链阻塞**。
+
+### 阶段 ⑤ — mcpp 本体
+
+**安装入口**
+
+- [ ] `[代码]` `install.sh:28-38` —— `case` 加 `Linux-aarch64) PLAT="linux-arm64" ;;`(映射 `arm64`),改行 33 文案。
+
+**生产代码硬编码 loader/triple**
+
+- [ ] `[代码]` `src/platform/linux.cppm:85` —— runtime lib dir 写死 `x86_64-unknown-linux-gnu` → 按探测 triple 拼。
+- [ ] `[代码]` `src/build/flags.cppm:336` —— `--dynamic-linker` 写死 `ld-linux-x86-64.so.2` → arch 派生 `ld-linux-aarch64.so.1`。
+- [ ] `[代码]` `src/pack/pack.cppm:648` —— PT_INTERP 写死 `/lib64/ld-linux-x86-64.so.2` → `/lib/ld-linux-aarch64.so.1`(且不在 `/lib64`)。
+- [ ] `[代码]` `src/pack/pipeline.cppm:37,61` —— pack 默认 target 写死 `x86_64-linux-musl` → 按 host 推导。
+- [ ] `[代码]` `src/toolchain/post_install.cppm`(93/115/118/146/249/306/319)、`src/toolchain/lifecycle.cppm`(382/387/406/407)—— glibc loader 名 + `x86_64-*` triple 目录(patchelf/specs/cfg 修复链)→ arch 派生。
+- [ ] `[代码]` **建议新增** `src/platform/common.cppm` 的 `host_arch` 抽象 + `arch→loader` 映射表,统一上面所有点(当前只有 OS 维度,无 CPU arch 维度)。
+
+**配置**
+
+- [ ] `[代码]` `mcpp.toml:24` —— 新增 `[target.aarch64-linux-musl]`(前提:xlings 有 aarch64 musl-gcc)。
+- [ ] `.xlings.json:3` —— bootstrap pin 纯版本号,**无需改 arch**(前提:xim-x-mcpp 有 arm64 资产)。
+
+**发布/CI**
+
+- [ ] `[CI]` `.github/workflows/release.yml` —— 新增 aarch64 job(`runs-on: ubuntu-24.04-arm`)或 matrix;改行 102(xlings 引导下载)、127/131/143-146(`--target`/资产名)、165-168(别名)、248-256(`files:`)。
+- [ ] `[CI]` `ci-linux.yml` / `ci-fresh-install.yml` —— 可选 aarch64 leg。
+- [ ] `[代码]` `README.md:215` / `README.zh-CN.md:215` —— `Linux aarch64` 状态 🔄→✅。
+
+**测试夹具**
+
+- [ ] `[代码]` `tests/unit/*`、`tests/e2e/*.sh` 多处断言 `x86_64-linux-*` 路径 → 参数化或加 aarch64 用例。
+
+**顺手 bug**(非 arch,但影响所有 Clang 宿主)
+
+- [ ] `[代码]` `src/doctor.cppm:106` —— std 模块检查只认 `std.gcm`,Clang 产 `std.pcm` 会误报。
+
+---
+
+## 5. 最小可用路径(MVP)
+
+只为跑通 gcc 路线的 `xlings install mcpp` + `mcpp build`:
+
+```
+⓪ 引导第0个 aarch64 mcpp
+ → ① 构建 gcc/glibc/binutils/ninja aarch64(linux-headers 走 scode)
+ → ② 上架 arm64 资产(8 个最小主链包)
+ → ③ libxpkg elfpatch + glibc.lua loader 修正
+ → ⑤ mcpp 4 处硬编码 + install.sh + release.yml aarch64 job
+```
+
+llvm(clang/`import std`)、musl-gcc、DSL 扩展可作为第二阶段。
+
+---
+
+## 6. 关键技术依据(代码出处)
+
+| 结论 | 出处 |
+|---|---|
+| 引擎 arch token = `arm64` | `xlings/src/core/xim/installer.cppm:123-133` `detect_arch_()` |
+| XLINGS_RES 自动拼 arch | `xlings/src/core/xim/installer.cppm:146` `build_xlings_res_url_` |
+| 依赖解析只按 OS 不按 arch | `xlings` resolver/catalog/index 全用 `platform` key |
+| DSL 不支持同平台 per-arch URL | `xim-pkgindex/docs/spec/url-template.md:69-72` |
+| elfpatch loader 只列 x86_64 | `libxpkg/.../elfpatch.lua:287-289,315-317` |
+| mcpp 二进制全静态(musl) | `mcpp/mcpp.toml:24-26` `[target.x86_64-linux-musl] linkage=static` |
+| mcpp 静态链接不挂 glibc payload | `mcpp/src/build/flags.cppm:322-323` |
+| triple 由 `-dumpmachine` 动态产出 | `mcpp/src/toolchain/probe.cppm:260-269` |
+
+---
+
+## 7. Termux/Android (bionic) —— 单列
+
+目标 A(aarch64-linux)做完,**在 Termux 原生(bionic)上仍不能直接用**,因为 Android 用 bionic libc,与 glibc/musl ABI 不兼容,且全生态零 `android` 平台维度。
+
+**额外阻塞:**
+1. xlings/xim-pkgindex 需新增 `android`/`termux` 平台 key(改 `src/platform/`、所有 `entries.find(platform)`、索引数据)。
+2. ELF loader 完全不同(`/system/bin/linker64`、Termux `$PREFIX/lib`),elfpatch 的 ld-linux 假设全失效。
+3. sysroot 在 `$PREFIX`,glibc 探测(`/usr/include`、`features.h`、`/lib64`)全不成立。
+4. 工具链需 NDK `aarch64-linux-android` 或 Termux 自身工具链。
+
+**推荐取巧路线:** 优先做 **`aarch64-linux-musl` 全静态** —— 产物和工具链全静态,**同时绕开 bionic ABI 和 "glibc 能否在 Android 内核运行" 两个变量**。代价是 `musl-gcc.lua` 那套三元组/loader 改动量大(§4 D-1)。
+
+**给 #143 报告人的最快验证:** 出一个 `aarch64-linux-musl` 全静态 mcpp,让其在 Termux 原生直接跑(不进 proot)试探;或先用 aarch64-linux glibc 包在 proot-distro(Ubuntu)里验证 self-contained 路线成立。
+
+---
+
+## 8. 风险与待确认
+
+- [ ] LLVM 官方 `Linux-ARM64` libc++ 是否带 `std.cppm` + `-print-library-module-manifest-path`(决定 aarch64 上 `import std` 是否开箱即用)。
+- [ ] GitHub `ubuntu-24.04-arm` runner 在本项目 org 是否可用(决定原生构建 vs 交叉)。
+- [ ] `scode:linux-headers` 是否已有 aarch64 源(委托型,§4 D-3)。
+- [ ] CN 镜像(gitcode)aarch64 资产同步是否需要额外脚本(参考 [[release-publish-pipeline]] 的双端镜像流程)。
+</content>
+</invoke>

--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -1,0 +1,126 @@
+name: ci-aarch64
+
+# aarch64 / Android closed-loop CI.
+#
+# Cross-builds mcpp (and a tiny `import std` project) from x86_64 to
+# `aarch64-linux-musl` using the cross toolchain delivered through the xlings
+# ecosystem (xim:aarch64-linux-musl-gcc -> xlings-res), then runs the produced
+# binaries under qemu-aarch64.
+#
+# Why this validates Android: the artifact is a *fully static* musl aarch64 ELF
+# (no PT_INTERP, no glibc/bionic runtime dep), which is exactly what runs
+# natively in Termux on an Android phone. qemu-aarch64 is the reliable CI proxy
+# for "does this aarch64 binary actually execute".
+#
+# Depends on: openxlings/xim-pkgindex (aarch64-linux-musl-gcc.lua) and
+# xlings-res/aarch64-linux-musl-gcc (the prebuilt toolchain asset).
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cross-build-and-run:
+    name: cross-build aarch64 (host x86_64) + qemu run
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      MCPP_HOME: /home/runner/.mcpp
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache mcpp sandbox
+        uses: actions/cache@v4
+        with:
+          path: ~/.mcpp
+          key: mcpp-sandbox-${{ runner.os }}-aarch64-${{ hashFiles('mcpp.toml', '.xlings.json') }}
+          restore-keys: |
+            mcpp-sandbox-${{ runner.os }}-aarch64-
+
+      - name: Cache xlings
+        uses: actions/cache@v4
+        with:
+          path: ~/.xlings
+          key: xlings-${{ runner.os }}-v2-${{ hashFiles('.xlings.json') }}
+          restore-keys: |
+            xlings-${{ runner.os }}-v2-
+
+      - name: Install qemu-user-static (run aarch64 binaries)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y qemu-user-static
+          qemu-aarch64-static --version | head -1
+
+      - name: Bootstrap mcpp via xlings
+        env:
+          XLINGS_NON_INTERACTIVE: '1'
+          XLINGS_VERSION: '0.4.30'
+        run: |
+          tarball="xlings-${XLINGS_VERSION}-linux-x86_64.tar.gz"
+          curl -fsSL -o "/tmp/${tarball}" \
+            "https://github.com/d2learn/xlings/releases/download/v${XLINGS_VERSION}/${tarball}"
+          tar -xzf "/tmp/${tarball}" -C /tmp
+          "/tmp/xlings-${XLINGS_VERSION}-linux-x86_64/subos/default/bin/xlings" self install
+          export PATH="$HOME/.xlings/subos/default/bin:$PATH"
+          xlings --version
+          xlings install mcpp -y
+          echo "XLINGS_BIN=$HOME/.xlings/subos/default/bin/xlings" >> "$GITHUB_ENV"
+          echo "MCPP_BOOT=$HOME/.xlings/subos/default/bin/mcpp" >> "$GITHUB_ENV"
+
+      - name: Cache target/
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: mcpp-target-${{ runner.os }}-aarch64-${{ hashFiles('src/**', 'mcpp.toml', 'mcpp.lock') }}
+          restore-keys: |
+            mcpp-target-${{ runner.os }}-aarch64-
+
+      - name: Self-host build (bootstrap mcpp -> fresh mcpp with host-aware cross logic)
+        run: |
+          export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
+          "$XLINGS_BIN" config --mirror GLOBAL 2>/dev/null || true
+          "$MCPP_BOOT" self config --mirror GLOBAL 2>/dev/null || true
+          "$MCPP_BOOT" build
+          MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
+          test -x "$MCPP"
+          "$MCPP" self config --mirror GLOBAL
+          echo "MCPP=$MCPP" >> "$GITHUB_ENV"
+
+      - name: Cross-build a tiny `import std` project -> aarch64, run under qemu
+        run: |
+          export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
+          work=$(mktemp -d); cd "$work"
+          cat > mcpp.toml <<'EOF'
+          [package]
+          name = "aacheck"
+          version = "0.0.1"
+          EOF
+          mkdir -p src
+          printf 'import std;\nint main(){ std::println("aacheck aarch64 ok"); }\n' > src/main.cpp
+          "$MCPP" build --target aarch64-linux-musl
+          bin=$(find target/aarch64-linux-musl -type f -name aacheck | head -1)
+          echo "== file =="; file "$bin"
+          file "$bin" | grep -q "ARM aarch64" || { echo "NOT aarch64"; exit 1; }
+          file "$bin" | grep -q "statically linked" || { echo "NOT static"; exit 1; }
+          echo "== qemu run =="; out=$(qemu-aarch64-static "$bin"); echo "$out"
+          [ "$out" = "aacheck aarch64 ok" ] || { echo "unexpected output"; exit 1; }
+
+      - name: Cross-build mcpp itself -> aarch64 static, smoke-run under qemu
+        run: |
+          export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
+          "$MCPP" build --target aarch64-linux-musl
+          mbin=$(find target/aarch64-linux-musl -type f -name mcpp | head -1)
+          echo "== file =="; file "$mbin"
+          file "$mbin" | grep -q "ARM aarch64" || { echo "NOT aarch64"; exit 1; }
+          file "$mbin" | grep -q "statically linked" || { echo "NOT static"; exit 1; }
+          echo "== qemu mcpp --version =="
+          ver=$(qemu-aarch64-static "$mbin" --version)
+          echo "$ver"
+          echo "$ver" | grep -q "mcpp" || { echo "mcpp --version failed under qemu"; exit 1; }

--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -70,6 +70,10 @@ jobs:
           "/tmp/xlings-${XLINGS_VERSION}-linux-x86_64/subos/default/bin/xlings" self install
           export PATH="$HOME/.xlings/subos/default/bin:$PATH"
           xlings --version
+          # Refresh the package index so a cached ~/.xlings still sees newly
+          # published packages (xim:aarch64-linux-musl-gcc).
+          xlings config --mirror GLOBAL 2>/dev/null || true
+          xlings update -y 2>/dev/null || xlings update 2>/dev/null || true
           xlings install mcpp -y
           echo "XLINGS_BIN=$HOME/.xlings/subos/default/bin/xlings" >> "$GITHUB_ENV"
           echo "MCPP_BOOT=$HOME/.xlings/subos/default/bin/mcpp" >> "$GITHUB_ENV"

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -25,6 +25,14 @@ windows = "llvm@20.1.7"
 toolchain = "gcc@15.1.0-musl"
 linkage   = "static"
 
+# aarch64 (ARM64) static target. No explicit toolchain: mcpp's host-aware
+# convention picks it — on an aarch64 host this is a NATIVE build (xim:musl-gcc),
+# on an x86_64 host a CROSS build (xim:aarch64-linux-musl-gcc, gcc 15.1.0 from
+# musl-cross-make). linkage=static is also implied by the -musl suffix; kept
+# explicit for clarity. See .agents/docs/2026-06-22-aarch64-android-mvp-design.md.
+[target.aarch64-linux-musl]
+linkage = "static"
+
 # Eat our own dog food: mcpp uses mcpplibs.cmdline for argument parsing.
 # NOTE: uses legacy dotted-key syntax so older bootstrapping mcpp versions
 # (pre-0.0.6, which don't understand [dependencies.<ns>] subtables) can

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -202,7 +202,11 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         auto sysroot_flag = " --sysroot=" + escape_path(plan.toolchain.sysroot);
         compile_toolchain_flags = sysroot_flag;
         link_toolchain_flags = sysroot_flag;
-        if (plan.toolchain.payloadPaths && !plan.toolchain.payloadPaths->linuxInclude.empty()) {
+        // Self-contained musl toolchains ship their own kernel headers in the
+        // sysroot; for a cross target the host (x86) linux-headers payload is
+        // the wrong arch, so don't supplement it.
+        if (!mcpp::toolchain::is_musl_target(plan.toolchain)
+            && plan.toolchain.payloadPaths && !plan.toolchain.payloadPaths->linuxInclude.empty()) {
             auto sysrootLinux = plan.toolchain.sysroot / "usr" / "include" / "linux" / "limits.h";
             if (!std::filesystem::exists(sysrootLinux))
                 compile_toolchain_flags += " -isystem" + escape_path(plan.toolchain.payloadPaths->linuxInclude);

--- a/src/build/prepare.cppm
+++ b/src/build/prepare.cppm
@@ -506,17 +506,27 @@ prepare_build(bool print_fingerprint,
             if (!it->second.linkage.empty())   m->buildConfig.linkage = it->second.linkage;
         }
         // Convention: "*-musl" target without an explicit `[target.X]`
-        // override gets the canonical musl-gcc spec the rest of mcpp
-        // uses internally. We can't just append "-musl" to the inherited
-        // toolchain version because xim doesn't have a `musl-gcc@<host
-        // gcc version>` for every gcc release — gcc 16.1 has no musl
-        // variant yet, only 9.4 / 11.5 / 13.3 / 15.1 do. Picking 15.1.0
-        // as the static default matches what mcpp itself uses for
-        // `mcpp build --target x86_64-linux-musl` (see mcpp.toml).
+        // override gets a canonical musl toolchain spec. The choice is
+        // host-aware:
+        //   - target arch == host arch → NATIVE build, use `gcc@15.1.0-musl`
+        //     (→ xim:musl-gcc; XLINGS_RES picks the host-matching asset).
+        //   - target arch != host arch → CROSS build, use the target-named
+        //     cross toolchain `<triple>-gcc@15.1.0` (→ xim:<triple>-gcc),
+        //     e.g. building aarch64 on an x86_64 host.
+        // We pin 15.1.0 because xim only has musl variants for 9.4 / 11.5 /
+        // 13.3 / 15.1 (gcc 16.1 has none yet); 15.1.0 matches what mcpp uses
+        // for `mcpp build --target x86_64-linux-musl` (see mcpp.toml).
         if (endswith(overrides.target_triple, "-musl")
             && (it == m->targetOverrides.end() || it->second.toolchain.empty()))
         {
-            tcSpec = "gcc@15.1.0-musl";
+            auto dash = overrides.target_triple.find('-');
+            std::string targetArch = dash == std::string::npos
+                ? overrides.target_triple
+                : overrides.target_triple.substr(0, dash);
+            if (targetArch.empty() || targetArch == mcpp::platform::host_arch)
+                tcSpec = "gcc@15.1.0-musl";                        // native
+            else
+                tcSpec = overrides.target_triple + "-gcc@15.1.0";  // cross
         }
         if (endswith(overrides.target_triple, "-musl")
             && m->buildConfig.linkage.empty()) {
@@ -532,6 +542,11 @@ prepare_build(bool print_fingerprint,
                 "[toolchain].{} = '{}' is invalid; expected '<pkg>@<version>'",
                 kCurrentPlatform, *tcSpec));
         }
+        // For a cross `--target <triple>` build, carry the triple into the spec
+        // so a musl toolchain resolves its `<triple>-g++` cross frontend
+        // (e.g. aarch64-linux-musl-g++) instead of the host x86_64 one.
+        if (spec->isMusl && !overrides.target_triple.empty())
+            spec->targetTriple = overrides.target_triple;
         auto pkg = mcpp::toolchain::to_xim_package(*spec);
 
         auto cfg = get_cfg();

--- a/src/platform/common.cppm
+++ b/src/platform/common.cppm
@@ -73,6 +73,24 @@ constexpr std::string_view name =
     "unknown";
 #endif
 
+// Host CPU architecture. Uses the GNU triple spelling (`aarch64`, not the
+// `arm64` token xlings uses for its release assets) so it composes directly
+// with target triples like `aarch64-linux-musl`. Used to decide native vs.
+// cross toolchain selection (target arch == host_arch → native musl-gcc;
+// otherwise a `<triple>-gcc` cross toolchain).
+constexpr std::string_view host_arch =
+#if defined(__aarch64__) || defined(_M_ARM64)
+    "aarch64";
+#elif defined(__x86_64__) || defined(_M_X64)
+    "x86_64";
+#elif defined(__i386__) || defined(_M_IX86)
+    "x86";
+#elif defined(__riscv) && (__riscv_xlen == 64)
+    "riscv64";
+#else
+    "unknown";
+#endif
+
 // xpkg platform key (used by resolver for xpkg.lua lookups).
 // Note: macOS uses "macosx" (not "macos") for xpkg compatibility.
 constexpr std::string_view xpkg_platform =

--- a/src/toolchain/gcc.cppm
+++ b/src/toolchain/gcc.cppm
@@ -107,9 +107,15 @@ std::string std_module_build_command(const Toolchain& tc,
                                      const std::filesystem::path& cacheDir,
                                      std::string_view sysrootFlag,
                                      std::string_view cppStandardFlag) {
+    // musl-cross-make toolchains bundle their own as/ld (and for a cross
+    // target the host's binutils would mis-assemble, e.g. `as: unrecognized
+    // option '-EL'`). Only the glibc gcc needs an external binutils package
+    // wired via -B. Mirrors the guard in build/flags.cppm.
     std::string bFlag;
-    if (auto binutilsBin = find_binutils_bin(tc.binaryPath)) {
-        bFlag = std::format(" -B'{}'", binutilsBin->string());
+    if (!is_musl_target(tc)) {
+        if (auto binutilsBin = find_binutils_bin(tc.binaryPath)) {
+            bFlag = std::format(" -B'{}'", binutilsBin->string());
+        }
     }
 
     return std::format(

--- a/src/toolchain/registry.cppm
+++ b/src/toolchain/registry.cppm
@@ -14,6 +14,10 @@ struct ToolchainSpec {
     std::string compiler;    // user-facing compiler name, namespace-stripped
     std::string version;     // user-facing version, may include -musl
     bool        isMusl = false;
+    // Target triple (e.g. "aarch64-linux-musl") when building for a non-host
+    // target via `--target`. For musl toolchains the cross frontend program is
+    // named `<triple>-g++`, so this drives frontend selection. Empty = host.
+    std::string targetTriple;
 };
 
 struct XimToolchainPackage {
@@ -79,8 +83,16 @@ std::string strip_namespace(std::string compiler) {
 }
 
 std::vector<std::string> frontend_candidates_for(std::string_view ximName,
-                                                 bool isMusl) {
-    if (isMusl) return {"x86_64-linux-musl-g++", "g++"};
+                                                 bool isMusl,
+                                                 std::string_view targetTriple = {}) {
+    if (isMusl) {
+        // Cross musl toolchains expose `<triple>-g++` (e.g.
+        // aarch64-linux-musl-g++). Prefer the triple-specific frontend so a
+        // `--target aarch64-linux-musl` build never falls back to the host g++.
+        if (!targetTriple.empty())
+            return {std::string(targetTriple) + "-g++", "g++"};
+        return {"x86_64-linux-musl-g++", "g++"};
+    }
     if (ximName == "gcc") return {"g++"};
     if (ximName == "llvm") return mcpp::toolchain::llvm::frontend_candidates();
     if (ximName == "msvc") return {"cl.exe"};
@@ -122,7 +134,12 @@ parse_toolchain_spec(std::string compilerArg,
     ToolchainSpec spec;
     spec.compiler = std::move(compilerArg);
     spec.version  = std::move(versionArg);
-    spec.isMusl   = spec.compiler == "musl-gcc" || ends_with(spec.version, "-musl");
+    // musl is signalled three ways: the canonical host-native `musl-gcc`, a
+    // `<ver>-musl` version suffix, or a target-named cross/native toolchain
+    // like `aarch64-linux-musl-gcc` (the compiler name carries the triple).
+    spec.isMusl   = spec.compiler == "musl-gcc"
+                 || ends_with(spec.version, "-musl")
+                 || ends_with(spec.compiler, "-linux-musl-gcc");
     return spec;
 }
 
@@ -130,6 +147,20 @@ XimToolchainPackage to_xim_package(const ToolchainSpec& spec) {
     XimToolchainPackage pkg;
     pkg.displayCompiler = spec.compiler;
     pkg.displayVersion  = spec.version;
+
+    // Target-named musl toolchain, e.g. "aarch64-linux-musl-gcc". The compiler
+    // name IS the xim package name and encodes the target triple, so it serves
+    // both cross (x86 host → aarch64) and on-target native builds — xlings'
+    // XLINGS_RES sentinel picks the host-matching prebuilt asset. The frontend
+    // is `<triple>-g++` (triple = name minus the trailing "-gcc").
+    if (ends_with(spec.compiler, "-linux-musl-gcc")) {
+        pkg.ximName    = spec.compiler;
+        pkg.ximVersion = spec.version;
+        std::string triple = spec.compiler.substr(0, spec.compiler.size() - 4);
+        pkg.frontendCandidates = {triple + "-g++", "g++"};
+        pkg.needsGccPostInstallFixup = false;
+        return pkg;
+    }
 
     std::string ximCompiler = spec.compiler;
     if (mcpp::toolchain::llvm::is_alias(ximCompiler))
@@ -145,7 +176,8 @@ XimToolchainPackage to_xim_package(const ToolchainSpec& spec) {
             pkg.ximVersion.resize(pkg.ximVersion.size() - 5);
     }
 
-    pkg.frontendCandidates = frontend_candidates_for(pkg.ximName, spec.isMusl);
+    pkg.frontendCandidates = frontend_candidates_for(pkg.ximName, spec.isMusl,
+                                                     spec.targetTriple);
     pkg.needsGccPostInstallFixup = spec.compiler == "gcc" && !spec.isMusl;
     return pkg;
 }
@@ -218,7 +250,13 @@ std::filesystem::path archive_tool(const Toolchain& tc) {
             return *binutilsBin / "ar";
     }
 
-    auto muslAr = tc.binaryPath.parent_path() / "x86_64-linux-musl-ar";
+    // musl `ar` is the triple-prefixed cross tool (e.g. aarch64-linux-musl-ar),
+    // sitting next to the frontend. Derive from the resolved target triple so
+    // cross targets pick the matching archiver instead of the x86_64 one.
+    std::string arName = !tc.targetTriple.empty()
+        ? tc.targetTriple + "-ar"
+        : "x86_64-linux-musl-ar";
+    auto muslAr = tc.binaryPath.parent_path() / arName;
     if (std::filesystem::exists(muslAr)) return muslAr;
     return {};
 }

--- a/src/toolchain/stdmod.cppm
+++ b/src/toolchain/stdmod.cppm
@@ -236,7 +236,10 @@ std::expected<StdModule, StdModError> ensure_built(
         // Supplement with -isystem for linux kernel headers from payload
         // if the probed sysroot is missing them.
         sysroot_flag = std::format(" --sysroot='{}'", tc.sysroot.string());
-        if (tc.payloadPaths && !tc.payloadPaths->linuxInclude.empty()) {
+        // Skip the external linux-headers payload for self-contained musl
+        // toolchains: their sysroot ships kernel headers, and for a cross
+        // target the host (x86) headers are the wrong arch.
+        if (!is_musl_target(tc) && tc.payloadPaths && !tc.payloadPaths->linuxInclude.empty()) {
             auto sysrootLinux = tc.sysroot / "usr" / "include" / "linux" / "limits.h";
             if (!std::filesystem::exists(sysrootLinux))
                 sysroot_flag += std::format(" -isystem'{}'", tc.payloadPaths->linuxInclude.string());


### PR DESCRIPTION
Closes the aarch64/Android gap from #143. mcpp can now cross-compile to a **fully static aarch64 ELF** that runs on Android/Termux with no bionic dependency.

### Validated end-to-end
`mcpp build --target aarch64-linux-musl` cross-compiles (1) a tiny `import std` program and (2) **mcpp itself** to static aarch64 ELFs that run under qemu-aarch64 (`mcpp --version` → `mcpp 0.0.58`). x86_64-linux-musl native path regression-clean.

### Toolchain selection (host-aware native vs cross)
- `platform/common.cppm`: `host_arch`.
- `build/prepare.cppm`: `*-musl` convention picks native (`musl-gcc`, target==host) vs cross (`<triple>-gcc`) by host arch.
- `toolchain/registry.cppm`: recognize target-named musl specs (`aarch64-linux-musl-gcc`); derive frontend `<triple>-g++` / ar from the triple instead of hardcoded x86_64.
- `mcpp.toml`: `[target.aarch64-linux-musl]`.

### Cross-correctness fixes
mcpp applied the glibc-gcc model to the self-contained musl-cross-make toolchain:
- `gcc.cppm`: std-module build skips external binutils `-B` for musl (host x86 `as` else fails `unrecognized option '-EL'`).
- `stdmod.cppm` + `flags.cppm`: skip external linux-headers `-isystem` for musl.

### CI
- `ci-aarch64.yml`: cross-build + qemu-run, using the toolchain delivered via the ecosystem.

### Ecosystem dependencies (companion PRs / assets)
- `openxlings/xim-pkgindex#294` — `aarch64-linux-musl-gcc` package.
- `xlings-res/aarch64-linux-musl-gcc` — prebuilt toolchain asset.

Design + analysis in `.agents/docs/`.