### PR TITLE
chore(manifest): use TOML-native namespaced dep for mcpplibs.cmdline

### DIFF
--- a/mcpp.toml
+++ b/mcpp.toml
@@ -34,11 +34,12 @@ linkage   = "static"
 linkage = "static"
 
 # Eat our own dog food: mcpp uses mcpplibs.cmdline for argument parsing.
-# NOTE: uses legacy dotted-key syntax so older bootstrapping mcpp versions
-# (pre-0.0.6, which don't understand [dependencies.<ns>] subtables) can
-# still parse this file during the self-host release build.
+# TOML-native namespaced form: `mcpplibs.cmdline` is the dotted subtable
+# `[dependencies.mcpplibs] cmdline = "0.0.1"` ⇒ identity (mcpplibs, cmdline).
+# The bootstrap mcpp used by the self-host build (xlings install mcpp, well
+# past 0.0.6) understands this, so the legacy quoted form is no longer needed.
 [dependencies]
-"mcpplibs.cmdline" = "0.0.1"
+mcpplibs.cmdline = "0.0.1"
 
 # `mcpp build` ignores [dev-dependencies]; only `mcpp test` resolves them.
 [dev-dependencies]


### PR DESCRIPTION
Drop the legacy quoted dotted key in the self-host manifest:

```diff
-"mcpplibs.cmdline" = "0.0.1"
+mcpplibs.cmdline = "0.0.1"
```

`mcpplibs.cmdline = "0.0.1"` under `[dependencies]` is the TOML-native dotted subtable `[dependencies.mcpplibs] cmdline = "0.0.1"`, which mcpp's manifest parser resolves to the same identity `(mcpplibs, cmdline)` as the quoted legacy form (form (2) vs form (3) in `src/manifest.cppm`).

The quotes existed only so a **pre-0.0.6** bootstrap mcpp (which couldn't parse `[dependencies.<ns>]` subtables) could still read this file during the self-host release build. That constraint is moot: the self-host build now bootstraps via `xlings install mcpp` (latest published, well past 0.0.6).

**Verified:** a clean self-host `mcpp build` with the published bootstrap (0.0.56) resolves `mcpplibs.cmdline v0.0.1` from the unquoted form and links green.