### PR TITLE
fix(index): offline-first refresh-on-miss covers version-miss too

### DIFF
--- a/src/pm/package_fetcher.cppm
+++ b/src/pm/package_fetcher.cppm
@@ -775,6 +775,23 @@ Fetcher::resolve_xpkg_path(std::string_view target,
             // for large toolchain packages and keeps the real failure output
             // visible to CI/users when it still fails.
             mcpp::fallback::clean_incomplete_install(verdir);
+
+            // Offline-first refresh-on-miss: the failure may be a stale local
+            // index that doesn't list this package@version (e.g. installing a
+            // NEW toolchain version when the cached index predates it). The
+            // pre-install gate only refreshes when the package *file* is
+            // missing, so a version-miss slips through. Refresh the index ONCE
+            // here — on an actual install miss — then retry. Steady-state
+            // installs (package+version already local) succeed on the first
+            // try and never reach this path, so they stay offline.
+            if (parsed.indexName == "xim") {
+                mcpp::xlings::Env refreshEnv{ cfg_.xlingsBinary, cfg_.xlingsHome() };
+                mcpp::log::verbose("fetcher",
+                    std::format("install failed for {}; refreshing index before retry",
+                                targets[0]));
+                mcpp::xlings::update_index(refreshEnv, /*quiet=*/true);
+            }
+
             mcpp::log::verbose("fetcher",
                 std::format("interface install failed for {}; retrying direct xlings install",
                             targets[0]));


### PR DESCRIPTION
## Problem
mcpp main's `ci-linux` failed on the **LLVM toolchain step** (on a docs-only merge, #160):
```
[error] package 'xim:llvm@20.1.7' not found
error: install failed: xlings install of 'xim:llvm@20.1.7' failed
```
This is a **resolution** failure (the local index doesn't list the version), not a download error.

## Root cause
WS3's offline-first gate (`ensure_official_package_index_fresh`) refreshes only when the package **file** is missing locally. A stale-but-present `llvm.lua` that lacks the requested **version** (20.1.7) slips through → no refresh → "not found". `toolchain install` → `resolve_xpkg_path` → that gate, so it's hit by any new-version install against a stale cached index.

## Fix
In the install-failure path (`exitCode != 0`), refresh the xim index **once** before the existing direct-install retry — **lazy refresh-on-miss**:
- Steady-state installs (package + version already local) succeed on the first try and never reach this path → stay offline (the Termux hang fix is preserved).
- An actual miss (package **or** version) now triggers one refresh + retry.

Honors the "缺包/缺版本就刷新一次" intent at the version level, not just package-file level.

Build: clean self-host. The ci-linux LLVM toolchain step exercises this directly.