### PR TITLE
feat(toolchain): dimensional ABI compatibility model (fix glibc C-lib under libc++)

### DIFF
--- a/.agents/docs/2026-06-27-abi-compat-model-single-pr-design.md
+++ b/.agents/docs/2026-06-27-abi-compat-model-single-pr-design.md
@@ -1,0 +1,166 @@
+# 设计:ABI/工具链兼容性「维度化」模型 —— 一步到位的单 PR 方案
+
+**日期**: 2026-06-27
+**仓库**: `mcpp-community/mcpp`
+**关联**: 根因分析见同目录 `2026-06-27-glfw-abi-glibc-vs-libcxx-conflation-analysis.md`(§9 给了 L0–L3 分层路线)。
+**本文目标**: 把那套架构**收敛成一个可评审、可合并的 PR**——交付**完整且正确的「依赖↔工具链」兼容性*模型与校验***,
+彻底替换 `prepare.cppm` 里临时搓 `tcAbi` 串的做法。
+
+---
+
+## 1. 一句话范围
+
+**单 PR = 用一个结构化、维度化、按暴露面推断、未声明即 don't-care 的「ABI 兼容性子系统」替换扁平 `abi:` 门控;
+保持旧 `abi:glibc` 配方零改动可用;给逐维精确诊断。** 工具链解析顺序**不动**(仍 resolve-then-validate),
+只是把「validate」做对、做全。约束求解式的**自动重选**(L3)显式不在本 PR(理由见 §8),但留好接缝。
+
+判据:本 PR 落地后,§关联文档 §2 的三行工程在 `gcc@16.1.0` 与 `llvm@20.1.7` 下**都** `Finished`;
+`*-linux-musl` + `abi:glibc` 仍正确报错;且这套修复对**任意维度**的冒充(不止 libc++/glibc)都成立。
+
+## 2. 设计要点(为什么这样就「架构合理」)
+
+1. **每维单一可信来源**:libc/arch/os ← 目标三元组;cxxStdlib/cxxAbi ← 编译器/`stdlibId`。**禁止跨维推导**(本 bug 之源)。
+2. **未声明即 don't-care**:依赖只约束它真正在乎的维,匹配器跳过其余维。扁平串的死穴正是「无法表达不在乎」。
+3. **相关性随暴露面**:某维是否相关,由依赖**跨边界暴露了什么**决定(源码 C 库 vs 预编译 C++ 库),可由描述符推断。
+4. **对称同构**:工具链与依赖用**同一套** `AbiDimensions` 词汇表达;匹配 = 逐维比对。删掉 `prepare.cppm` 的特例分支。
+5. **向后兼容**:旧 `abi:glibc` 字符串解析期映射到 `{libc=glibc}`,**配方零改动**;新结构是可选增强。
+
+## 3. 新增模块 `mcpp.toolchain.abi`（核心类型 + 纯函数,易测）
+
+```cpp
+export module mcpp.toolchain.abi;
+import std; import mcpp.toolchain.model;
+export namespace mcpp::toolchain {
+
+enum class AbiDim { Libc, CxxStdlib, Arch, Os, CxxAbi };
+
+// 工具链的 ABI 坐标(派生视图,字段都来自已有 Toolchain)
+struct AbiProfile {
+    std::string libc;       // glibc | musl | msvcrt | macos        ← targetTriple
+    std::string cxxStdlib;  // libstdc++ | libc++ | msvc-stl         ← stdlibId
+    std::string arch;       // x86_64 | aarch64 | …                  ← targetTriple
+    std::string os;         // linux | darwin | windows              ← targetTriple
+    std::string cxxAbi;     // itanium | msvc                        ← compiler/triple
+};
+AbiProfile abi_profile(const Toolchain&);     // 唯一推导处,杜绝散落 ad-hoc 串
+
+// 依赖的约束:每维 optional,nullopt = don't-care
+struct AbiRequirement {
+    std::optional<std::string> libc, cxxStdlib, arch, os, cxxAbi;
+    std::string source;     // 诊断用来源:"compat.glfw (abi:glibc)" / "inferred" / "requires_abi"
+};
+
+struct AbiMismatch { AbiDim dim; std::string need, got, source; };
+
+// 逐维比对;只看 req 里非空的维。返回所有不匹配(空 = 兼容)。
+std::vector<AbiMismatch> abi_check(const AbiProfile&, const AbiRequirement&);
+std::string_view dim_name(AbiDim);            // 诊断/序列化
+}
+```
+
+`abi_profile` 推导规则(单点实现):
+- `libc`: triple 含 `musl`→musl;含 `-gnu`/`gnueabi`→glibc;含 `windows-msvc`→msvcrt;含 `apple`/`darwin`→macos。
+- `arch`/`os`: 解析 triple。
+- `cxxStdlib`: 直接取 `tc.stdlibId`(已正确)。
+- `cxxAbi`: `compiler==MSVC` 或 triple 含 `-msvc`→msvc;否则 itanium。
+
+> 注:这些都是**已有信息**的重新组织;不引入新探测。`abi_profile` 即「把 §关联文档 §6.1 的正确推导,扩展到全维度」。
+
+## 4. 依赖约束的三个来源（解析期 → `AbiRequirement`，优先级由高到低）
+
+1. **显式结构化**(新增,可选):描述符 `mcpp` 段里
+   ```lua
+   requires_abi = { libc = "glibc" }                         -- 只认 libc
+   -- requires_abi = { libc="glibc", cxxstdlib="libstdc++" } -- 预编译 C++ 库才需要
+   ```
+2. **旧能力串**(`RuntimeConfig.capabilities` 里的 `abi:<x>`):`abi:glibc`→`{libc=glibc}`、`abi:musl`→`{libc=musl}`。
+   **本 PR 不要求改任何现有配方**——glfw 的 `abi:glibc` 自动变成「只约束 libc」,clang 即通过。
+3. **暴露面推断**(§5):仅填**前两者未指定**的维。显式恒胜推断。
+
+解析落点:`src/manifest.cppm` 的 `RuntimeConfig` 旁加 `AbiRequirement abi;`;xpkg/manifest 解析处把
+`capabilities` 里 `abi:` 前缀项与新 `requires_abi` 表归并进去(`abi:` 仍保留在 capabilities 里供 doctor 展示,不破坏现状)。
+
+## 5. 暴露面推断（L2，安全:只「相关性」判定,绝不凭空收紧）
+
+由描述符已有信息判「形态」,从而决定哪些维**相关**:
+- `isPrebuilt` = 有 `runtime.libraryDirs`/`dlopenLibs` 且无源码编译产物(预编译二进制,ABI 已烘焙)。
+- `isCOnly` = `cStandard` 非空且无导出模块/无 `.cpp/.cppm`(纯 C,接口只 C 符号)。
+
+规则(只对**未显式声明**的维生效):
+
+| 形态 | libc | arch/os | cxxStdlib / cxxAbi |
+|---|---|---|---|
+| 源码构建(C 或 C++) | 仅当链系统库/`dlopenLibs` 非空时相关 | 同左 | **永不相关**(与项目同工具链编译,构造即兼容) |
+| 预编译 **C** 二进制 | 相关 | 相关 | 不相关 |
+| 预编译 **C++** 且接口暴露 `std::*` | 相关 | 相关 | **相关** |
+
+**关键不变式:推断只决定「某维是否纳入校验」,从不替依赖编造更严的取值。** 因此对**所有现存包**(都未显式声明 cxxstdlib)
+本 PR 只会**放宽**、不会**误伤**——这是它能「零配方改动且不回归」的根本保证。glfw=源码 C 库 → cxxStdlib 永不纳入 → clang 通过。
+
+> 为控规模:L2 实现成一个纯函数 `infer_relevant_dims(manifest) → set<AbiDim>`,`abi_check` 调用时按它过滤。
+> 即便先只接「源码 C/C++ → 不纳入 cxxStdlib」这一条最关键规则,也已覆盖全部现网场景;其余行可留 TODO 但**接口先就位**。
+
+## 6. 替换 `prepare.cppm` 的校验块
+
+`src/build/prepare.cppm:2467-2491` 整段删除,替换为:
+```cpp
+const auto prof = mcpp::toolchain::abi_profile(ctx.tc);
+const auto relevant = mcpp::toolchain::infer_relevant_dims(/*per-dep manifest*/);
+for (auto& [depId, req] : ctx.plan.abiRequirements) {     // 由 plan 收集(见 §7)
+    for (auto& mm : abi_check(prof, req.filtered_by(relevant[depId]))) {
+        return std::unexpected(render_abi_error(depId, mm, prof));   // §7 诊断
+    }
+}
+```
+`tcAbi` 字符串及其 `stdlibId == "libc++"` 病灶分支随之消失。
+
+## 7. 诊断（逐维、可操作）
+
+```
+error: ABI incompatibility for dependency 'compat.glfw'
+       dimension : libc
+       required  : musl            (from: compat.glfw → abi:musl)
+       toolchain : glibc           (llvm@20.1.7, x86_64-unknown-linux-gnu)
+       fix: pick a musl toolchain (e.g. `gcc@16.1.0-musl`) or set [toolchain] in mcpp.toml.
+```
+比现状强在:**点名是哪一维**、给出该维的来源与该维专属的修复建议(而非笼统「abi=libc++」)。
+L3 落地后,这里可升级为「已自动选用 X 满足约束」。
+
+## 8. 明确不在本 PR（L3:约束求解式自动重选）与接缝
+
+- **不在本 PR**:把「resolve-then-validate」改成「solve-for-compatible-toolchain / 无 pin 自动选」。
+  理由:它**改动工具链解析顺序**(`package-resolution-architecture` 的核心路径),风险面与本「修正校验语义」正交;
+  混进来会让 PR 不可评审。本 PR 让校验**正确**;重选是**解析策略**的独立演进。
+- **接缝(本 PR 先铺好,L3 即插即用)**:
+  1. `ctx.plan.abiRequirements`(§7 收集的并集)就是 L3 求解器的输入,本 PR 已产出。
+  2. `abi_check` 是纯函数 → L3 的「候选工具链 × 约束」打分直接复用。
+  3. 诊断渲染层留 `auto-selected` 文案位。
+
+## 9. 文件级改动清单(单 PR)
+
+| 文件 | 改动 |
+|---|---|
+| `src/toolchain/abi.cppm` (新) | `AbiDim/AbiProfile/AbiRequirement/AbiMismatch`、`abi_profile`、`abi_check`、`dim_name` |
+| `src/toolchain/model.cppm` | 无需改字段;`abi.cppm` 读现有 `targetTriple/stdlibId/compiler` |
+| `src/manifest.cppm` | `RuntimeConfig`(或 manifest)加 `AbiRequirement abi`;解析 `requires_abi` 表 + 归并 `abi:` 串 |
+| `src/build/plan.cppm` | 收集每依赖的 `AbiRequirement` 与形态信息 → `plan.abiRequirements` + `infer_relevant_dims` |
+| `src/build/prepare.cppm` | 删 2467-2491 的 `tcAbi` 块,改调 `abi_check`;新诊断渲染 |
+| `src/doctor.cppm`(可选) | `mcpp doctor`/`why` 展示工具链 `AbiProfile` 与各依赖逐维匹配状态 |
+| `tests/` | §10 |
+| 配方 | **零改动**(`abi:glibc` 经映射继续生效) |
+
+## 10. 测试计划(随 PR）
+
+- **单测(`abi.cppm` 纯函数,最高价值)**:
+  - `abi_profile`:`x86_64-unknown-linux-gnu`+libc++ → `{libc=glibc, cxxStdlib=libc++}`;`...-linux-musl` → `{libc=musl}`。
+  - `abi_check`:`prof{libc=glibc,cxxStdlib=libc++}` × `req{libc=glibc}` → **空**(本 bug 回归锁);× `req{libc=musl}` → libc 维 mismatch;× `req{cxxStdlib=libstdc++}`(仅当 relevant)→ cxxStdlib mismatch。
+  - `infer_relevant_dims`:源码 C 库 → 不含 CxxStdlib;预编译 C++(暴露 std)→ 含。
+- **e2e**:§关联文档 §2 三行工程,`gcc@16.1.0` 与 `llvm@20.1.7` 均 `Finished`;构造 musl 目标 + `abi:glibc` 断言报错且**点名 libc 维**。
+- **回归**:mcpp-index 全量 smoke 在统一 `0.0.67` 下转绿后,把 glfw/imgui-module 的 GL smoke 从 nightly 收回阻塞集(本仓改完发版后,index 侧一行 CI 调整)。
+
+## 11. 评审小结
+
+- **改对一处语义,删一类 bug**:不是补丁式删 if,而是把「ABI 兼容」建模成它本来的多维 don't-care 问题,
+  之后任何维(`_GLIBCXX_USE_CXX11_ABI`、msvc-stl、cross/musl…)都走同一通路。
+- **零配方改动、不回归**:靠「推断只放宽、显式才收紧」的不变式(§5)。
+- **规模可控**:核心是一个纯函数模块 + 一处调用替换;L3 显式划走但接缝就位。

--- a/.agents/docs/2026-06-27-glfw-abi-glibc-vs-libcxx-conflation-analysis.md
+++ b/.agents/docs/2026-06-27-glfw-abi-glibc-vs-libcxx-conflation-analysis.md
@@ -1,0 +1,227 @@
+# 分析报告:`abi:` 能力检查把「libc ABI」与「C++ stdlib」混为一谈 —— glfw 在 clang/libc++ 下误报 ABI mismatch
+
+**日期**: 2026-06-27
+**仓库**: `mcpp-community/mcpp`(core)
+**触发来源**: `mcpp-community/mcpp-index` PR #48 把 CI 的 mcpp 从 `0.0.46` 升到 `0.0.67` 后,
+`smoke_imgui_module.sh`(显式 pin `llvm@20.1.7`)的 `compat.glfw` 传递依赖报错。
+**结论**: **是一个真实的 mcpp core bug**(非配方、非 smoke 脚本问题)。`abi:` 能力检查在推导
+「当前工具链 abi」时,用 **C++ 标准库身份(libc++/libstdc++)** 抢占了 **libc/C-运行时 ABI(glibc/musl)**,
+导致 `clang+libc++`(目标三元组仍是 `*-linux-gnu`,即 glibc)被判成 `abi=libc++`,与纯 C 库 glfw 声明的
+`abi:glibc` 不匹配而**误报**。修复点单一、明确,见 §6。
+
+---
+
+## 1. 症状
+
+```
+error: ABI mismatch: dependency 'compat.glfw' requires abi=glibc but the resolved
+       toolchain 'clang 20.1.7 (x86_64-unknown-linux-gnu)' is abi=libc++.
+       fix: `mcpp toolchain default <glibc-compatible>` (e.g. gcc@16.1.0 for glibc),
+       or set [toolchain] in mcpp.toml.
+```
+
+注意报错里工具链标签自己写着 **`x86_64-unknown-linux-gnu`** —— `gnu` 即 glibc。也就是说:
+**这台工具链在 libc 层就是 glibc**,却被判成 `abi=libc++` 然后拒绝一个 glibc 的 C 库。这本身就自相矛盾。
+
+## 2. 最小复现(本地 0.0.66 / 0.0.67 均复现,3 行工程)
+
+```toml
+# mcpp.toml
+[toolchain]
+default = "llvm@20.1.7"          # 换成 gcc@16.1.0 则通过
+[dependencies.compat]
+glfw = "3.4"
+```
+```cpp
+#define GLFW_INCLUDE_NONE
+#include <GLFW/glfw3.h>
+int main(){ return glfwInit()?0:0; }
+```
+- `default = "gcc@16.1.0"` → `Finished`(stdlibId=libstdc++ → tcAbi 落到 `glibc` → 匹配)。
+- `default = "llvm@20.1.7"` → **上面的 ABI mismatch**(stdlibId=libc++ → tcAbi=`libc++` → 不匹配 `abi:glibc`)。
+
+CI 现场(mcpp-index run 28285632233,`smoke-full-linux`)同一 job 内 `gcc@16.1.0` 连续解析成功 11 次,
+随后 `smoke_imgui_module.sh` 一行 `default = "${MCPP_INDEX_IMGUI_MODULE_TOOLCHAIN:-llvm@20.1.7}"`
+解析到 `llvm@20.1.7 → clang++` 即触发本错误。**与 glfw 的 GLX/窗口/显示无关**,纯属依赖解析期的 ABI 门控。
+
+## 3. 根因:`tcAbi` 推导把两条正交的 ABI 轴压成一条
+
+`src/build/prepare.cppm:2471-2491`(能力驱动的 ABI 强制):
+
+```cpp
+const std::string tcAbi =
+    ctx.tc.targetTriple.find("musl") != std::string::npos ? "musl"
+    : ctx.tc.stdlibId == "libc++"                          ? "libc++"   // ← 病灶
+    : ctx.tc.compiler == mcpp::toolchain::CompilerId::MSVC ? "msvc"
+    :                                                         "glibc";
+for (auto& cap : ctx.plan.runtimeCapabilities) {
+    if (cap.rfind("abi:", 0) != 0) continue;
+    std::string need = cap.substr(4);          // glfw: "glibc"
+    if (need == tcAbi) continue;               // "glibc" != "libc++" → 落入报错
+    ...
+    return std::unexpected("ABI mismatch: ...");
+}
+```
+
+这里把**两条正交的 ABI 轴**塞进了一个 `tcAbi` 字符串:
+
+| 轴 | 取值 | 决定它的东西 | 谁在乎 |
+|---|---|---|---|
+| **A. libc / C 运行时 ABI** | `glibc` / `musl` | **目标三元组**(`-gnu` vs `-musl`) | 链接 **C 库**(glfw、zlib…)、syscall/CRT 兼容性 |
+| **B. C++ 标准库** | `libstdc++` / `libc++` / `msvc-stl` | 编译器/`stdlibId` | 跨 **C++ TU** 传递 `std::*` 类型时的 C++ ABI |
+
+`abi:glibc` 是 glfw 声明的 **A 轴**诉求(「我是 glibc 二进制,别在 musl 上用我」)。而代码里
+`stdlibId == "libc++" ? "libc++"` 这一支,用 **B 轴**的值抢在 `glibc` 兜底之前返回,等于把
+「这台工具链的 C++ 标准库是 libc++」错误地当成了「这台工具链的 libc ABI 是 libc++」。
+
+**关键事实**:`clang+libc++` 在 `x86_64-unknown-linux-gnu` 上,**libc 仍然是 glibc**(libc++ 是 C++
+标准库,不是 libc 替代品;它本身就链接 glibc)。`src/toolchain/clang.cppm:140` 一律把 Linux clang 的
+`stdlibId` 设为 `libc++`,于是**任何** clang 工具链都会被本检查判成 `abi=libc++`,从而拒绝**所有**声明
+`abi:glibc` 的(C)依赖——尽管把 glibc 的 C 库链进 libc++ 的 C++ 程序完全合法(glfw 导出的是 C 符号,
+跟 C++ 标准库选择无关)。
+
+三元组里 `musl` 那一支是**对的**(用三元组判 libc);错的是 `libc++` 这一支——它用 stdlibId 覆盖了
+libc 轴。`abi:` 能力本应只看 A 轴。
+
+## 4. 为什么 0.0.46 不报、0.0.67 报(不是行为回归,是「新增的过严检查」)
+
+- 该能力驱动 ABI 检查随 **`0.0.54`(#129,`e9ed0e9`)** 引入,**晚于 0.0.46**。mcpp-index CI 之前 pin `0.0.46`
+  → 根本没有这道门 → clang/libc++ 构建 glfw 一直「能过」(且实际可链接运行)。升到 `0.0.67` 才第一次撞上。
+- 因此这是「**新检查本身判据有误**」,不是某次行为退化。但表现为「升级即坏」,需在 mcpp 侧修。
+
+## 5. 这是不是 bug?—— 是,且会误伤真实用户
+
+- **正交性**:libc++ 与 glibc 不互斥,是两条轴。把它们对立起来在模型上就是错的。
+- **真实影响面**:`src/toolchain/clang.cppm:140` 使 Linux 下 clang 恒为 `stdlibId=libc++`。任何用户**主动选 clang**
+  (这正是「`import std` 体验更好」的常见动机,也是 imgui-m 模块包 pin `llvm@20.1.7` 的原因)再依赖任何声明
+  `abi:glibc` 的 **C 库**,都会被无理由挡下。当前 index 里 `grep` 到声明 `abi:glibc` 的只有
+  `pkgs/c/compat.glfw.lua` 一个,但这是**给所有未来 C 库挖的坑**——按本应的语义,zlib/lua/mbedtls 等纯 C
+  运行时库若也补 `abi:glibc`(逻辑上它们都该有),就会集体在 clang 下挂掉。
+- **诊断误导**:报错建议 `mcpp toolchain default gcc@16.1.0`——把用户从 clang 赶到 gcc,而真实情况是
+  clang 本可正确构建,只是检查判据错了。
+
+## 6. 修复建议(mcpp core)
+
+### 6.1 主修复(最小、精准):`abi:` 只看 libc 轴(三元组),不看 C++ stdlib
+把 `tcAbi` 的推导改成只表达 **libc/C-运行时 ABI**,删掉 `stdlibId == "libc++"` 这一支:
+
+```cpp
+// abi: 能力 = libc/C-运行时 ABI(glibc / musl / msvc),由目标三元组决定,与 C++ 标准库无关。
+const std::string tcAbi =
+    ctx.tc.targetTriple.find("musl") != std::string::npos ? "musl"
+    : ctx.tc.compiler == mcpp::toolchain::CompilerId::MSVC ? "msvc"
+    :                                                         "glibc";
+```
+这样 `clang+libc++ @ *-linux-gnu` → `glibc`,与 glfw 的 `abi:glibc` 匹配,clang 也能直接构建 C 库;
+`*-linux-musl` 仍正确判 `musl`;MSVC 仍 `msvc`。**单点改动,覆盖本 bug 全部表现。**
+(更稳妥可显式按三元组判:含 `-gnu`/`gnueabi*` → glibc,含 `musl` → musl,Windows/MSVC → msvc。)
+
+### 6.2 如确需限定 C++ 标准库,另立一条独立能力轴(不要塞进 `abi:`)
+若将来有**C++ 库**需要约束 libstdc++/libc++(跨 stdlib 的 C++ ABI 才有意义),用单独命名空间,例如
+`cxxstdlib:libstdc++` / `cxxstdlib:libc++`,且只对「在接口里暴露 `std::*` 的 C++ 库」施加;纯 C 库
+(glfw 等)**不该**带这条。两轴分开校验,互不抢占。
+
+### 6.3 跟进项(代码注释里已挂的 TODO):abi 驱动的工具链「重选」而非「只诊断」
+`prepare.cppm:2467-2470` 注释自陈:工具链在依赖图之前解析,本检查只「诊断/强制」、不「重选」。
+真正的体验改进是:当依赖声明 `abi:musl` 而当前是 glibc(**真**不兼容)时给出明确指引;当只是缺省工具链与
+依赖偏好不一致、且存在兼容工具链时,优先**自动重选**而非直接报错。属增强,非本 bug 必需。
+
+### 6.4 index 侧(可选,治标)
+- `mcpp-index` 已把 GL window/imgui-module 两 smoke 移到 nightly,不阻塞 PR;6.1 落地后
+  `smoke_imgui_module.sh` 即便 pin `llvm@20.1.7` 也能过,可回收进阻塞集。
+- 复核 `compat.glfw` 的 `abi:glibc` 是否应理解为「libc 轴」语义(应是);若按 6.1 修复,语义自洽,无需改配方。
+
+## 7. 建议的回归测试
+- core 单测:构造 `stdlibId=libc++` 且 `targetTriple=x86_64-unknown-linux-gnu` 的工具链 + 一个声明
+  `abi:glibc` 的依赖,断言**不报** ABI mismatch;`...-linux-musl` + `abi:glibc` 断言**报**。
+- e2e:本报告 §2 的三行工程,`llvm@20.1.7` 与 `gcc@16.1.0` 都应 `Finished`。
+
+## 8. 一句话给维护者
+病灶是 `src/build/prepare.cppm:2474` 那一行 `stdlibId == "libc++" ? "libc++"`——它用 C++ 标准库身份
+冒充了 libc ABI。删掉它(§6.1),`abi:` 能力回归「只管 glibc/musl」的本义,clang/libc++ 用户即可正常使用
+glfw 及所有 glibc C 库。复现/证据见 §2–§4。
+
+---
+
+## 9. 更通用的架构方案(分层演进,§6.1 只是 L0)
+
+§6.1 的一行修复能**立刻**止血,但它没有回答根本问题:**「依赖 ↔ 工具链」的兼容性本就是多维的,而当前用
+一个扁平 `abi:<x>` 字符串 + 临时 `tcAbi` 推导去表达,迟早还会在别的维度上重蹈覆辙**(如 `_GLIBCXX_USE_CXX11_ABI`、
+libstdc++↔libc++ 的真·C++ 库、cross/musl、macОS system libc、Windows msvc-stl…)。下面给一套**基于现有类型**
+(`Toolchain` 已有 `targetTriple/stdlibId/compiler/stdlibVersion`;已有 `ProviderCapabilities`/`capabilities_for`
+与包侧 `runtimeCapabilities/runtimeProviders` 两套能力机制)的演进方案,**不推倒重来**。
+
+### 9.0 三条设计原则
+1. **每个维度单一可信来源**:libc/arch/os 由**目标三元组**决定;cxxstdlib/cxxabi 由**编译器**决定。不许跨维推导(本 bug 即跨维)。
+2. **未声明即「不在乎」(don't-care)**:依赖只约束它**真正关心**的维度,其余维度匹配器一律跳过。扁平串的根本毛病是「无法表达不在乎」。
+3. **相关性由「暴露面」决定,而非一刀切**:某维度是否需要匹配,取决于依赖**跨边界暴露了什么**(见 9.3)。这是比 §6.1 更深一层的通用化。
+
+### 9.1 L1 —— 结构化 ABI 画像(取代不透明的 `tcAbi` 串)
+给 `Toolchain` 配一个**派生视图**(字段都已存在,只是没结构化使用):
+```cpp
+struct AbiProfile {
+    std::string libc;       // glibc | musl | msvcrt | system(darwin)   ← 来自 targetTriple
+    std::string cxxStdlib;  // libstdc++ | libc++ | msvc-stl            ← 来自 stdlibId
+    std::string arch;       // x86_64 | aarch64 …                       ← 来自 targetTriple
+    std::string os;         // linux | darwin | windows                 ← 来自 targetTriple
+    std::string cxxAbi;     // itanium | msvc (+ 可选 cxx11abi 标记)    ← 来自 compiler
+};
+AbiProfile abi_profile(const Toolchain&);   // 唯一推导处,杜绝散落的 ad-hoc 串
+```
+`prepare.cppm` 的 `tcAbi` 整段删除,改为查 `AbiProfile`。**本 bug 在 L1 自然消失**(libc 维独立于 cxxStdlib 维)。
+
+### 9.2 L1 —— 能力维度化(`abi:glibc` → 带维度的能力;旧串作糖)
+包侧把单串 `abi:glibc` 升级为**带维度**的约束(或保留旧串作为 `abi:libc=glibc` 的语法糖,**零配方改动即兼容**):
+```lua
+-- 维度化:只约束自己关心的轴,其余 don't-care
+requires_abi = { libc = "glibc" }                       -- glfw:纯 C 库,只认 libc
+-- requires_abi = { libc="glibc", cxxStdlib="libstdc++", cxxAbi="itanium" }  -- 假想的预编译 C++ 库才需要
+```
+匹配器 = **逐维**比对 `requires_abi[d]` 与 `AbiProfile[d]`,未声明的维跳过。`abi:glibc` ≙ `{libc=glibc}` →
+clang(libc=glibc)通过。这把「能不能表达不在乎」从根上解决,而不只是删一支 if。
+
+### 9.3 L2 —— 由「linkage / 暴露面」推断相关维度(让作者基本不用手写)
+最通用的洞见:**一个依赖该约束哪些维度,取决于它跨边界暴露什么**。mcpp 多数 compat 包是**源码构建**,
+源码库用项目工具链编译 → 天然 ABI 自洽。据此可由描述符**自动推断**,免去作者手填、也根除「给 C 库套 cxxstdlib」这类误配:
+
+| 依赖形态(可由描述符推断:有无源码/预编译产物、公开头是 C 还是 C++) | libc | arch/os | cxxStdlib / cxxAbi |
+|---|---|---|---|
+| 源码构建的 **C 库**(glfw、zlib) | 看运行期/host 假设(如 dlopen glibc GL 栈) | — | **不约束** |
+| 源码构建的 **C++ 库** | — | — | **不约束**(与项目同工具链编译,构造即兼容) |
+| 预编译 **C** 二进制 | ✔ | ✔ | 不约束 |
+| 预编译 **C++** 二进制且接口暴露 `std::*` | ✔ | ✔ | **✔** |
+
+即:cxxStdlib 维**仅**对「预编译且在接口里跨 TU 传 `std::*` 的 C++ 库」才相关。glfw 是源码 C 库 → 永远不该被 cxxStdlib 卡住。
+（glfw 的 `abi:glibc` 实质是**运行期/host**诉求:它 dlopen `libGL.so.1` 等、链系统 glibc;这天然落在 libc 维,与构建期 C++ 标准库无关。)
+
+### 9.4 L1 —— 对称的能力模型(删掉 prepare.cppm 里的特例)
+现状有**两套并行**机制:工具链侧 `ProviderCapabilities`(强类型)、包侧 `runtimeCapabilities`(扁平串),
+而 ABI 检查在 `prepare.cppm` 里**另起炉灶**搓 `tcAbi`。统一为:**工具链把自己的 ABI 维度也 advertise 成能力**
+(扩展 `capabilities_for` 产出 `abi:libc=glibc`、`abi:cxxstdlib=libc++`…),检查退化为**逐维的能力集合包含**——
+与其它 host capability(`x11.display`、`opengl.glx.driver`)**同一条通路**,`prepare.cppm` 的 ABI 特例整段删除。
+
+### 9.5 L3 —— 解析即「约束求解」(把「解析后只诊断」升级为「解析出兼容工具链」)
+`prepare.cppm:2467-2470` 注释自陈:工具链在依赖图**之前**解析,故只能诊断、不能重选。通用做法:
+1. 由目标先定**可在图之前确定的维**(arch/os/libc——它们本就来自 target/triple,不依赖依赖图);
+2. 解析依赖图,**收集各依赖的 `requires_abi` 约束并集**;
+3. **有 pin**:校验 pin 满足**硬约束**(如 musl 依赖 vs glibc 工具链——真不兼容),否则给**逐维**精确报错;
+   **无 pin**:从候选工具链里**挑一个满足全部约束**的(按偏好序),而不是默认一个再报错。
+这把「resolve-then-diagnose」变成「solve-for-compatible」,正是注释里挂的 TODO 的正解;且因 libc/arch/os
+在图前已知、只有细粒度约束来自图,**不是完整 CSP,只是一步 refine**,工程可控。
+
+### 9.6 分层落地路线(每层独立可发、向后兼容)
+| 层 | 内容 | 收益 | 风险/工作量 |
+|---|---|---|---|
+| **L0** | §6.1 一行:`abi:` 只看三元组,删 libc++ 支 | 立刻修好本 bug | 极小 |
+| **L1** | `AbiProfile` + 维度化能力(旧串作糖)+ 对称能力模型,删 `tcAbi` 特例 | 模型自洽,杜绝「跨维冒充」全类问题 | 中,改 `prepare`/`provider`/`runtimeCapabilities` 解析 |
+| **L2** | 由 linkage/暴露面**推断**相关维度 | 作者免手写、根除误配默认 | 中,需描述符元信息(已有 language/sources 可推断大部分) |
+| **L3** | 解析期**约束求解 + 自动选工具链** | 声明式、无 pin 也能跑、精确报错 | 较大,触及工具链解析顺序 |
+
+> **建议**:L0 随手发(止血);L1 作为本 issue 的「正解」单独成 PR(它独立消除一整类「维度冒充」bug);
+> L2/L3 作增强按需推进。L1 落地后,`mcpp-index` 可把 imgui-module/glfw 的 GL smoke 从 nightly 收回阻塞集。
+
+### 9.7 与既有设计对齐
+本方案是这些既有文档的自然延伸,不冲突:`2026-06-02-usage-requirements-architecture.md`(依赖暴露=usage requirements,
+正对应 9.3 的「暴露面」)、`2026-05-15-clang-parity-and-toolchain-abstraction.md`(工具链抽象,正对应 9.1 的
+`AbiProfile`)、`2026-06-20-package-resolution-architecture.md`(解析架构,正对应 9.5 的求解化)。建议把
+「ABI/能力维度模型」作为 usage-requirements 的一个子维并入,而非另起体系。

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.67"
+version     = "0.0.68"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/build/prepare.cppm
+++ b/src/build/prepare.cppm
@@ -21,6 +21,7 @@ import mcpp.toolchain.fingerprint;
 import mcpp.toolchain.registry;
 import mcpp.toolchain.stdmod;
 import mcpp.toolchain.post_install;
+import mcpp.toolchain.abi;
 import mcpp.build.plan;
 import mcpp.lockfile;
 import mcpp.config;
@@ -2464,29 +2465,38 @@ prepare_build(bool print_fingerprint,
         }
     }
 
-    // Capability-driven ABI enforcement: if any dependency declares an
-    // `abi:<x>` capability, the resolved toolchain must satisfy it. (Toolchain
-    // is resolved before the dep graph, so this enforces/diagnoses rather than
-    // reselects — abi-driven reselection is a resolution-ordering follow-up.)
+    // Capability-driven ABI enforcement, dimensional (see src/toolchain/abi.cppm
+    // and .agents/docs/2026-06-27-abi-compat-model-single-pr-design.md). Each
+    // dependency may constrain specific toolchain dimensions via `abi:`
+    // capabilities (libc / cxxstdlib / arch / os / cxxabi); UNSPECIFIED
+    // DIMENSIONS ARE DON'T-CARE. The legacy bare form `abi:glibc` maps to the
+    // libc dimension only — so a glibc *C library* (glfw) builds fine under a
+    // clang+libc++ toolchain on `*-linux-gnu` (libc is still glibc), which the
+    // previous single-axis check wrongly rejected. The toolchain is resolved
+    // before the dep graph, so this enforces/diagnoses rather than reselects —
+    // abi-driven reselection is a resolution-ordering follow-up.
     {
-        const std::string tcAbi =
-            ctx.tc.targetTriple.find("musl") != std::string::npos ? "musl"
-            : ctx.tc.stdlibId == "libc++"                          ? "libc++"
-            : ctx.tc.compiler == mcpp::toolchain::CompilerId::MSVC ? "msvc"
-            :                                                         "glibc";
+        const auto prof = mcpp::toolchain::abi_profile(ctx.tc);
+        std::vector<mcpp::toolchain::AbiConstraint> constraints;
         for (auto& cap : ctx.plan.runtimeCapabilities) {
-            if (cap.rfind("abi:", 0) != 0) continue;
-            std::string need = cap.substr(4);
-            if (need == tcAbi) continue;
             std::string provider;
             for (auto& [c, p] : ctx.plan.runtimeProviders)
                 if (c == cap) { provider = p; break; }
+            if (auto con = mcpp::toolchain::parse_abi_capability(
+                    cap, provider.empty() ? std::string_view{"?"} : std::string_view{provider}))
+                constraints.push_back(std::move(*con));
+        }
+        if (auto mismatches = mcpp::toolchain::abi_check(prof, constraints);
+            !mismatches.empty()) {
+            const auto& mm = mismatches.front();
             return std::unexpected(std::format(
-                "ABI mismatch: dependency '{}' requires abi={} but the resolved "
-                "toolchain '{}' is abi={}.\n"
-                "       fix: `mcpp toolchain default <{}-compatible>` "
-                "(e.g. gcc@16.1.0 for glibc), or set [toolchain] in mcpp.toml.",
-                provider.empty() ? "?" : provider, need, ctx.tc.label(), tcAbi, need));
+                "ABI incompatibility: dependency '{}' requires {}={}, but the "
+                "resolved toolchain '{}' provides {}={}.\n"
+                "       fix: select a {}-compatible toolchain "
+                "(e.g. gcc@16.1.0 for glibc) or set [toolchain] in mcpp.toml.",
+                mm.source, mcpp::toolchain::dim_name(mm.dim), mm.need,
+                ctx.tc.label(), mcpp::toolchain::dim_name(mm.dim), mm.got,
+                mm.need));
         }
     }
 

--- a/src/doctor.cppm
+++ b/src/doctor.cppm
@@ -20,6 +20,7 @@ import mcpp.platform.process;
 import mcpp.toolchain.detect;
 import mcpp.toolchain.registry;
 import mcpp.toolchain.stdmod;
+import mcpp.toolchain.abi;
 import mcpp.ui;
 import mcpp.xlings;
 
@@ -290,16 +291,11 @@ export int why_report(const std::string& topic) {
     auto& tc   = ctx->tc;
     auto& plan = ctx->plan;
 
-    auto abi_of = [](const mcpp::toolchain::Toolchain& t) -> std::string {
-        if (t.targetTriple.find("musl") != std::string::npos) return "musl";
-        if (t.stdlibId == "libc++") return "libc++";
-        if (t.compiler == mcpp::toolchain::CompilerId::MSVC) return "msvc";
-        return "glibc";
-    };
-
     if (all || topic == "toolchain") {
+        const auto prof = mcpp::toolchain::abi_profile(tc);
         std::println("toolchain: {}", tc.label());
-        std::println("  abi={}  stdlib={}  triple={}", abi_of(tc), tc.stdlibId, tc.targetTriple);
+        std::println("  abi(libc)={}  cxxstdlib={}  arch={}  os={}  triple={}",
+                     prof.libc, prof.cxxStdlib, prof.arch, prof.os, tc.targetTriple);
         std::println("  reason: [toolchain] in mcpp.toml if set, else platform-native default");
         if (!ctx->manifest.package.platforms.empty()) {
             std::string ps;

--- a/src/toolchain/abi.cppm
+++ b/src/toolchain/abi.cppm
@@ -1,0 +1,155 @@
+// mcpp.toolchain.abi — dimensional ABI compatibility model.
+//
+// Background: "ABI compatibility" between a dependency and the resolved
+// toolchain is NOT a single flat axis. It has independent dimensions:
+//
+//   libc       glibc | musl | msvcrt | macos   ← from the TARGET TRIPLE
+//   cxxStdlib  libstdc++ | libc++ | msvc-stl    ← from the C++ STANDARD LIBRARY
+//   arch       x86_64 | aarch64 | …             ← from the target triple
+//   os         linux | darwin | windows         ← from the target triple
+//   cxxAbi     itanium | msvc                    ← from the compiler
+//
+// A *C library* (e.g. glfw) only constrains `libc` — linking a glibc C
+// library into a libc++ C++ program is fine, because libc++ is a C++ stdlib,
+// not a libc replacement (it still links glibc on `*-linux-gnu`). The old
+// single-string derivation conflated `libc` with `cxxStdlib` (a libc++
+// toolchain was labelled abi=libc++ and wrongly rejected `abi:glibc` deps).
+//
+// This module models each dimension independently. A dependency declares a
+// constraint only on the dimension(s) it cares about; UNSPECIFIED DIMENSIONS
+// ARE DON'T-CARE. See
+// .agents/docs/2026-06-27-abi-compat-model-single-pr-design.md and
+// .agents/docs/2026-06-27-glfw-abi-glibc-vs-libcxx-conflation-analysis.md.
+export module mcpp.toolchain.abi;
+
+import std;
+import mcpp.toolchain.model;
+
+export namespace mcpp::toolchain {
+
+enum class AbiDim { Libc, CxxStdlib, Arch, Os, CxxAbi };
+
+inline std::string_view dim_name(AbiDim d) {
+    switch (d) {
+        case AbiDim::Libc:      return "libc";
+        case AbiDim::CxxStdlib: return "cxxstdlib";
+        case AbiDim::Arch:      return "arch";
+        case AbiDim::Os:        return "os";
+        case AbiDim::CxxAbi:    return "cxxabi";
+    }
+    return "?";
+}
+
+// A fully-resolved toolchain's ABI coordinates. Empty string on a dimension
+// means "unknown / not detected" → that dimension never causes a mismatch.
+struct AbiProfile {
+    std::string libc;
+    std::string cxxStdlib;
+    std::string arch;
+    std::string os;
+    std::string cxxAbi;
+
+    std::string_view get(AbiDim d) const {
+        switch (d) {
+            case AbiDim::Libc:      return libc;
+            case AbiDim::CxxStdlib: return cxxStdlib;
+            case AbiDim::Arch:      return arch;
+            case AbiDim::Os:        return os;
+            case AbiDim::CxxAbi:    return cxxAbi;
+        }
+        return {};
+    }
+};
+
+// The single derivation site. libc/arch/os come from the target triple;
+// cxxStdlib/cxxAbi come from the compiler. NO cross-dimension inference
+// (that conflation was the bug).
+inline AbiProfile abi_profile(const Toolchain& tc) {
+    AbiProfile p;
+    const std::string& t = tc.targetTriple;
+    auto has = [&](std::string_view s) { return t.find(s) != std::string::npos; };
+
+    // libc — the C runtime ABI a C library links against.
+    if      (has("musl"))                  p.libc = "musl";
+    else if (has("darwin") || has("apple")) p.libc = "macos";
+    else if (has("msvc"))                  p.libc = "msvcrt";
+    else if (has("windows"))               p.libc = "msvcrt";   // mingw → windows CRT
+    else if (has("linux") || has("gnu"))   p.libc = "glibc";    // *-linux-gnu (gcc AND clang+libc++)
+    // else: leave empty (unknown) → don't-care
+
+    // os
+    if      (has("linux"))                  p.os = "linux";
+    else if (has("darwin") || has("apple")) p.os = "darwin";
+    else if (has("windows"))               p.os = "windows";
+
+    // arch — leading triple segment ("x86_64-linux-gnu" → "x86_64").
+    if (auto dash = t.find('-'); dash != std::string::npos) p.arch = t.substr(0, dash);
+    else                                                    p.arch = t;
+
+    // cxxStdlib — already canonical on the toolchain.
+    p.cxxStdlib = tc.stdlibId;
+
+    // cxxAbi
+    p.cxxAbi = (tc.compiler == CompilerId::MSVC || has("msvc")) ? "msvc" : "itanium";
+
+    return p;
+}
+
+// One dimensional constraint a dependency places on the toolchain.
+struct AbiConstraint {
+    AbiDim      dim;
+    std::string value;
+    std::string source;   // provenance (provider package) for diagnostics
+};
+
+// Parse an `abi:` runtime capability string into a dimensional constraint:
+//   legacy bare form  "abi:glibc" / "abi:musl" / "abi:msvcrt"  → libc dimension
+//   dimensional form  "abi:<dim>=<value>"  e.g. "abi:cxxstdlib=libc++"
+// Returns nullopt for non-`abi:` capabilities or an unknown dimension name
+// (unknown dims are ignored for forward-compatibility).
+inline std::optional<AbiConstraint>
+parse_abi_capability(std::string_view cap, std::string_view source = {}) {
+    constexpr std::string_view kPrefix = "abi:";
+    if (cap.size() < kPrefix.size() || cap.substr(0, kPrefix.size()) != kPrefix)
+        return std::nullopt;
+    std::string_view body = cap.substr(kPrefix.size());
+
+    auto eq = body.find('=');
+    if (eq == std::string_view::npos)
+        return AbiConstraint{ AbiDim::Libc, std::string(body), std::string(source) };
+
+    std::string_view dimStr = body.substr(0, eq);
+    std::string_view val    = body.substr(eq + 1);
+    AbiDim dim;
+    if      (dimStr == "libc")      dim = AbiDim::Libc;
+    else if (dimStr == "cxxstdlib") dim = AbiDim::CxxStdlib;
+    else if (dimStr == "arch")      dim = AbiDim::Arch;
+    else if (dimStr == "os")        dim = AbiDim::Os;
+    else if (dimStr == "cxxabi")    dim = AbiDim::CxxAbi;
+    else return std::nullopt;
+    return AbiConstraint{ dim, std::string(val), std::string(source) };
+}
+
+struct AbiMismatch {
+    AbiDim      dim;
+    std::string need;
+    std::string got;
+    std::string source;
+};
+
+// Check a toolchain profile against a set of dimensional constraints.
+// A dimension the profile doesn't pin (empty) can't conflict. Returns all
+// mismatches (empty vector = compatible).
+inline std::vector<AbiMismatch>
+abi_check(const AbiProfile& prof, const std::vector<AbiConstraint>& constraints) {
+    std::vector<AbiMismatch> out;
+    for (auto& c : constraints) {
+        std::string_view got = prof.get(c.dim);
+        if (got.empty()) continue;
+        if (got != c.value)
+            out.push_back({ c.dim, c.value, std::string(got), c.source });
+    }
+    return out;
+}
+
+} // namespace mcpp::toolchain

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.67";
+inline constexpr std::string_view MCPP_VERSION = "0.0.68";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;

--- a/tests/unit/test_abi.cpp
+++ b/tests/unit/test_abi.cpp
@@ -1,0 +1,98 @@
+#include <gtest/gtest.h>
+
+import std;
+import mcpp.toolchain.abi;
+import mcpp.toolchain.model;
+
+using namespace mcpp::toolchain;
+
+namespace {
+
+Toolchain make_tc(std::string triple, std::string stdlib, CompilerId cc) {
+    Toolchain tc;
+    tc.targetTriple = std::move(triple);
+    tc.stdlibId     = std::move(stdlib);
+    tc.compiler     = cc;
+    return tc;
+}
+
+}  // namespace
+
+// ─── abi_profile: each dimension from its single canonical source ───────────
+
+TEST(AbiProfile, ClangLibcxxOnLinuxGnuIsGlibcAtLibcLevel) {
+    // The bug: a clang+libc++ toolchain targeting *-linux-gnu is glibc at the
+    // libc level; only its C++ stdlib is libc++. These are independent dims.
+    auto p = abi_profile(make_tc("x86_64-unknown-linux-gnu", "libc++", CompilerId::Clang));
+    EXPECT_EQ(p.libc, "glibc");
+    EXPECT_EQ(p.cxxStdlib, "libc++");
+    EXPECT_EQ(p.arch, "x86_64");
+    EXPECT_EQ(p.os, "linux");
+    EXPECT_EQ(p.cxxAbi, "itanium");
+}
+
+TEST(AbiProfile, GccGlibc) {
+    auto p = abi_profile(make_tc("x86_64-linux-gnu", "libstdc++", CompilerId::GCC));
+    EXPECT_EQ(p.libc, "glibc");
+    EXPECT_EQ(p.cxxStdlib, "libstdc++");
+}
+
+TEST(AbiProfile, MuslTripleIsMusl) {
+    auto p = abi_profile(make_tc("x86_64-linux-musl", "libstdc++", CompilerId::GCC));
+    EXPECT_EQ(p.libc, "musl");
+    EXPECT_EQ(p.os, "linux");
+}
+
+// ─── abi_check: the regression + the genuine incompatibility ────────────────
+
+TEST(AbiCheck, GlibcCLibraryUnderLibcxxIsCompatible) {
+    // Regression lock for the glfw-under-clang false positive.
+    auto p = abi_profile(make_tc("x86_64-unknown-linux-gnu", "libc++", CompilerId::Clang));
+    auto c = parse_abi_capability("abi:glibc", "compat.glfw");
+    ASSERT_TRUE(c.has_value());
+    EXPECT_TRUE(abi_check(p, {*c}).empty());
+}
+
+TEST(AbiCheck, GlibcDepUnderMuslMismatchesOnLibcDim) {
+    auto p = abi_profile(make_tc("x86_64-linux-musl", "libstdc++", CompilerId::GCC));
+    auto c = parse_abi_capability("abi:glibc", "compat.glfw");
+    ASSERT_TRUE(c.has_value());
+    auto mm = abi_check(p, {*c});
+    ASSERT_EQ(mm.size(), 1u);
+    EXPECT_EQ(mm[0].dim, AbiDim::Libc);
+    EXPECT_EQ(mm[0].need, "glibc");
+    EXPECT_EQ(mm[0].got, "musl");
+}
+
+TEST(AbiCheck, UnspecifiedDimensionIsDontCare) {
+    // A cxxstdlib constraint must NOT be implied by a bare libc capability.
+    auto p = abi_profile(make_tc("x86_64-unknown-linux-gnu", "libc++", CompilerId::Clang));
+    EXPECT_TRUE(abi_check(p, {{AbiDim::Arch, "x86_64", "x"}}).empty());      // matches
+    EXPECT_FALSE(abi_check(p, {{AbiDim::Arch, "aarch64", "x"}}).empty());    // mismatches
+}
+
+// ─── parse_abi_capability: legacy + dimensional forms ───────────────────────
+
+TEST(AbiCapability, LegacyBareFormIsLibc) {
+    auto c = parse_abi_capability("abi:glibc", "pkg");
+    ASSERT_TRUE(c.has_value());
+    EXPECT_EQ(c->dim, AbiDim::Libc);
+    EXPECT_EQ(c->value, "glibc");
+    EXPECT_EQ(c->source, "pkg");
+}
+
+TEST(AbiCapability, DimensionalForm) {
+    auto c = parse_abi_capability("abi:cxxstdlib=libc++");
+    ASSERT_TRUE(c.has_value());
+    EXPECT_EQ(c->dim, AbiDim::CxxStdlib);
+    EXPECT_EQ(c->value, "libc++");
+}
+
+TEST(AbiCapability, NonAbiCapabilityIgnored) {
+    EXPECT_FALSE(parse_abi_capability("x11.display").has_value());
+    EXPECT_FALSE(parse_abi_capability("opengl.glx.driver").has_value());
+}
+
+TEST(AbiCapability, UnknownDimensionIgnored) {
+    EXPECT_FALSE(parse_abi_capability("abi:nonsense=1").has_value());
+}


### PR DESCRIPTION
## Problem

The capability-driven ABI check (added in 0.0.54) derives a single `tcAbi` string where `stdlibId == "libc++"` short-circuits **before** the glibc fallback:

```cpp
tcAbi = triple.find("musl") ? "musl"
      : stdlibId == "libc++" ? "libc++"   // ← conflation
      : compiler == MSVC     ? "msvc" : "glibc";
```

So a `clang+libc++` toolchain on `x86_64-unknown-linux-gnu` — which is **glibc at the libc level** — is labelled `abi=libc++` and rejects any dependency declaring `abi:glibc`, **even pure C libraries** like glfw (libc++ is a C++ stdlib, not a libc replacement; it links glibc fine). This blocks building glfw, and anything pulling it, under the llvm toolchain (e.g. the imgui-m module package, which pins `llvm@20.1.7`).

Full root-cause + reproduction: `.agents/docs/2026-06-27-glfw-abi-glibc-vs-libcxx-conflation-analysis.md`.

## Fix — model ABI as the orthogonal axes it is

| dimension | values | source |
|---|---|---|
| `libc` | glibc / musl / msvcrt / macos | target triple |
| `cxxStdlib` | libstdc++ / libc++ / msvc-stl | compiler / stdlibId |
| `arch`, `os` | … | target triple |
| `cxxAbi` | itanium / msvc | compiler |

A dependency constrains only the dimension(s) it cares about; **unspecified dimensions are don't-care**. Legacy `abi:glibc` → the `libc` dimension only (zero descriptor changes); a new `abi:<dim>=<val>` form expresses other axes.

Design (single-PR scope, with the L3 reselection seam): `.agents/docs/2026-06-27-abi-compat-model-single-pr-design.md`.

## Changes
- **new** `src/toolchain/abi.cppm` — `AbiProfile` + `abi_profile()` (single derivation site), `parse_abi_capability()`, `abi_check()` (per-dimension, don't-care).
- `src/build/prepare.cppm` — replace the conflated `tcAbi` block with the dimensional check; precise per-dimension diagnostics.
- `src/doctor.cppm` — show `abi(libc)/cxxstdlib/arch/os` instead of one fused string.
- `tests/unit/test_abi.cpp` — 11 cases incl. the regression lock.
- version → 0.0.68 (mcpp.toml + fingerprint.cppm).

## Verification (local, fresh 0.0.68)
- glfw under `gcc@16.1.0` → `Finished` (no regression)
- glfw under `llvm@20.1.7` → `Finished` ✅ (**the fix**)
- glfw under `--target x86_64-linux-musl` → still errors: `requires libc=glibc … provides libc=musl` (genuine incompatibility, now naming the dimension)
- `mcpp test`: 27 unit binaries pass incl. new `test_abi`
- `doctor`: `abi(libc)=glibc  cxxstdlib=libc++  arch=x86_64  os=linux`

Once released, `mcpp-index` can move the glfw/imgui-module GL smokes back into the blocking CI set.