### PR TITLE
feat(manifest): platform-conditional [target.'cfg(...)'.dependencies] (v0.0.75)

### DIFF
--- a/.agents/docs/2026-06-29-manifest-environment-and-platform-design.md
+++ b/.agents/docs/2026-06-29-manifest-environment-and-platform-design.md
@@ -230,10 +230,15 @@ missing declared outputs as failure.
   after `--target` resolution. Grammar: `all/any/not` over `os`/`arch`/`family`/`env`
   + bare `windows`/`unix`/`linux`/`macos`; native build → host coords, `--target` →
   target coords. Test: `tests/e2e/85_target_cfg_build_flags.sh`.
-- **Phase 1b — L1 conditional dependencies + `lazy` fetch.** Same `[target.'cfg(...)']`
-  namespace, `.dependencies`/`.dev-dependencies`/`.build-dependencies`; merge into
-  `m->dependencies` in the same window (before dep resolution at `prepare.cppm:~731`).
-  Add `lazy = true` (fetch only when a gated path requests it) + content-hash identity.
+- **✅ Phase 1b — L1 conditional dependencies (mcpp 0.0.75).** Same `[target.'cfg(...)']`
+  namespace, `.dependencies`/`.dev-dependencies`/`.build-dependencies`, parsed via a
+  refactored `load_deps_table` (the dep loader, now table-based so it serves both the
+  global `[dependencies]` and the nested conditional tables that dotted getters can't
+  address) into `ConditionalConfig`, merged into `m->dependencies` in the same
+  evaluation window — before dep resolution — so they resolve like any dep.
+  `insert()` keeps an existing unconditional entry (no silent override). Test:
+  `tests/e2e/86_target_cfg_dependencies.sh`. **Still TODO:** `lazy = true` (fetch only
+  when a gated path requests it) + content-hash identity.
 - **Phase 2 — L-1 environment.** Surface `[environment]` → extend the project
   `.xlings.json` writer (`config.cppm:699-705`) to emit `deps`/`workspace`/`envs`/`subos`;
   fold `[toolchain]` into `workspace`; wire `[build-dependencies]`.

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.74"
+version     = "0.0.75"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/build/prepare.cppm
+++ b/src/build/prepare.cppm
@@ -655,6 +655,12 @@ prepare_build(bool print_fingerprint,
                                            cc.cxxflags.begin(), cc.cxxflags.end());
             m->buildConfig.ldflags.insert(m->buildConfig.ldflags.end(),
                                           cc.ldflags.begin(), cc.ldflags.end());
+            // Conditional dependencies (Phase 1b): merge into the manifest maps
+            // before dependency resolution so they resolve like any dep. insert()
+            // keeps an existing unconditional entry (no silent override).
+            m->dependencies.insert(cc.dependencies.begin(), cc.dependencies.end());
+            m->devDependencies.insert(cc.devDependencies.begin(), cc.devDependencies.end());
+            m->buildDependencies.insert(cc.buildDependencies.begin(), cc.buildDependencies.end());
         }
     }
 

--- a/src/manifest.cppm
+++ b/src/manifest.cppm
@@ -183,6 +183,12 @@ struct ConditionalConfig {
     std::vector<std::string>            cflags;
     std::vector<std::string>            cxxflags;
     std::vector<std::string>            ldflags;
+    // Conditional dependencies (Phase 1b): merged into the corresponding
+    // manifest maps in prepare_build when the predicate matches the resolved
+    // target — before dependency resolution, so they resolve like any dep.
+    std::map<std::string, DependencySpec> dependencies;
+    std::map<std::string, DependencySpec> devDependencies;
+    std::map<std::string, DependencySpec> buildDependencies;
 };
 
 // `[lib]` — library "root" interface convention.
@@ -999,12 +1005,16 @@ std::expected<Manifest, ManifestError> parse_string(std::string_view content,
         return {};
     };
 
-    auto load_deps = [&](std::string_view section, std::map<std::string, DependencySpec>& out)
+    // Parse a dependency table (already obtained) into `out`. Factored out of
+    // load_deps so the same logic serves both [dependencies] (via doc->get_table)
+    // and [target.'cfg(...)'.dependencies] (a nested table the dotted getter
+    // can't address). `section` is the logical section name, used for error
+    // messages and namespace/selector resolution.
+    auto load_deps_table = [&](std::string_view section, auto& tt,
+                               std::map<std::string, DependencySpec>& out)
         -> std::expected<void, ManifestError>
     {
-        auto* tt = doc->get_table(section);
-        if (!tt) return {};
-        for (auto& [k, v] : *tt) {
+        for (auto& [k, v] : tt) {
             // (1) string value → flat default-ns short version, or
             // (3) legacy "ns.name" = "ver" (dotted key).
             if (v.is_string()) {
@@ -1066,6 +1076,13 @@ std::expected<Manifest, ManifestError> parse_string(std::string_view content,
             }
         }
         return {};
+    };
+    auto load_deps = [&](std::string_view section, std::map<std::string, DependencySpec>& out)
+        -> std::expected<void, ManifestError>
+    {
+        auto* tt = doc->get_table(section);
+        if (!tt) return {};
+        return load_deps_table(section, *tt, out);
     };
     if (auto r = load_deps("dependencies",       m.dependencies);       !r) return std::unexpected(r.error());
     if (auto r = load_deps("dev-dependencies",   m.devDependencies);    !r) return std::unexpected(r.error());
@@ -1183,14 +1200,14 @@ std::expected<Manifest, ManifestError> parse_string(std::string_view content,
             }
             m.targetOverrides[canon_triple(triple)] = std::move(e);
 
-            // [target.<predicate>.build] — platform-conditional flags (L1).
-            // `triple` here is the predicate key (cfg(...) or a bare triple);
-            // stored deferred, evaluated against the resolved target in
-            // prepare_build. Reuses the [profile] array-reading idiom.
+            // [target.<predicate>.{build,dependencies,...}] — platform-conditional
+            // config (L1). `triple` is the predicate key (cfg(...) or a bare
+            // triple); stored deferred, evaluated against the resolved target in
+            // prepare_build.
+            ConditionalConfig cc;
+            cc.predicate = triple;
             if (auto bit = body.find("build"); bit != body.end() && bit->second.is_table()) {
                 auto& bt = bit->second.as_table();
-                ConditionalConfig cc;
-                cc.predicate = triple;
                 auto read_list = [&](const char* key, std::vector<std::string>& out) {
                     if (auto f = bt.find(key); f != bt.end() && f->second.is_array())
                         for (auto& v : f->second.as_array())
@@ -1199,9 +1216,24 @@ std::expected<Manifest, ManifestError> parse_string(std::string_view content,
                 read_list("cflags",   cc.cflags);
                 read_list("cxxflags", cc.cxxflags);
                 read_list("ldflags",  cc.ldflags);
-                if (!cc.cflags.empty() || !cc.cxxflags.empty() || !cc.ldflags.empty())
-                    m.conditionalConfigs.push_back(std::move(cc));
             }
+            // [target.<predicate>.{dependencies,dev-dependencies,build-dependencies}]
+            // parsed via the shared table-based loader (same selectors/namespaces
+            // as the global [dependencies]) into the deferred config.
+            auto read_deps = [&](const char* key, std::map<std::string, DependencySpec>& out)
+                -> std::expected<void, ManifestError>
+            {
+                if (auto f = body.find(key); f != body.end() && f->second.is_table())
+                    return load_deps_table(key, f->second.as_table(), out);
+                return {};
+            };
+            if (auto r = read_deps("dependencies",       cc.dependencies);     !r) return std::unexpected(r.error());
+            if (auto r = read_deps("dev-dependencies",   cc.devDependencies);  !r) return std::unexpected(r.error());
+            if (auto r = read_deps("build-dependencies", cc.buildDependencies); !r) return std::unexpected(r.error());
+            if (!cc.cflags.empty() || !cc.cxxflags.empty() || !cc.ldflags.empty()
+                || !cc.dependencies.empty() || !cc.devDependencies.empty()
+                || !cc.buildDependencies.empty())
+                m.conditionalConfigs.push_back(std::move(cc));
         }
     }
 

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.74";
+inline constexpr std::string_view MCPP_VERSION = "0.0.75";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;

--- a/tests/e2e/86_target_cfg_dependencies.sh
+++ b/tests/e2e/86_target_cfg_dependencies.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# 86_target_cfg_dependencies.sh — L1b platform-conditional DEPENDENCIES: a normal
+# mcpp.toml can scope a dependency to a target predicate via
+# `[target.'cfg(...)'.dependencies]`, evaluated against the resolved target (here
+# the host). A matching predicate's dep resolves like any dep; a non-matching
+# predicate's dep is never fetched/resolved. Host-aware so it runs on all three
+# CI platforms. See .agents/docs/2026-06-29-manifest-environment-and-platform-design.md (L1b).
+set -e
+
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+cd "$TMP"
+
+# A real path dependency exposing one symbol.
+mkdir -p widget/src
+cat > widget/mcpp.toml <<'EOF'
+[package]
+name    = "widget"
+version = "0.1.0"
+[targets.widget]
+kind = "lib"
+EOF
+cat > widget/src/widget.cppm <<'EOF'
+export module widget;
+export int widget_anchor() { return 0; }
+EOF
+
+mkdir -p app/src
+cat > app/mcpp.toml <<'EOF'
+[package]
+name    = "app"
+version = "0.1.0"
+
+# widget is pulled under whichever family matches the host — so exactly one of
+# these applies and widget is ALWAYS resolved (on any of the 3 platforms).
+[target.'cfg(unix)'.dependencies]
+widget = { path = "../widget" }
+[target.'cfg(windows)'.dependencies]
+widget = { path = "../widget" }
+
+# A never-matching predicate (no such arch) points at a non-existent path. If the
+# conditional merge wrongly pulled it, resolution of the bogus path would FAIL the
+# build — so a clean build proves non-matching deps are excluded.
+[target.'cfg(arch = "no_such_arch")'.dependencies]
+ghost = { path = "../this_path_does_not_exist" }
+EOF
+cat > app/src/main.cpp <<'EOF'
+import widget;  // fails to build unless the cfg-matched widget dep was resolved
+int main() { return widget_anchor(); }
+EOF
+
+cd app
+"$MCPP" build > b.log 2>&1 || { cat b.log; echo "FAIL: conditional dep not resolved, or non-matching dep wrongly pulled"; exit 1; }
+
+# Sanity: the matched dependency really was wired (widget appears in the lockfile).
+if [ -f mcpp.lock ]; then
+    grep -q 'widget' mcpp.lock || { echo "FAIL: widget missing from lockfile"; cat mcpp.lock; exit 1; }
+fi
+# The never-matching ghost must NOT be present.
+if [ -f mcpp.lock ] && grep -q 'ghost' mcpp.lock; then
+    echo "FAIL: non-matching cfg dependency 'ghost' leaked into the resolve"; exit 1; fi
+
+echo "OK"


### PR DESCRIPTION
## Summary
L1b — extends the `[target.'cfg(...)']` namespace (shipped in 0.0.74 for flags) to **conditional dependencies**, evaluated against the **resolved target**:

```toml
[target.'cfg(windows)'.dependencies.compat]
openblas = "0.3.33"
[target.'cfg(all(linux, not(arch = "aarch64")))'.dev-dependencies]
some-x64-linux-test-helper = "1.0"
```

A Windows-only dependency is now **declared**, not faked out-of-band — directly serving the mcpp-index workspace design (windows-only `compat.openblas`).

## Mechanism
Reuses the 0.0.74 `cfg()` evaluator; the dependency **graph stays applicative** (à la carte).
- `manifest.cppm`: the dependency loader is refactored into a table-based `load_deps_table` (identical selector/namespace/legacy-key handling) so it serves both the global `[dependencies]` and the **nested** conditional tables — which dotted getters can't address (the quoted `cfg()` segment). The `[target.<predicate>]` loop parses `.dependencies`/`.dev-dependencies`/`.build-dependencies` into the deferred `ConditionalConfig`.
- `prepare.cppm`: matching predicates' dep maps merge into `m->{dependencies,devDependencies,buildDependencies}` **before dependency resolution** (same window as the conditional flags). `insert()` preserves an existing unconditional entry (no silent override).

`lazy` fetch + content-hash identity remain documented TODO.

## Verification
- New e2e `86_target_cfg_dependencies.sh` — a `cfg(unix)`+`cfg(windows)` `widget` always resolves on any host; a never-matching `cfg(arch="no_such_arch")` bogus-path `ghost` is **excluded** (a clean build proves both). **PASS.**
- Unit + integration — 27 ok, 0 failed; **the `load_deps` refactor is sound** (dep e2e 09/18/24/27/… all pass).
- Self-host build at v0.0.75 — clean.

Version bump 0.0.74 → 0.0.75.