### PR TITLE
ci: fresh-install post-release trigger via workflow_run (drop PAT dispatch)

### DIFF
--- a/.github/workflows/ci-fresh-install.yml
+++ b/.github/workflows/ci-fresh-install.yml
@@ -11,8 +11,17 @@ name: ci-fresh-install
 # It runs on release publish, manual trigger, and daily schedule.
 
 on:
+  # NOTE: `release: published` never fires from the release pipeline — the
+  # release is created by release.yml with GITHUB_TOKEN, and GitHub
+  # suppresses workflow triggers from GITHUB_TOKEN-generated events. Kept
+  # only for releases created manually outside the pipeline. The reliable
+  # post-release hook is `workflow_run` below: a platform-generated event,
+  # exempt from that suppression, and requiring no cross-repo PAT.
   release:
     types: [ published ]
+  workflow_run:
+    workflows: [ release ]
+    types: [ completed ]
   workflow_dispatch:
   schedule:
     # Run daily at 06:00 UTC to catch issues from xlings/runner updates
@@ -28,6 +37,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────
   linux-fresh:
     name: Linux fresh install
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:
@@ -133,6 +143,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────
   linux-distro-matrix:
     name: Linux distro (${{ matrix.distro }})
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
     container:
       image: ${{ matrix.image }}
@@ -218,6 +229,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────
   macos-fresh:
     name: macOS fresh install
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     # macos-14: the support floor (mcpp ≥0.0.50 / xlings ≥0.4.50 ship
     # minos=14.0 static-libc++ binaries). A fresh install passing here
     # is the continuous proof of the macOS 14 floor — and of host-tool
@@ -278,6 +290,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────
   windows-fresh:
     name: Windows fresh install
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: windows-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -738,15 +738,9 @@ jobs:
           bash .github/tools/bump_index.sh mcpp "${{ steps.version.outputs.version }}" \
             || echo "index bump reported issues (non-blocking)"
 
-      # ci-fresh-install declares `on: release published`, but the release is
-      # created with GITHUB_TOKEN and GitHub suppresses workflow triggers from
-      # GITHUB_TOKEN-generated events — so that hook has never fired (only the
-      # daily schedule ran it). Dispatch it explicitly with a PAT; best-effort
-      # (the schedule remains the fallback).
-      - name: Dispatch fresh-install verification
-        if: ${{ env.XIM_PKGINDEX_TOKEN != '' }}
-        env:
-          GH_TOKEN: ${{ secrets.XIM_PKGINDEX_TOKEN }}
-        run: |
-          gh workflow run ci-fresh-install.yml -R "${{ github.repository }}" --ref main \
-            || echo "fresh-install dispatch failed (non-blocking; daily schedule covers it)"
+      # Post-release verification (ci-fresh-install) is triggered via its
+      # `workflow_run: [release]` hook — a platform-generated event that is
+      # exempt from GITHUB_TOKEN trigger suppression and needs no cross-repo
+      # PAT. (A PAT-based dispatch step lived here briefly; it never worked —
+      # XIM_PKGINDEX_TOKEN's resource owner is the index org and cannot cover
+      # this repository.)


### PR DESCRIPTION
Replaces the PAT-based dispatch step added on the 0.0.83 train (commit 1db0816), which never worked: `XIM_PKGINDEX_TOKEN` is a fine-grained PAT whose resource owner is the index org — it structurally cannot cover this repository, so every release logged `HTTP 403` behind the non-blocking fallback.

**Replacement**: `ci-fresh-install.yml` gains `workflow_run: [release] / completed` — a platform-generated event exempt from GITHUB_TOKEN trigger suppression, requiring no cross-repo PAT and no secret maintenance. Every job carries `if: event != workflow_run || run.conclusion == success` so only successful releases trigger verification. `release: published` is kept for manually created releases; `workflow_dispatch` and the daily schedule are unchanged. The dead dispatch step in release.yml is removed with a pointer comment.

Verification note: the `workflow_run` path can only fire for real on the next release; this PR is validated by YAML/workflow static checks + the unchanged dispatch path (manually exercised throughout 0.0.83/0.0.84).