### PR TITLE
0.0.86: pipeline hardening + unified macOS test stdlib + aarch64 cross gcc16 floor

### DIFF
--- a/.agents/docs/2026-07-08-root-cause-remediation-design.md
+++ b/.agents/docs/2026-07-08-root-cause-remediation-design.md
@@ -189,11 +189,11 @@ defense-in-depth for the next regression of any kind.
 
 | # | Task | Repo / PR | Status |
 |---|------|-----------|--------|
-| R1 (A4) | pipeline hardening: timeouts, GH-side verify+retry, completeness gate, fresh-install bounded wait | mcpp `.github/` | 🔄 |
-| R2 (A1) | TestBinary → toolchain libc++ (dynamic+rpath); e2e otool assertion; unpin macOS llvm | mcpp `flags.cppm` | pending |
-| R3 (A3) | staged+atomic index acquisition | xlings `downloader.cppm` | pending |
-| R4 (C.1) | toolchain-bump consumer smoke | xim-pkgindex CI | pending |
-| R5 (A2) | cross gcc 16 packaging feasibility → floor bump → delete anchor | xlings-res packaging | pending |
+| R1 (A4) | pipeline hardening | ✅ PR #201 merged (6/6); positive+negative tested against live 0.0.85 mirror | ✅ |
+| R2 (A1) | TestBinary stdlib unification | ✅ PR #202 merged (6/6, 8 forensics-driven rounds): static -load_hidden for tests = distributable model; llvm 22.1.8 green; dynamic route falsified (dylib set upward-links system libc++) | ✅ |
+| R3 (A3) | staged+atomic git index acquisition + catalog self-heal | ✅ xlings PR #353 merged; artifact path already atomic since 0.4.62 — incidents were v0.4.44 pins, bumped in #343 | ✅ |
+| R4 (C.1) | toolchain-bump consumer smoke + xlings pin v0.4.62 | ✅ xim-pkgindex PR #343 merged | ✅ |
+| R5 (A2) | cross gcc 16 packaging → floor bump | ✅ packaged (build-cross/build-native workflows added, release 16.1.0 4 assets, smoke-tested); xim entry merged (#344); mcpp cross pin → 16.1.0. **R5b remains**: anchor stays until xim ships x86_64 musl gcc 16 (the x86_64-linux-musl release build is still on musl-gcc 15.1.0) | 🔄 |
 | R6 | mcpp 0.0.86 release + ecosystem closure (mirror / index bump / fresh-install) | all | pending |
 
 ## Order of execution

--- a/.github/workflows/cross-build-test.yml
+++ b/.github/workflows/cross-build-test.yml
@@ -10,7 +10,7 @@ name: cross-build-test
 # ── Supported cross matrix (built + verified below) ────────────────────────
 #   target                | toolchain                       | host→target   | run
 #   ----------------------|---------------------------------|---------------|-----
-#   aarch64-linux-musl    | aarch64-linux-musl-gcc@15.1.0   | x86_64→arm64  | qemu
+#   aarch64-linux-musl    | aarch64-linux-musl-gcc@16.1.0   | x86_64→arm64  | qemu
 #
 # mcpp resolves a cross `--target <triple>-musl` build to the triple-named cross
 # gcc musl toolchain from the xlings ecosystem (xim:<triple>-gcc, see

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "0.0.85"
+version     = "0.0.86"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/build/prepare.cppm
+++ b/src/build/prepare.cppm
@@ -636,9 +636,11 @@ prepare_build(bool print_fingerprint,
         //   - target arch != host arch → CROSS build, use the target-named
         //     cross toolchain `<triple>-gcc@15.1.0` (→ xim:<triple>-gcc),
         //     e.g. building aarch64 on an x86_64 host.
-        // We pin 15.1.0 because xim only has musl variants for 9.4 / 11.5 /
-        // 13.3 / 15.1 (gcc 16.1 has none yet); 15.1.0 matches what mcpp uses
-        // for `mcpp build --target x86_64-linux-musl` (see mcpp.toml).
+        // Versions: CROSS uses 16.1.0 (packaged 2026-07-08; GCC 15 drops
+        // module template instantiations at link — remediation doc A2).
+        // NATIVE musl stays 15.1.0 until xim ships an x86_64 musl gcc 16
+        // (R5b); the manifest:types instantiation anchor covers it until
+        // then.
         if (endswith(overrides.target_triple, "-musl")
             && (it == m->targetOverrides.end() || it->second.toolchain.empty()))
         {
@@ -649,7 +651,7 @@ prepare_build(bool print_fingerprint,
             if (targetArch.empty() || targetArch == mcpp::platform::host_arch)
                 tcSpec = "gcc@15.1.0-musl";                        // native
             else
-                tcSpec = overrides.target_triple + "-gcc@15.1.0";  // cross
+                tcSpec = overrides.target_triple + "-gcc@16.1.0";  // cross
         }
         if (endswith(overrides.target_triple, "-musl")
             && m->buildConfig.linkage.empty()) {

--- a/src/manifest/types.cppm
+++ b/src/manifest/types.cppm
@@ -517,7 +517,10 @@ std::filesystem::path resolve_lib_root_path(const Manifest& manifest) {
 
 
 // ── GCC 15 cross-link workaround ────────────────────────────────────
-// GCC 15 (aarch64-linux-musl cross, xim gcc 15.1.0) does not emit
+// GCC 15 does not emit
+// (cross is on gcc 16 since 2026-07-08; this anchor stays for the
+//  x86_64-linux-musl NATIVE release build, still on musl-gcc 15.1.0 —
+//  remove when xim ships an x86_64 musl gcc 16, remediation doc R5b)
 // implicit template instantiations for std::map/... members of
 // module-attached structs in IMPORTER object files — it expects the
 // owning module to provide them. The old single-file mcpp.manifest

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "0.0.85";
+inline constexpr std::string_view MCPP_VERSION = "0.0.86";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;


### PR DESCRIPTION
Release train for the root-cause remediation set (design: `.agents/docs/2026-07-08-root-cause-remediation-design.md`, live status table inside).

Already merged into main and shipped by this release: #201 (A4 — verified, gated mirroring; blocking completeness gate; fresh-install index wait) and #202 (A1 — test binaries use the same static `-load_hidden` libc++ as distributables; llvm 22.1.8 green after 8 forensics-driven CI rounds; macOS pin → 22.1.8, latest-first install restored).

This PR adds:
- **A2/R5a — aarch64 cross floor → gcc 16.1.0**: `prepare.cppm` cross convention now resolves `<triple>-gcc@16.1.0` (packaged today via xlings-res builder workflows, xim entry openxlings/xim-pkgindex#344). GCC 15's module-instantiation link bug leaves the cross path. The `manifest:types` instantiation anchor REMAINS for the x86_64-linux-musl release build (musl-gcc 15.1.0) until R5b packages its gcc 16 — comment updated with the exit criterion.
- version 0.0.86 + remediation-doc live status.

The cross-build CI job on this PR is the gcc-16 verification (fresh toolchain download + full static aarch64 link of mcpp itself).