### PR TITLE
fix(build): all musl paths on gcc 16.1.0 — delete the GCC-15 instantiation anchor (A2 complete)

### DIFF
--- a/.github/workflows/ci-fresh-install.yml
+++ b/.github/workflows/ci-fresh-install.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   # ──────────────────────────────────────────────────────────────────
-  # Linux: gcc@16.1.0, musl-gcc@15.1.0, llvm@20.1.7
+  # Linux: gcc@16.1.0, musl-gcc@16.1.0, llvm@20.1.7
   # ──────────────────────────────────────────────────────────────────
   # A4: post-release runs race the xim-pkgindex bump (a PR a maintainer
   # merges asynchronously) — the 0.0.85 fresh-install failed with
@@ -120,8 +120,8 @@ jobs:
 
       - name: "musl-gcc: mcpp new → run"
         run: |
-          mcpp toolchain install gcc 15.1.0-musl
-          mcpp toolchain default gcc@15.1.0-musl
+          mcpp toolchain install gcc 16.1.0-musl
+          mcpp toolchain default gcc@16.1.0-musl
           cd "$(mktemp -d)"
           mcpp new hello_musl
           cd hello_musl
@@ -129,7 +129,7 @@ jobs:
 
       - name: "musl-gcc: build mcpp"
         run: |
-          mcpp toolchain default gcc@15.1.0-musl
+          mcpp toolchain default gcc@16.1.0-musl
           mcpp clean
           mcpp run
 

--- a/.github/workflows/ci-linux-e2e.yml
+++ b/.github/workflows/ci-linux-e2e.yml
@@ -115,7 +115,7 @@ jobs:
           # deterministic GNU answer instead of an auto-install pick.
           "$MCPP" toolchain default gcc@16.1.0
           # Warm musl once so fresh-home e2e tests inherit the payload.
-          "$MCPP" toolchain install gcc 15.1.0-musl
+          "$MCPP" toolchain install gcc 16.1.0-musl
           bash tests/e2e/run_all.sh
 
   # ──────────────────────────────────────────────────────────────────

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -121,7 +121,7 @@ jobs:
       # longer relies on e2e's toolchain warm-ups: the GCC build uses the
       # mcpp.toml-pinned default (gcc@16.1.0, already in the sandbox from the
       # self-host build above), and the musl `--target` build auto-installs
-      # gcc@15.1.0-musl on demand (cached across runs).
+      # gcc@16.1.0-musl on demand (cached across runs).
 
       - name: Save freshly-built mcpp for toolchain tests
         run: |
@@ -138,7 +138,7 @@ jobs:
       - name: "Toolchain: musl-gcc — build mcpp (--target)"
         run: |
           "$MCPP" clean
-          "$MCPP" build --target x86_64-linux-musl 2>&1 | tee build.log; grep -q "Resolved gcc@15.1.0-musl" build.log
+          "$MCPP" build --target x86_64-linux-musl 2>&1 | tee build.log; grep -q "Resolved gcc@16.1.0-musl" build.log
 
       - name: "Toolchain: LLVM — build mcpp"
         run: |

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -22,7 +22,7 @@ macos   = "llvm@22.1.8"
 windows = "llvm@20.1.7"
 
 # Per-target overrides: `mcpp build --target x86_64-linux-musl` (or the
-# four-segment form `x86_64-unknown-linux-musl`) picks musl-gcc 15.1 + full
+# four-segment form `x86_64-unknown-linux-musl`) picks musl-gcc 16.1 + full
 # static linkage. Used by .github/workflows/release.yml to produce a
 # portable static binary that drops in anywhere with no ELF interp / RUNPATH
 # baggage.

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -27,7 +27,7 @@ windows = "llvm@20.1.7"
 # portable static binary that drops in anywhere with no ELF interp / RUNPATH
 # baggage.
 [target.x86_64-linux-musl]
-toolchain = "gcc@15.1.0-musl"
+toolchain = "gcc@16.1.0-musl"
 linkage   = "static"
 
 # aarch64 (ARM64) static target. No explicit toolchain: mcpp's host-aware

--- a/src/build/prepare.cppm
+++ b/src/build/prepare.cppm
@@ -636,11 +636,9 @@ prepare_build(bool print_fingerprint,
         //   - target arch != host arch → CROSS build, use the target-named
         //     cross toolchain `<triple>-gcc@15.1.0` (→ xim:<triple>-gcc),
         //     e.g. building aarch64 on an x86_64 host.
-        // Versions: CROSS uses 16.1.0 (packaged 2026-07-08; GCC 15 drops
-        // module template instantiations at link — remediation doc A2).
-        // NATIVE musl stays 15.1.0 until xim ships an x86_64 musl gcc 16
-        // (R5b); the manifest:types instantiation anchor covers it until
-        // then.
+        // Both native and cross musl default to gcc 16.1.0 — GCC 15 drops
+        // module template instantiations at link (remediation doc A2;
+        // packages shipped 2026-07-08/09, stripped, GitHub+GitCode).
         if (endswith(overrides.target_triple, "-musl")
             && (it == m->targetOverrides.end() || it->second.toolchain.empty()))
         {
@@ -649,7 +647,7 @@ prepare_build(bool print_fingerprint,
                 ? overrides.target_triple
                 : overrides.target_triple.substr(0, dash);
             if (targetArch.empty() || targetArch == mcpp::platform::host_arch)
-                tcSpec = "gcc@15.1.0-musl";                        // native
+                tcSpec = "gcc@16.1.0-musl";                        // native
             else
                 tcSpec = overrides.target_triple + "-gcc@16.1.0";  // cross
         }

--- a/src/manifest/types.cppm
+++ b/src/manifest/types.cppm
@@ -400,8 +400,6 @@ std::filesystem::path resolve_lib_root_path(const Manifest& manifest);
 bool has_lib_target(const Manifest& manifest);
 
 
-// GCC 15 cross-link workaround anchor — see definition below.
-void force_template_instantiations();
 
 } // namespace mcpp::manifest
 
@@ -516,32 +514,5 @@ std::filesystem::path resolve_lib_root_path(const Manifest& manifest) {
 
 
 
-// ── GCC 15 cross-link workaround ────────────────────────────────────
-// GCC 15 does not emit
-// (cross is on gcc 16 since 2026-07-08; this anchor stays for the
-//  x86_64-linux-musl NATIVE release build, still on musl-gcc 15.1.0 —
-//  remove when xim ships an x86_64 musl gcc 16, remediation doc R5b)
-// implicit template instantiations for std::map/... members of
-// module-attached structs in IMPORTER object files — it expects the
-// owning module to provide them. The old single-file mcpp.manifest
-// emitted them by accident (its parser code constructed every struct);
-// this non-inline, exported definition recreates that guarantee
-// deliberately. Remove once the cross toolchain floor is GCC 16.
-void force_template_instantiations() {
-    Manifest          m;
-    WorkspaceConfig   w;
-    XlingsConfig      x;
-    Modules           mo;
-    BuildConfig       bc;
-    RuntimeConfig     rc;
-    TargetEntry       te;
-    ConditionalConfig cc;
-    LibConfig         lc;
-    PackConfig        pc;
-    Profile           pr;
-    Toolchain         tc;
-    (void)m; (void)w; (void)x; (void)mo; (void)bc; (void)rc;
-    (void)te; (void)cc; (void)lc; (void)pc; (void)pr; (void)tc;
-}
 
 } // namespace mcpp::manifest


### PR DESCRIPTION
musl-gcc 16.1.0 shipped (stripped dual-arch, GitHub+GitCode, xim #345 gated by the consumer smoke). Native x86_64 static release build, native aarch64 and cross all move to GCC 16; the `force_template_instantiations()` anchor loses its last consumer and is deleted — this PR's musl/cross links ARE the regression test. Local verification: anchor-free static builds green on both targets with `GCC: (GNU) 16.1.0` ELF notes. Design: `.agents/docs/2026-07-08-root-cause-remediation-design.md` A2.