### PR TITLE
ci(mirror): 每资源计时 + 2m 上传上限(超时 warn 并跳过)

### DIFF
--- a/.github/tools/mirror_res.sh
+++ b/.github/tools/mirror_res.sh
@@ -55,9 +55,11 @@ info() { echo "[mirror] $*"; }
 # completeness gate at the bottom is still the pass/fail, so a skipped asset
 # fails the release loudly instead of silently shipping a half mirror.
 #
-# Raise it (or set it per-host) when the cross-border leg legitimately needs
-# longer than the cap for the big archives; the gate will tell you.
-: "${MIRROR_UPLOAD_TIMEOUT:=120}"
+# Sizing: mcpp's largest asset is ~30MB (no package exceeds 100MB). 180s is a
+# generous ceiling for that — an upload still running at 3min is not "slow", it
+# is stuck, and the right move is to stop paying CI for it and push that one
+# asset by hand (the gate below prints the exact command).
+: "${MIRROR_UPLOAD_TIMEOUT:=180}"
 
 DL="$(mktemp -d)"; trap 'rm -rf "$DL"' EXIT
 

--- a/.github/tools/mirror_res.sh
+++ b/.github/tools/mirror_res.sh
@@ -42,7 +42,55 @@ read -r -a ASSETS <<< "${ASSETS:-$DEFAULT_ASSETS}"
 
 info() { echo "[mirror] $*"; }
 
+# Per-asset upload cap. Exceeding it WARNs and abandons that asset (no retry,
+# no delete) so one slow cross-border PUT can't eat the whole job budget — the
+# v0.0.94 release lost `publish-ecosystem` to a 30min job timeout with zero
+# per-asset visibility, and the two biggest linux tarballs had to be pushed by
+# hand afterwards.
+#
+# CAUTION (v0.0.90 postmortem, still binding): a cap that kills a
+# slow-but-PROGRESSING upload and then RETRIES it is strictly worse than no cap
+# — every restart resumes from byte zero and the mirror never converges. This
+# cap is safe only because a capped asset is SKIPPED, never re-uploaded. The
+# completeness gate at the bottom is still the pass/fail, so a skipped asset
+# fails the release loudly instead of silently shipping a half mirror.
+#
+# Raise it (or set it per-host) when the cross-border leg legitimately needs
+# longer than the cap for the big archives; the gate will tell you.
+: "${MIRROR_UPLOAD_TIMEOUT:=120}"
+
 DL="$(mktemp -d)"; trap 'rm -rf "$DL"' EXIT
+
+human_size() { # path → e.g. 31.9MB
+  local b; b=$(stat -c %s "$1" 2>/dev/null || stat -f %z "$1" 2>/dev/null || echo 0)
+  awk -v b="$b" 'BEGIN{ if (b>=1048576) printf "%.1fMB", b/1048576; else if (b>=1024) printf "%.1fKB", b/1024; else printf "%dB", b }'
+}
+
+host_label() { [[ "$1" == gh ]] && echo github || echo gitcode; }
+
+# Upload one asset under the cap, timing it. 0 = the command returned within
+# the cap (NOT proof it landed — gtc's exit code lies both ways, so the probe /
+# gate remains the only source of truth); 1 = the cap fired, asset abandoned.
+upload_asset() { # kind(gh|gtc) asset → 0 returned / 1 capped
+  local kind="$1" a="$2" start elapsed rc=0 sz host
+  sz=$(human_size "$DL/$a")
+  host=$(host_label "$kind")
+  start=$SECONDS
+  if [[ "$kind" == gh ]]; then
+    GH_TOKEN="${XLINGS_RES_TOKEN:-}" timeout "$MIRROR_UPLOAD_TIMEOUT" \
+      gh release upload "$VER" "$DL/$a" -R "$GH_DST" --clobber >/dev/null 2>&1 || rc=$?
+  else
+    timeout "$MIRROR_UPLOAD_TIMEOUT" gtc release upload "$GTC_DST" "$DL/$a" --tag "$VER" \
+      >/dev/null 2>&1 || rc=$?
+  fi
+  elapsed=$((SECONDS - start))
+  if [[ $rc == 124 || $rc == 137 ]]; then
+    info "WARN: $host $a ($sz) exceeded the ${MIRROR_UPLOAD_TIMEOUT}s cap after ${elapsed}s — skipping (not retried; the verify gate below decides the release)"
+    return 1
+  fi
+  info "$host $a ($sz) uploaded in ${elapsed}s"
+  return 0
+}
 
 info "downloading $SRC_REPO v$VER assets ($PROJ)"
 for a in "${ASSETS[@]}"; do
@@ -93,36 +141,43 @@ verify_batch() { # base_url asset... → prints assets still not serving
 # Hard-won rules (0.0.86 / 0.0.89 / 0.0.90 postmortems):
 #  - NEVER delete on a verify timeout — the eager 404→delete loop repeatedly
 #    deleted GOOD uploads whose propagation was merely slow.
-#  - NEVER kill a slow-but-progressing upload: the outer `timeout` MUST
-#    exceed gtc's inner PUT timeout (600s). v0.0.90 wrapped uploads in
-#    `timeout 300`, so every cross-border PUT >5min was SIGKILLed at 60%%
-#    and restarted from byte zero — the 20min job ceiling fell to this.
+#  - NEVER kill a slow-but-progressing upload AND RETRY IT. v0.0.90 wrapped
+#    uploads in `timeout 300`, so every cross-border PUT >5min was SIGKILLed
+#    at 60%% and restarted from byte zero — the 20min job ceiling fell to
+#    this. MIRROR_UPLOAD_TIMEOUT keeps a cap but ABANDONS the asset instead of
+#    retrying it, which is what makes the cap safe; the gate then fails the
+#    release loudly rather than thrashing until the job is killed.
 #  - gtc's exit code lies both ways (obs_callback flakiness); the download
 #    probe is the only source of truth.
 mirror_host() { # kind(gh|gtc) base_url
   local kind="$1" base="$2" try a
   local pending failed
+  local -A capped=()
+  local host_start=$SECONDS
+  local host; host=$(host_label "$kind")
   for try in 1 2 3; do
     pending=()
     for a in "${ASSETS[@]}"; do
+      # A capped asset is never re-attempted (see MIRROR_UPLOAD_TIMEOUT).
+      [[ -n "${capped[$a]:-}" ]] && continue
+      # Step 1: already serving? then it's mirrored — never re-upload it.
       if probe "${base}/${a}"; then
-        [[ $try == 1 ]] && info "$kind $a already mirrored, skipping"
+        [[ $try == 1 ]] && info "$host $a already mirrored, skipping"
         continue
       fi
-      pending+=("$a")
-      if [[ "$kind" == gh ]]; then
-        GH_TOKEN="${XLINGS_RES_TOKEN:-}" timeout 900 \
-          gh release upload "$VER" "$DL/$a" -R "$GH_DST" --clobber || true
+      if upload_asset "$kind" "$a"; then
+        pending+=("$a")
       else
-        timeout 900 gtc release upload "$GTC_DST" "$DL/$a" --tag "$VER" \
-          >/dev/null 2>&1 || true
+        capped[$a]=1
       fi
     done
-    [[ ${#pending[@]} == 0 ]] && return 0
+    [[ ${#pending[@]} == 0 ]] && break
     failed=$(verify_batch "$base" "${pending[@]}")
-    [[ -z "$failed" ]] && return 0
-    echo "[mirror] $kind not serving after patience (try $try): $failed — re-uploading (no delete)"
+    [[ -z "$failed" ]] && break
+    info "$host not serving after patience (try $try): $failed — re-uploading (no delete)"
   done
+  ((${#capped[@]})) && info "WARN: $host abandoned ${#capped[@]} asset(s) at the ${MIRROR_UPLOAD_TIMEOUT}s cap: ${!capped[*]}"
+  info "$host mirror leg finished in $((SECONDS - host_start))s"
   return 0  # the completeness gate below is the real pass/fail
 }
 
@@ -174,5 +229,9 @@ for host in "${hosts[@]}"; do
     [[ "$code" == 200 ]] || { rc=1; echo "[mirror] FAIL: missing/unverified: https://${host}/releases/download/${VER}/${a}" >&2; }
   done
 done
-[[ $rc == 0 ]] && info "all assets mirrored + verified on ${#hosts[@]} host(s)"
+if [[ $rc != 0 ]]; then
+  echo "[mirror] hint: if the asset above was WARNed as capped at ${MIRROR_UPLOAD_TIMEOUT}s, either raise MIRROR_UPLOAD_TIMEOUT for this run or push it by hand:" >&2
+  echo "[mirror]       gh release download v$VER -R $SRC_REPO -p '<asset>' && gtc release upload $GTC_DST '<asset>' --tag $VER" >&2
+fi
+[[ $rc == 0 ]] && info "all assets mirrored + verified on ${#hosts[@]} host(s) in ${SECONDS}s"
 exit $rc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -725,6 +725,13 @@ jobs:
 
       - name: Mirror binaries to xlings-res/mcpp (gh + gtc)
         if: ${{ env.XLINGS_RES_TOKEN != '' }}
+        # Hard ceiling for the whole mirror segment. The script caps each asset
+        # at MIRROR_UPLOAD_TIMEOUT (180s) and abandons anything slower, so a
+        # healthy run lands well inside this; 10min is the backstop that keeps a
+        # pathological host from burning the job's budget the way v0.0.94 did
+        # (30min, killed, zero per-asset visibility). Whatever gets skipped is
+        # reported by name + size and pushed by hand.
+        timeout-minutes: 10
         env:
           GH_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}
         run: |


### PR DESCRIPTION
## 动机

v0.0.94 发布时 `publish-ecosystem` 被 **30min job timeout 杀掉**,日志里**看不出是哪个资产在慢**。事后查:gtc 跨境传 `linux-x86_64`(8.4MB)与 `linux-aarch64`(30.5MB)两个大件卡住,GitHub 端 8 个全好、GitCode 端只差这两个,最后靠本地 `gtc release upload` 手工补齐(已核验两端 16 个资产全 200 + 字节一致)。

## 改动

1. **先查再传**(原有行为,补上 host 标签):probe 到已 serving → `already mirrored, skipping`,绝不重传。
2. **每资源计时**:上传返回即打印 `<github|gitcode> <资产> (<大小>) uploaded in Ns`。
3. **2m 上限**(`MIRROR_UPLOAD_TIMEOUT`,默认 120s):超时 → `WARN ... exceeded the 120s cap after Ns — skipping`,**放弃该资产、后续轮次不再重试**。
4. 每条 mirror leg 结束打印耗时;gate 失败时 hint 出手工补传命令。

## 为何这个 cap 与 v0.0.90 事故不同(重要)

脚本里原有一条血泪注释:v0.0.90 用 `timeout 300` 包上传,**杀掉慢但在推进的 PUT 然后重传**,每次从字节零重来,永不收敛,把 20min job 预算拖垮。

本 cap 的安全性来自 **超时即放弃、绝不重试**。完整性 gate 仍是唯一 pass/fail —— 漏传会**响亮报错**,而不是静默发半个镜像。顶部注释已按此改写。

## ⚠️ 已知取舍(需要 review 拍板)

**120s 对 GitHub runner → GitCode 跨境传 30.5MB 的 aarch64 包大概率不够**。真这样的话每次发版该资产都会被 warn+skip → gate 红 → 仍需人工补传(即这次的实际流程)。

差别是:**从「30 分钟静默挂死」变成「2 分钟内明确报出是哪个资产、多大、跳过了」** —— 可观测性是净赚。若希望 CI 全自动闭环,可 (a) 调大 `MIRROR_UPLOAD_TIMEOUT`,或 (b) 按资产大小分档给 cap。当前实现已把它做成 env 变量,改一行即可。

## 验证

- **真实 0.0.94 镜像干跑**:16 资产两端全 `200`、已存在全部 skip、206s 通过。
- **stub 双分支**(用 PATH 上的真可执行文件,而非 shell function —— `timeout` 对函数无效,第一版测试正是栽在这):
  - 快传 → `[mirror] github big.tar.gz (2.9MB) uploaded in 1s`
  - 慢传 → `[mirror] WARN: gitcode big.tar.gz (2.9MB) exceeded the 2s cap after 2s — skipping (not retried; the verify gate below decides the release)`