### PR TITLE
fix: skip Form B packages in template name resolution

### DIFF
--- a/src/scaffold/create.cppm
+++ b/src/scaffold/create.cppm
@@ -44,6 +44,12 @@ fetch_template_package(const mcpp::scaffold::TemplateSpec& spec) {
     std::optional<std::string> lua;
     for (std::string cand : {std::string{}, std::string{"compat"}}) {
         if (auto l = fetcher.read_xpkg_lua(cand, spec.pkg)) {
+            // Form B packages (mcpp = { ... }) are build recipes without
+            // a source tree — no physical mcpp.toml or templates/.
+            auto field = mcpp::manifest::extract_mcpp_field(*l);
+            if (field.kind == mcpp::manifest::McppField::TableBody) {
+                continue;
+            }
             lua = std::move(*l);
             break;
         }

--- a/tests/e2e/69_package_templates.sh
+++ b/tests/e2e/69_package_templates.sh
@@ -133,4 +133,31 @@ grep -qi "not found in the index" out5.log || { cat out5.log; echo "missing inde
 "$MCPP" new app6 --template gui > out6.log 2>&1 || { cat out6.log; echo "gui builtin broke"; exit 1; }
 grep -qi "deprecated" out6.log || { cat out6.log; echo "missing gui deprecation"; exit 1; }
 
+# 7. Form B (mcpp = { ... }) compat package → skipped, "not found in the index".
+mkdir -p "$MCPP_HOME/registry/data/mcpplibs/pkgs/c"
+cat > "$MCPP_HOME/registry/data/mcpplibs/pkgs/c/compat.tpl-repro.lua" <<'EOF'
+package = {
+    spec      = "1",
+    namespace = "compat",
+    name      = "compat.tpl-repro",
+    type      = "package",
+    xpm = {
+        linux   = { ["0.1.0"] = { url = "https://example.invalid/x.tar.gz", sha256 = "0" } },
+        macosx  = { ["0.1.0"] = { url = "https://example.invalid/x.tar.gz", sha256 = "0" } },
+        windows = { ["0.1.0"] = { url = "https://example.invalid/x.tar.gz", sha256 = "0" } },
+    },
+    mcpp = {
+        language     = "c++23",
+        include_dirs = {"*"},
+        sources      = {"*.cpp"},
+        targets      = { tpl_repro = { kind = "lib" } },
+    },
+}
+EOF
+mkdir -p "$MCPP_HOME/registry/data/xpkgs/compat-x-compat.tpl-repro/0.1.0"
+if "$MCPP" new app7 --template tpl-repro > out7.log 2>&1; then
+    cat out7.log; echo "L7: Form B template must fail"; exit 1
+fi
+grep -qi "not found in the index" out7.log || { cat out7.log; echo "L7: wrong error for Form B skip"; exit 1; }
+
 echo "OK"


### PR DESCRIPTION
## Summary

- `fetch_template_package()` now skips Form B packages whose manifest
  is synthesized from the descriptor (`mcpp = { ... }`)
- Uses existing `mcpp::manifest::extract_mcpp_field()` API, consistent
  with `prepare.cppm` Form A/B dispatch
- 4 lines added in `src/scaffold/create.cppm`

Refs #265 (hardening — does not close it; see review comment below for the
verified root cause, which lands in a separate PR)

## Test plan

- [x] `bash tests/e2e/69_package_templates.sh` — new Form B filter case
- [x] `bash tests/e2e/02_new_build_run.sh` — no regression
- [x] `bash tests/e2e/12_add_command.sh` — no regression
- [x] `bash tests/e2e/27_namespace_dependencies.sh` — no regression
- [x] CI: Linux / macOS / Windows
