### PR TITLE
fix: remove trailing " - " in --version output and fix em dash in usage header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ target/
 .claude
 mcpp.lock
 doctor.log
+/.mcpp-bmi/
 
 # editor / OS
 .DS_Store

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -46,7 +46,7 @@ namespace mcpp::cli {
 // canonical printer here so the docs/CHANGELOG examples don't drift
 // every time cmdline tweaks its formatting.
 void print_usage() {
-    std::println("mcpp v{} — modern C++23 build tool", mcpp::toolchain::MCPP_VERSION);
+    std::println("mcpp v{} - modern C++23 build tool", mcpp::toolchain::MCPP_VERSION);
     std::println("");
     std::println("Usage:");
     std::println("Project commands:");
@@ -121,7 +121,7 @@ int run(int argc, char** argv) {
         std::string_view a = argv[1];
         if (a == "--help" || a == "-h") { print_usage(); return 0; }
         if (a == "--version" || a == "-V") {
-            std::println("mcpp {} - ", mcpp::toolchain::MCPP_VERSION);
+            std::println("mcpp {}", mcpp::toolchain::MCPP_VERSION);
             return 0;
         }
     }


### PR DESCRIPTION
## Summary
- Remove trailing ` - ` in `--version` output (src/cli.cppm:124)
- Replace Chinese em dash `—` with English `-` in usage header (src/cli.cppm:49)
- Add `/.mcpp-bmi/` to .gitignore

## Test plan
- [ ] mcpp build passes
- [ ] `mcpp --version` outputs `mcpp 0.0.103` (no trailing ` - `)
- [ ] `mcpp --help` outputs `mcpp v0.0.103 - modern C++23 build tool`