### PR TITLE
ci: publish to a Homebrew tap after each release (#313)

### DIFF
--- a/.agents/skills/mcpp-release/SKILL.md
+++ b/.agents/skills/mcpp-release/SKILL.md
@@ -231,6 +231,24 @@ git commit -am "ci: workspace mcpp bootstrap pin -> $NEW_VERSION (released, mirr
 资产 CDN 上可能还要几分钟才更新。紧接着跑的 CI 可能仍拿到旧索引并报
 `package 'mcpp@X.Y.Z' not found` —— 这不是 release 坏了，等指针稳定后重跑即可。
 
+### 下游分发渠道（都是自动的，只需核验）
+
+两条渠道都挂在 `release` workflow 的 `workflow_run: completed` 上，不需要人工推：
+
+| 渠道 | workflow | 核验 |
+|------|----------|------|
+| AUR (`mcpp-bin` / `mcpp-m`) | `.github/workflows/aur-publish.yml` | `gh run list --workflow aur-publish.yml --limit 1` |
+| Homebrew tap (`mcpp-m`) | `.github/workflows/homebrew-publish.yml` → ping [`mcpp-community/homebrew-mcpp`](https://github.com/mcpp-community/homebrew-mcpp) | `gh api repos/mcpp-community/homebrew-mcpp/contents/Formula/mcpp-m.rb --jq .content \| base64 -d \| grep '^  version'` |
+
+Homebrew 那条**不写公式**，只发一个 `repository_dispatch`；公式重写由 tap 仓库自己的
+`bump-formula.yml` 完成（它读 release 的 `.sha256` 边车）。这条 ping 依赖仓库 secret
+`HOMEBREW_TAP_TOKEN`；**没配也不会让发布失败** —— tap 有每日 schedule 兜底，24h 内自己跟上。
+想立刻跟上就手动触发一次：
+
+```bash
+gh workflow run bump-formula.yml -R mcpp-community/homebrew-mcpp
+```
+
 ### 常见失败原因
 
 | 症状 | 原因 | 修复 |

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -1,0 +1,83 @@
+name: homebrew-publish
+
+# Tell the Homebrew tap (mcpp-community/homebrew-mcpp) that a release is out.
+#
+# The tap owns the formula rewrite — it reads the .sha256 sidecars from the
+# release and commits the new url/version itself. All this workflow does is
+# fire the starting gun, so nothing here needs to know what a formula is.
+#
+# Triggers on COMPLETION of the `release` workflow rather than on
+# `release: published`, for the same reason aur-publish.yml does: release.yml
+# creates the GitHub Release in its first job but uploads the macOS / aarch64
+# assets in later jobs, and the tap needs every sidecar to exist.
+#
+# Requires one repository secret:
+#   HOMEBREW_TAP_TOKEN — fine-grained PAT scoped to mcpp-community/homebrew-mcpp
+#                        with "Contents: read and write" (repository_dispatch
+#                        is a write-level API).
+#
+# The secret is OPTIONAL. Without it this workflow logs a notice and exits 0;
+# the tap runs the same bump on a daily schedule, so a missing token costs
+# freshness (up to 24h), not correctness. That keeps a release from failing
+# over a credential the release itself doesn't need.
+
+on:
+  workflow_run:
+    workflows: [release]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (default: [package].version in mcpp.toml)"
+        required: false
+
+concurrency:
+  group: homebrew-publish
+  cancel-in-progress: false
+
+jobs:
+  notify-tap:
+    runs-on: ubuntu-latest
+    # On the workflow_run trigger, only proceed if the release actually
+    # succeeded (skip failed/cancelled release runs).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Checkout released commit
+        uses: actions/checkout@v4
+        with:
+          # workflow_run: the exact commit the release was built from.
+          # workflow_dispatch: default ref (HEAD of the branch).
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+
+      - name: Resolve version
+        id: resolve
+        run: |
+          VER="${{ github.event.inputs.version }}"
+          if [ -z "$VER" ]; then
+            # mcpp.toml at the released commit carries the right version.
+            VER=$(grep -m1 -E '^\s*version\s*=' mcpp.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          fi
+          [ -n "$VER" ] || { echo "cannot resolve version"; exit 1; }
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+          echo ":: version $VER"
+
+      - name: Ping the tap
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VER: ${{ steps.resolve.outputs.version }}
+        run: |
+          set -eu
+          if [ -z "${TAP_TOKEN}" ]; then
+            echo "::notice::HOMEBREW_TAP_TOKEN is not configured; skipping the ping. mcpp-community/homebrew-mcpp bumps itself on a daily schedule, so ${VER} reaches the tap within 24h."
+            exit 0
+          fi
+          curl -fsS -X POST \
+            -H "Authorization: Bearer ${TAP_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/mcpp-community/homebrew-mcpp/dispatches \
+            -d "{\"event_type\":\"mcpp-release\",\"client_payload\":{\"version\":\"${VER}\"}}"
+          echo ":: dispatched mcpp-release ${VER} to mcpp-community/homebrew-mcpp"
+          echo "Pinged the Homebrew tap for **${VER}**." >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,23 @@ Installs into `~/.mcpp/` and adds it to your shell PATH. Deleting `~/.mcpp` unin
 </details>
 
 <details>
-<summary><b>Option 2</b> — Arch Linux (AUR)</summary>
+<summary><b>Option 2</b> — Homebrew (macOS / Linux)</summary>
+
+```bash
+brew install mcpp-community/mcpp/mcpp-m
+```
+
+One command — it taps [`mcpp-community/homebrew-mcpp`](https://github.com/mcpp-community/homebrew-mcpp)
+and installs the same prebuilt release binary. macOS needs Apple silicon +
+macOS 14; per-user data lives in `~/.mcpp/`.
+
+Homebrew's `mcpp` is an unrelated C preprocessor, hence the `mcpp-m` formula
+name — the command it installs is still `mcpp`.
+
+</details>
+
+<details>
+<summary><b>Option 3</b> — Arch Linux (AUR)</summary>
 
 ```bash
 yay -S mcpp-bin      # prebuilt release binary
@@ -95,7 +111,7 @@ On Arch the name `mcpp` is an unrelated C preprocessor, so the packages are
 </details>
 
 <details>
-<summary><b>Option 3</b> — let an AI assistant install it for you</summary>
+<summary><b>Option 4</b> — let an AI assistant install it for you</summary>
 
 Copy the following prompt to your AI coding assistant (Claude Code / Cursor / Copilot, etc.):
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -81,7 +81,23 @@ curl -fsSL https://github.com/mcpp-community/mcpp/releases/latest/download/insta
 </details>
 
 <details>
-<summary><b>方式 2</b> — Arch Linux（AUR）</summary>
+<summary><b>方式 2</b> — Homebrew（macOS / Linux）</summary>
+
+```bash
+brew install mcpp-community/mcpp/mcpp-m
+```
+
+一条命令即可，会自动 tap [`mcpp-community/homebrew-mcpp`](https://github.com/mcpp-community/homebrew-mcpp)
+并安装同一份预编译 release 二进制。macOS 需要 Apple 芯片 + macOS 14；
+每个用户的数据仍在各自的 `~/.mcpp/`。
+
+Homebrew 上 `mcpp` 属于一个无关的 C 预处理器，所以公式名是 `mcpp-m`，
+装出来的命令仍然是 `mcpp`。
+
+</details>
+
+<details>
+<summary><b>方式 3</b> — Arch Linux（AUR）</summary>
 
 ```bash
 yay -S mcpp-bin      # 预编译 release 二进制
@@ -95,7 +111,7 @@ Arch 上 `mcpp` 这个名字属于一个无关的 C 预处理器，所以包名�
 </details>
 
 <details>
-<summary><b>方式 3</b> — 让 AI 助手帮你安装</summary>
+<summary><b>方式 4</b> — 让 AI 助手帮你安装</summary>
 
 将以下提示词复制给你的 AI 编码助手（Claude Code / Cursor / Copilot 等）：
 


### PR DESCRIPTION
Closes part of #313 (the "增加 Homebrew 作为分发渠道" item).

## What this adds

```sh
brew install mcpp-community/mcpp/mcpp-m
```

One command — `brew install <user>/<repo>/<formula>` auto-taps a repo named
`homebrew-<repo>`, so there is no separate `brew tap` step.

The formula itself lives in a new dedicated tap repo,
**[mcpp-community/homebrew-mcpp](https://github.com/mcpp-community/homebrew-mcpp)**
(already created and working). This PR is the upstream half: a workflow that
pings the tap after a release, plus docs.

## Why the formula is not in this repo

Homebrew only scans three locations in a tap (`tap.rb:950`): `Formula/`,
`HomebrewFormula/`, repo root — `scripts/` is not one of them. And a tap whose
repo isn't named `homebrew-*` can only be tapped by passing its URL, which
makes installation two commands instead of one and kills the auto-tap path.

## Why `mcpp-m` and not `mcpp`

homebrew-core owns `mcpp` — [Matsui's C preprocessor](https://formulae.brew.sh/formula/mcpp)
(675 installs/yr, not deprecated, autobump on). Same collision as `extra/mcpp`
on Arch, same resolution as `scripts/aur`: the formula is `mcpp-m`, with
`Aliases/{mcpp,mcpp-bin}` pointing at it. The installed command is still `mcpp`.

## Why a launcher, not a symlink

mcpp resolves `MCPP_HOME` from the canonicalized path of the running binary
(`src/home.cppm:77` + `src/platform/fs.cppm:97`). Linked straight into `bin`,
that path is the Cellar — the registry sandbox, caches and every downloaded
toolchain would live in a versioned directory that `brew upgrade` removes. The
formula keeps the tree under `libexec` and ships a launcher pinning
`MCPP_HOME` / `MCPP_VENDORED_XLINGS`, mirroring `scripts/aur/mcpp-bin/mcpp.sh`.

## How the sync works

`homebrew-publish.yml` never writes a formula. It sends a
`repository_dispatch` and the tap rewrites itself from the release's `.sha256`
sidecars. Trigger is `workflow_run: [release] completed`, not
`release: published` — the macOS/aarch64 assets are uploaded by later jobs
(same reasoning `aur-publish.yml` documents).

| Trigger on the tap side | When |
| --- | --- |
| `repository_dispatch` | this workflow, seconds after a release finishes |
| `schedule` (daily) | catch-up when no token is configured |
| `workflow_dispatch` | manual pin / re-run |

## Configuration needed

Repository secret **`HOMEBREW_TAP_TOKEN`** — fine-grained PAT scoped to
`mcpp-community/homebrew-mcpp`, permission **Contents: read and write**.

**It is optional.** Without it this job logs a notice and exits 0; the tap's
daily schedule lands the release within 24h. A release shouldn't fail over a
credential it doesn't itself need.

## Verified

- Tap repo created, formula + aliases + bump script pushed; symlink modes
  (`120000`) survived the push.
- The bump workflow ran end to end on GitHub twice: pinned `2026.7.30.2` from
  a dispatch payload, then resolved and restored `2026.7.30.3` from upstream's
  latest release — commit and push both succeeded despite the org's read-only
  default `GITHUB_TOKEN` (the workflow declares `permissions: contents: write`).
- `update-formula.sh` rewrite is byte-identical to the hand-written formula
  and idempotent on re-run; shellcheck clean; `ruby -c` OK.
- The published sha256 was checked against the real macOS asset
  (`1659be17…4e18`), and the tarball layout matches what the formula installs.
- `check_version_pins.sh` still OK; both workflow files parse.

Also verified by installing for real (throwaway Homebrew prefix, Linux x86_64):

```
$ brew install mcpp-community/mcpp/mcpp-m
Tapped 1 formula (20 files, 127.6KB).
==> Installing mcpp-m from mcpp-community/mcpp
🍺  .../Cellar/mcpp-m/2026.7.30.3: 8 files, 15.0MB
```

The auto-tap path works from cold (no prior `brew tap`), the layout comes out
as intended (`bin/mcpp` launcher, `libexec/{bin,registry}`), the launcher's
`MCPP_HOME` defaults to `$HOME/.mcpp` and not the Cellar, `mcpp --version`
prints `mcpp 2026.7.30.3`, and `brew uninstall` is clean. All four assertions
in the formula's `test` block were evaluated by hand against the installed keg
and pass. Fixing a `bin.mkpath` bug (Homebrew's `Pathname#write` does not
create parent directories) came out of this — it would have failed the very
first install.

Still unexercised: the macOS-specific lines (`depends_on arch: :arm64` /
`macos: :sonoma` and the arm64 asset), which need an Apple-silicon host.
