### PR TITLE
docs: document the mcpp-short-cmd aliases in both READMEs (#313)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,38 @@ irm https://d2learn.org/xlings-install.ps1.txt | iex
 
 </details>
 
+<details>
+<summary>Optional — short commands (<code>mp</code>, <code>mbuild</code>, <code>mrun</code>, …)</summary>
+
+```bash
+xlings install mcpp-short-cmd -y
+```
+
+Registers 30 shims, so `mcpp build` becomes `mbuild`. Naming rule: initial of
+every word but the last, plus the last word in full — `mcpp self doctor` →
+`msdoctor`. `mp` is bare `mcpp`. They alias the `mcpp` shim rather than a fixed
+binary, so `xlings use mcpp <ver>` switches them too.
+
+| Short | Expands to | Short | Expands to |
+| --- | --- | --- | --- |
+| `mp` | `mcpp` | `mexpkg` | `mcpp emit xpkg` |
+| `mnew` | `mcpp new` | `mxparse` | `mcpp xpkg parse` |
+| `mbuild` | `mcpp build` | `mtinstall` | `mcpp toolchain install` |
+| `mrun` | `mcpp run` | `mtlist` | `mcpp toolchain list` |
+| `mtest` | `mcpp test` | `mtdefault` | `mcpp toolchain default` |
+| `mclean` | `mcpp clean` | `mcdir` | `mcpp cache dir` |
+| `madd` | `mcpp add` | `mclist` | `mcpp cache list` |
+| `mremove` | `mcpp remove` | `mcinfo` | `mcpp cache info` |
+| `mupdate` | `mcpp update` | `mcgc` | `mcpp cache gc` |
+| `msearch` | `mcpp search` | `milist` | `mcpp index list` |
+| `mpublish` | `mcpp publish` | `miadd` | `mcpp index add` |
+| `mpack` | `mcpp pack` | `miremove` | `mcpp index remove` |
+| `msdoctor` | `mcpp self doctor` | `miupdate` | `mcpp index update` |
+| `msenv` | `mcpp self env` | `msconfig` | `mcpp self config` |
+| `msversion` | `mcpp self version` | `msexplain` | `mcpp self explain` |
+
+</details>
+
 **Other options**
 
 <details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,6 +67,37 @@ irm https://d2learn.org/xlings-install.ps1.txt | iex
 
 </details>
 
+<details>
+<summary>可选 —— 短命令（<code>mp</code>、<code>mbuild</code>、<code>mrun</code> …）</summary>
+
+```bash
+xlings install mcpp-short-cmd -y
+```
+
+装 30 个短命令，`mcpp build` 就是 `mbuild`。命名规则：除最后一个词外每词取首字母，
+最后一个词写全 —— `mcpp self doctor` → `msdoctor`；`mp` 就是裸 `mcpp`。
+它们指向 `mcpp` 这个 shim 而非固定路径，所以 `xlings use mcpp <ver>` 也会一起切换。
+
+| 短命令 | 展开 | 短命令 | 展开 |
+| --- | --- | --- | --- |
+| `mp` | `mcpp` | `mexpkg` | `mcpp emit xpkg` |
+| `mnew` | `mcpp new` | `mxparse` | `mcpp xpkg parse` |
+| `mbuild` | `mcpp build` | `mtinstall` | `mcpp toolchain install` |
+| `mrun` | `mcpp run` | `mtlist` | `mcpp toolchain list` |
+| `mtest` | `mcpp test` | `mtdefault` | `mcpp toolchain default` |
+| `mclean` | `mcpp clean` | `mcdir` | `mcpp cache dir` |
+| `madd` | `mcpp add` | `mclist` | `mcpp cache list` |
+| `mremove` | `mcpp remove` | `mcinfo` | `mcpp cache info` |
+| `mupdate` | `mcpp update` | `mcgc` | `mcpp cache gc` |
+| `msearch` | `mcpp search` | `milist` | `mcpp index list` |
+| `mpublish` | `mcpp publish` | `miadd` | `mcpp index add` |
+| `mpack` | `mcpp pack` | `miremove` | `mcpp index remove` |
+| `msdoctor` | `mcpp self doctor` | `miupdate` | `mcpp index update` |
+| `msenv` | `mcpp self env` | `msconfig` | `mcpp self config` |
+| `msversion` | `mcpp self version` | `msexplain` | `mcpp self explain` |
+
+</details>
+
 **其他方式**
 
 <details>


### PR DESCRIPTION
Covers the "命令自身支持别名调用" item in #313.

`xlings install mcpp-short-cmd -y` already ships
([xim-pkgindex `pkgs/m/mcpp-short-cmd.lua`](https://github.com/openxlings/xim-pkgindex/blob/main/pkgs/m/mcpp-short-cmd.lua)),
but nothing in this repo mentioned it — so the answer to "does mcpp support
aliases" read as "no, add them to your shell rc yourself".

## Where it goes

Under the recommended `xlings install mcpp` block, as a collapsed
`<details>` — not a new numbered option. It isn't a way to install mcpp; it's
something you add after installing it. Collapsed keeps a 30-row table out of
the way of first-time readers.

Both `README.md` and `README.zh-CN.md`.

## Content

One command, the naming rule, and the full table:

> Registers 30 shims, so `mcpp build` becomes `mbuild`. Naming rule: initial of
> every word but the last, plus the last word in full — `mcpp self doctor` →
> `msdoctor`. `mp` is bare `mcpp`. They alias the `mcpp` shim rather than a
> fixed binary, so `xlings use mcpp <ver>` switches them too.

The rule is stated so the table works as a reference rather than something to
memorise, and the shim detail answers the obvious follow-up ("do the short
commands still point at the old version after I switch?").

## Verified

Both tables were diffed entry-by-entry against the descriptor's `SHORT_CMDS`
map: **30/30 present, no extras, no wrong expansion**, in both languages.
Worth doing — a hand-copied alias table is exactly the kind of thing that
silently drifts one entry.