### PR TITLE
fix(build): make the C++ runtime contract one decision (#336)

### DIFF
--- a/.agents/docs/2026-08-02-issue336-pr142-analysis.md
+++ b/.agents/docs/2026-08-02-issue336-pr142-analysis.md
@@ -1,0 +1,357 @@
+# 深度分析:issue #336(macOS 静态 libc++)与 mcpp-index PR #142(boost-ext.ut)
+
+> 日期:2026-08-02 · 分析基准:mcpp `main` @ 76152d9(v2026.8.2.2)、mcpp-index PR #142 @ `c8cbfa14`
+> 验证手段:本地读码 + 本地 libc++ 20.1.7 归档反汇编 + GitHub CI/诊断作业日志
+> **未做**:macOS 上的端到端复现(本机无 macOS,所有 macOS 运行期结论均标注证据来源)
+
+---
+
+## 0. TL;DR
+
+- **issue #336 的两条主张都成立**,且问题二比 issue 标题暗示的更严重:它不是"测试二进制"的问题,**默认配置下任何 macOS 产物(含 `mcpp build` 出的可执行文件)只要有全局对象在静态初始化期碰 `std::cout` 就必崩**,自 0.0.50(#116)起就存在;0.0.86(#202)只是把测试二进制也拖进同一形态,并顺手废掉了唯一的逃生门。
+- **问题一(`static_stdlib=false` 对测试失效)是纯粹的疏漏**,`flags.cppm:659-682` 与 `:636-658` 是同一段逻辑的两份推导,只有后者带 `f.staticStdlib` 门。这是本仓的老病灶("同一决策两处推导")。
+- **issue 对问题二的根因链正确,但对"为什么包侧修不了"的归因错了**:它写的是"静态库符号的 ODR 实体分裂",而 PR #142 自己的诊断日志(`nm` 只有一个 `DoIOSInitC1Ev` 定义、shim 确实绑到它)与本地反汇编都指向**纯粹的次序问题**——shim 排在第 3 个初始化器,而崩溃点排在它前面。
+- **本地反汇编推翻了两条被写进 issue/PR 的"事实"**:
+  1. `std::__1::ios_base::Init::Init()` 在 libc++ 20 **不是空的**(fork PR 的 status note 说"empty");它是带 `__cxa_guard` 的函数内静态,内部调用 `DoIOSInit::DoIOSInit()`,而 `DoIOSInit::DoIOSInit()` **就是真正 placement-new 出 `cin/cout/cerr` 的那个函数**(重定位表里直接引用 `_ZNSt3__1L6__coutE` / `_ZNSt3__14coutE` / `basic_ostream` 的 vtable)。
+  2. 但 `ios_base::Init` 在 libc++ 头文件里**只有前向声明**(`ios:70: class Init;`,全树无定义)。**标准为 SIOF 提供的官方解药在 libc++ 上对用户不可用**——这才是"包侧修不了"的真原因,而且它比 issue 写的理由更硬:不是修不好,是**标准接口根本没暴露**。
+- 由此得到一条 **issue 没列的第 4 种修法**,它能修默认路径而不是只修逃生门:**在 macOS 静态 libc++ 时,由 mcpp 在链接行 `$in` 的最前面插一个自带的 stream-init 对象**。成本极小,收益是"默认就对"。
+- **PR #142 当前不可合并**,不只是因为被 #336 卡住:它带着 155 行临时诊断 workflow、PR 正文与代码已经不一致(正文描述的是两次迭代之前的形态)、设计文档里写着一个**已被证伪的根因**,而描述符文件顶部的权威注释同样把一个**不成立的根因**(module `std::cout` ODR 分裂)写成了事实,并为此付出了实实在在的代价(丢掉 `export import std;` + 24 行 GMF + 一个 Clang 上不存在的 `-Wno-template-body`)——而该"修复"根本没修好(CI 仍 139)。
+
+---
+
+## 1. 事实核验表
+
+| # | issue/PR 的主张 | 核验结果 | 证据 |
+|---|---|---|---|
+| 1 | `ldStdlibDefault` 尊重 `staticStdlib` | ✅ 属实 | `src/build/flags.cppm:636` `if (f.staticStdlib && !macosDeploymentTarget.empty() && !llvmRootForStdlib.empty())` |
+| 2 | `ldStdlibTest` 无条件注入静态 `-load_hidden` | ✅ 属实 | `src/build/flags.cppm:673` `if (!llvmRootForStdlib.empty())` —— 无 `staticStdlib` 项 |
+| 3 | 按 `LinkUnit::TestBinary` 二选一 | ✅ 属实 | `src/build/ninja_backend.cppm:1222-1223` |
+| 4 | 该行为自 #202 起 | ✅ 属实 | `git log -S ldStdlibTest`:`3730d23 fix(build): macOS test binaries link the toolchain's own libc++ (A1) + unpin llvm (#202)` |
+| 5 | 文档仍写着可以 opt-out | ✅ 属实 | `docs/05-mcpp-toml.md:197`、`docs/zh/05-mcpp-toml.md:181` |
+| 6 | 链接行是 `$cxx $in -o $out $ldflags $unit_ldflags`(静态库在目标文件之后) | ✅ 属实 | `src/build/ninja_backend.cppm:781` |
+| 7 | `static_stdlib` 不能按平台条件化 | ✅ 属实,且是**显式设计** | `src/manifest/toml.cppm:1052` `kKnownConditionalBuildKeys` 只有 8 个输入类键;`:1066` 的警告文案明确把 `static_stdlib` 与 `target`/`linkage` 一起归为"selection knobs …cannot be conditioned";`ConditionalConfig` 只携带 `BuildInputs`(`types.cppm:347-362`,注释说明这是**刻意**的防漂移设计) |
+| 8 | libc++ 的 `<iostream>` 没有 `ios_base::Init` 守卫 | ✅ 属实 | 本地 libc++ 20.1.7 头树:`iostream` 里零 `Init`;`ios:70` 只有 `class Init;` 前向声明,**全树无定义** |
+| 9 | 真正构造流的是带优先级的 `_GLOBAL__I_000100` | ✅ 属实 | 本地 `llvm-ar x libc++.a iostream.cpp.o` + `objdump -dr`:`_GLOBAL__I_000100` → `__start_std_streams` → `ios_base::Init::Init()` → `DoIOSInit::DoIOSInit()`,后者的重定位表直接写 `__cout`/`cout`/`basic_ostream` vtable |
+| 10 | PR #142 的 macOS CI 因此挂 | ✅ 属实 | run 30749985831 job 91502184327:`Running bin/ut` → `ut ... FAIL (exit 139)`;linux/windows 两条腿绿 |
+| 11 | "libc++ 20 的 Init ctor 是空的"(fork PR #1 status) | ❌ **不成立** | 反汇编见 #9;`ios_base::Init::Init()` = guard acquire → `DoIOSInit` ctor → `__cxa_atexit` → guard release |
+| 12 | "包内 9 种修复全失败,因静态库符号 ODR 实体分裂"(issue) | ⚠️ **结论对、归因错** | 诊断日志 `=== nm: who defines _ZNSt3__19DoIOSInitC1Ev ===` **只有一个定义**,S5 的 `ut_doios` 反汇编里 `bl 0x10003bf64 ; std::__1::DoIOSInit::DoIOSInit()` 绑的就是它 —— 没有分裂。真原因是 shim 的初始化器排在 `__init_offsets` **第 3 位**,崩溃点在它之前 |
+| 13 | 描述符注释:macOS 崩溃因 `export import std;` 造成 module 与库两份 `std::cout`(dev 1) | ❌ **不成立** | (a) issue 的最小复现是 `#include <iostream>` + 全局对象,**零模块**;(b) dev 1 已在 `3eff2899` 合入,head `c8cbfa14` 的 macOS CI **仍然 139** |
+| 14 | 设计文档 §2.3:因模块 BMI 未带模板成员定义 → dispatch 落空槽 | ❌ **不成立** | 同上;且崩溃地址 `0xffffffffffffffe8` = `this + (-0x18)`,是 vptr 为零的读取,不是未实例化 dispatch |
+| 15 | issue 复现段:"加 `static_stdlib = false` 依然崩" | ⚠️ **与代码不符,需在 macOS 复核** | `mcpp build && mcpp run` 产出的是 `LinkUnit::Binary`,走 `ldStdlibDefault`;`staticStdlib=false` 时它就是 `-lc++`(动态)→ 按 issue 自己的实验 E 应当**不崩**。问题一只影响 `mcpp test`。这条复现步骤大概率是把 `mcpp test` 的观察写到了 `mcpp run` 上 |
+
+---
+
+## 2. 问题一:opt-out 对测试二进制失效
+
+### 2.1 机制
+
+`flags.cppm` 在 macOS 分支里对同一件事(该链静态 libc++ 归档还是动态 `-lc++`)推导了**两次**:
+
+```
+:617-618   f.ldStdlibDefault = " -lc++";  f.ldStdlibTest = " -lc++";
+:636       if (f.staticStdlib && !macosDeploymentTarget.empty() && !llvmRootForStdlib.empty())
+:654-656       f.ldStdlibDefault = " -nostdlib++ -Wl,-load_hidden,libc++.a -Wl,-load_hidden,libc++abi.a";
+:673       if (!llvmRootForStdlib.empty())            // ← 少了 staticStdlib 与 deploymentTarget 两个条件
+:678-680       f.ldStdlibTest    = " -nostdlib++ -Wl,-load_hidden,libc++.a -Wl,-load_hidden,libc++abi.a";
+```
+
+这正是本仓反复出现的那类债:**同一决策在两处独立推导,新语义只加在其中一处**。#202 的意图(测试别再用系统 `-lc++` 配工具链头文件,那会炸 `__hash_memory`)是合理的,但它把"默认形态"和"唯一形态"混为一谈。
+
+### 2.2 影响面
+
+- `mcpp test` 在 macOS 上**没有任何**方式回到动态 libc++;
+- `docs/05-mcpp-toml.md` 与中文版同步说谎,已经说了约一年(#124 的措辞至今未改);
+- 对 PR #142 这类包,后果不是"少个选项",而是**没有任何 workaround 能让 CI 转绿**。
+
+### 2.3 修法(issue 建议 1)代价与风险
+
+把 `:673` 的条件对齐 `:636` 即可,~1 行。但必须同时讲清楚 **opt-out 的真实代价**,否则等于把 #202 修掉的坑重新挖开给用户踩:
+
+- `staticStdlib=false` ⇒ 测试链系统 `/usr/lib/libc++.1.dylib`,却仍用工具链的 libc++ **头文件**编译。issue 的实验 E 在 llvm@20.1.7 上通过,但 #202 的原始故障是 **libc++ 22 把 string hashing 移出内联**导致 `undefined __hash_memory` —— 也就是说**这条路在 llvm@22 上大概率仍然坏**。
+- 因此建议:合入 1 的同时,在 `staticStdlib=false` 且 macOS 且工具链 libc++ 主版本 > 系统时**发一条 schema/build 警告**,而不是静默切换。
+
+---
+
+## 3. 问题二:静态 libc++ 下的初始化次序(真正的缺陷)
+
+### 3.1 完整机制链(本地反汇编逐环证实)
+
+```
+用户/依赖 TU 的全局对象 ctor  ──┐
+                                ├─ 都进主可执行文件的 __init_offsets,顺序 = 链接顺序
+libc++.a::iostream.cpp.o     ──┘   (归档成员按需拉取 ⇒ 永远排在目标文件之后)
+
+iostream.cpp.o 里:
+  _GLOBAL__I_000100                 ← 带优先级标记,但 Mach-O 没有 ELF 的 .init_array.<prio> 机制
+    └→ __start_std_streams : ios_base::Init
+         └→ ios_base::Init::Init()  ← 非空!guard acquire → ... → guard release
+              └→ DoIOSInit::DoIOSInit()
+                   └→ placement-new __cin/cin/__cout/cout/__cerr/cerr  ← 真正构造流的地方
+```
+
+- ELF 上不会出问题:链接器按 `.init_array.NNNNN` 段名排序,priority 101 天然排到用户全局(默认 65535)之前。
+- Mach-O 上 `init_priority` **只在单个 TU 内有意义**(clang 在 TU 内部排 `__mod_init_func`),跨 TU 完全是链接顺序。
+- 动态 libc++ 之所以永远正确:dyld 保证被依赖的 image 先于依赖它的 image 初始化,`libc++.1.dylib` 的初始化器整体跑在主可执行文件之前。**"静态 vs 动态"才是分界线,`-load_hidden` 与此无关**——issue 的这个判断是对的。
+
+结论:**这是 Darwin 上"静态链接 libc++ + 全局对象用流"的通用缺陷,不是 mcpp 引入的**;但 mcpp **把它设成了默认**,并且没有诊断、没有文档、在测试路径上还没有开关。
+
+### 3.2 为什么包侧修不了(比 issue 给的理由更硬)
+
+issue 归因为"静态库符号的 ODR 实体分裂"。这条被 PR #142 自己的诊断日志证伪(见核验表 #12)。真实约束是两条:
+
+1. **标准的解药在 libc++ 上不可用**。`[ios.base]` 规定 `std::ios_base::Init` 是可用的完整类型,`<iostream>` 的效果等同于声明一个 `ios_base::Init` 静态对象——libstdc++/MSVC STL 正是这么做的,所以它们不受影响。libc++ **只在 `ios:70` 前向声明 `class Init;`,全头树无定义**,用户写 `std::ios_base::Init x;` 编译不过。也就是说:**在 libc++ 上,用户没有任何符合标准的手段解决 SIOF**。
+2. **剩下的都是 TU 内次序问题**。S5 实验(自行声明 `DoIOSInit` 并构造)符号绑定完全正确,唯一的毛病是它的初始化器排在 `__init_offsets` 第 3 位,而崩溃的初始化器在它之前。这**不是**"包侧修不了"的证据,而是"shim 放错位置"的证据。
+
+> 由 #2 直接得到一条**尚未被试过的包侧修法**:把 shim 放到 `#include "ut.hpp"` **之前**(同一 TU 内声明序即初始化序)。若 `cfg` 的初始化器来自 ut.hpp,shim 前置后应当排到它之前。**这条值得在 PR #142 上先试一次**——它可能让 PR 在 mcpp 修复落地前就能自解。
+
+### 3.3 修复选项评估
+
+| 选项 | 是什么 | 修默认路径? | 成本 | 风险 |
+|---|---|---|---|---|
+| **1. `ldStdlibTest` 跟随 `staticStdlib`**(issue 建议 1) | 对齐 `:673` 的门 | ❌ 只恢复逃生门 | ~1 行 + e2e | 低;但把 #202 的 header/dylib 版本裂开重新暴露给显式 opt-out 的用户(llvm@22 上可能仍坏) |
+| **2. `static_stdlib` 可条件化**(issue 建议 2) | 加进 `kKnownConditionalBuildKeys` | ❌ | 中 | **与既有设计正面冲突**:`ConditionalConfig` 刻意只携带 `BuildInputs`,注释明写"key 不在其中就无法静默解析"。要做就得开第二条通道(`conditionalSelectors`),不能简单加 key。**但 toml.cppm:1066 把 `static_stdlib` 与 `target`/`linkage` 并列的理由不成立**:前者仅在 `flags.cppm:512` 被读,严格晚于 `merge_conditional_build_inputs`,不构成循环;后两者才真的参与谓词求值本身 |
+| **3. 修 lld 的初始化器排序** | 上游 LLVM | ✅ | 极高 | **基本不可行**:Mach-O 格式层面就没有 ELF 的按优先级分段机制,不是 lld 的疏忽 |
+| **4.(本报告新增)mcpp 注入 stream-init 对象** | macOS + 静态 libc++ 时,生成一个极小 TU 排在 `$in` **最前**,构造流 | ✅ **修默认** | 小 | 依赖 libc++ 内部符号(见下) |
+
+**选项 4 的具体形态**(避免伪造 `namespace std` 里的类型,用 asm label 直接绑符号):
+
+```cpp
+// target/.mcpp/macos_stream_init.cpp —— 仅 macOS + 静态 libc++ 时生成,排在链接行首位
+extern "C" void mcpp_libcxx_ios_init(void*) asm("__ZNSt3__18ios_base4InitC1Ev");
+namespace { struct Force { Force() { char storage[1]; mcpp_libcxx_ios_init(storage); } } force; }
+```
+
+要点:
+- 调 `ios_base::Init::Init()` **而不是** `DoIOSInit::DoIOSInit()`,因为前者带 `__cxa_guard`,后来 `_GLOBAL__I_000100` 再跑一次时是 no-op;直接调后者会对已构造的流二次 placement-new。
+- 该对象排在 `$in` 首位 ⇒ `__init_offsets[0]`,先于任何用户/依赖初始化器。
+- 它引用 libc++ 的符号 ⇒ 把 `iostream.cpp.o` 从 `-load_hidden` 归档拉进来,可见性仍是 hidden,不破坏 #117 的 split-brain 修复。
+- 唯一代价:耦合 `_ZNSt3__18ios_base4InitC1Ev` 这个 mangled 名。它是 libc++ ABI 的**导出稳定符号**(`_LIBCPP_EXPORTED_FROM_ABI`),多年未变;且可以在生成时用 `llvm-nm` 校验符号存在,不存在就退回现状 + 发诊断。
+
+**推荐组合**:**1 + 4 + 文档**。1 恢复承诺过的语义(低成本、马上让 PR #142 有出路);4 让默认路径真正正确(这才是缺陷本身);文档补一段 macOS 静态 libc++ 的 SIOF 说明。选项 2 独立评估——它有独立价值(跨平台工程确实需要按平台关静态 stdlib),但**不该作为本 bug 的修法**,那是拿工程配置去绕引擎缺陷。
+
+### 3.4 必须补的回归测试
+
+`mcpp` 现有 e2e 没有任何一条覆盖"静态初始化期用流"。建议加一条 macOS-only e2e:
+
+```cpp
+#include <iostream>
+struct G { G() { std::cout.rdbuf(); } } g;
+int main() { std::cout << "ok\n"; }
+```
+断言:(a) 默认 `mcpp build && mcpp run` 输出 `ok`(选项 4 落地后);(b) `mcpp test` 同源用例通过;(c) `static_stdlib=false` 时 `otool -L` 含 `libc++.1.dylib`(选项 1 落地后)。
+
+---
+
+## 4. PR #142(boost-ext.ut)独立评审
+
+包本身的形态判断是对的:`boost-ext` 独立命名空间(非 `compat`、非 `boost`)、`name = "ut"` 单原子段、Form B + `generated_files` wrapper、pin 在 v2.3.1 release tag、无 feature。**但当前 head 不可合并**,按严重度排:
+
+### 4.1 阻塞级
+
+1. **macOS CI 红**(exit 139)。根因在 mcpp,不在包。除非 §3.2 末尾的"shim 前置"包侧试验成功,否则应**等 #336 修复后再合**。
+2. **`.github/workflows/diag-ut-macos.yml`(155 行)是临时诊断产物,必须删**。19 个 commit 里 16 个是诊断 churn,合并前需要 squash 成一条。
+
+### 4.2 正确性 / 一致性级
+
+3. **描述符顶部的权威注释写了一个已被证伪的根因**。它把 macOS 崩溃归因为 `export import std;` 造成 module 与库两份 `std::cout` 的 ODR 分裂,并称 dev 1 是"the macOS fix"。事实是:dev 1 已合入,macOS 仍 139;而 issue 的最小复现根本不含模块。这段注释会长期误导后来者,**必须重写**。
+4. **dev 1 的代价是白付的**。为了这个不成立的根因,描述符丢掉了上游干净的 `export import std;`,换来 24 行 GMF `#include` 列表 + `-Wno-template-body`。既然它没修好任何东西,应当**回退 dev 1、恢复 `export import std;`**——除非能证明 dev 1 独立地修了别的什么(目前证据里没有)。
+5. **`cxxflags = { "-Wno-template-body" }` 在 Clang 上是未知警告选项**。诊断日志里明写:`warning: unknown warning option '-Wno-template-body'; did you mean '-Wno-empty-body'?`。它在两条 Clang 平台上给每次编译加一条噪音警告,并且在任何开 `-Werror` 的消费端会直接失败。若 dev 1 回退后不再需要它,一并删;若仍需要,应当按编译器族条件化。
+6. **设计文档 §2.3 记录的根因(模块 BMI 未带模板成员定义 → dispatch 落空槽)同样已被证伪**,§6 表格里还有一处版本号笔误(`"2.2.3"` 应为 `"2.3.1"`)。设计文档是本仓的知识资产,留着错误根因比不留更糟。
+7. **PR 正文与代码严重脱节**:正文描述的是"verbatim 上游 cppm + 两处 shim、不删任何一行",而实际文件已经删了 `export import std;`、加了 GMF、加了 `-Wno-template-body`、加了 dev 3 的 8 行显式实例化;正文的验证表也只覆盖 Windows 两条工具链,没有 macOS。**合并前必须重写正文**。
+
+### 4.3 次要
+
+8. 4 个新文件缺行尾换行(`\ No newline at end of file`)。
+9. dev 3(从上游 `master` 取的显式实例化块)与 dev 1 的关系在注释里自相矛盾:一处说 dev 3 修 macOS SIGSEGV(设计文档 §2.4 表格),另一处说"dev 3 does NOT address the macOS ODR-split, dev 1 does"(描述符注释)。实际两者都没修 macOS。留 dev 3 本身无害(上游自己的 forward-port),但理由要写对。
+10. CN 镜像缺失是已知且 lint 允许的,不阻塞。
+
+---
+
+## 5. 建议行动
+
+**mcpp 侧(issue #336)**
+
+1. 修 `flags.cppm:673` 的门,对齐 `:636`(issue 建议 1),并对 macOS + `staticStdlib=false` + 工具链 libc++ 版本高于系统的组合加一条构建警告。
+2. 落地选项 4(注入 stream-init 对象),修默认路径。
+3. 补 §3.4 的 macOS e2e 三条断言。
+4. 文档:`docs/05-mcpp-toml.md` + 中文版补一段 macOS 静态 libc++ 与静态初始化次序的说明。
+5. 选项 2(`static_stdlib` 条件化)另开 issue 评估——顺带修正 `toml.cppm:1066` 那条警告文案里对 `static_stdlib` 的错误归类。
+
+**mcpp-index 侧(PR #142)**
+
+1. 立刻试一次"shim 前置到 `#include \"ut.hpp\"` 之前"——若成功,PR 可自解,不必等 mcpp。
+2. 无论上条结果如何:删 diag workflow、squash、回退 dev 1(含 `-Wno-template-body`)、重写描述符顶部注释与设计文档 §2.3/§2.4、重写 PR 正文、补行尾换行。
+3. 在 PR 正文里明确链接 #336,说明 macOS 腿的红是引擎缺陷而非包缺陷。
+
+---
+
+## 6. 从 mcpp 视角的评估:需要修吗 / 应该修吗
+
+### 6.1 先把"谁的缺陷"讲清楚
+
+缺陷本身**不是 mcpp 造的**:Darwin 上静态链接 libc++ 会丢跨 TU 初始化次序,是 Mach-O 格式 + libc++ 头文件不带守卫这两件事叠出来的。Apple 与 LLVM 的主流姿态一直是"别静态链 libc++"。
+
+但**默认值是 mcpp 选的**。#116 把 macOS 默认设成静态 libc++ 有正当理由(系统 libc++ 会把可运行下限钉死在构建机的 OS 版本,`std::print` 的支撑符号在 macOS 14 上不存在,是真实的用户可见 bug)。选了一个与平台主流相反的默认,就要自己扛住这个默认引入的失败模式——**mcpp 拥有的不是缺陷,是默认值的后果**。这一条决定了"应该修"。
+
+### 6.2 稳定性评估
+
+**缺陷侧的失败质量是最坏的一档**:
+
+- 确定性(不是竞态),但**零诊断**:`exit 139`、无任何输出、`mcpp test` 只报 `FAIL (exit 139)`;
+- **非局部**:崩溃点在依赖的头文件里(`ut.hpp:1620`),没有任何线索指向链接参数;
+- **静默**:构建全绿,只在运行期炸;
+- 触发条件"全局对象的构造函数里用流"并不罕见(日志单例、自注册型测试框架、静态 `std::ostream&` 包装),PR #142 一次就撞上了。
+
+**修复侧的爆炸半径高度不对称**,这决定了推进节奏:
+
+| 修法 | 影响面 | 最坏情况 | 可回退性 |
+|---|---|---|---|
+| 建议 1(补 `staticStdlib` 门) | **只在用户显式写 `static_stdlib=false` 时改变行为**,默认路径字节不变 | 显式 opt-out 的用户在 llvm@22 上撞回 #202 的 `__hash_memory` | 改回 1 行 |
+| 选项 4(注入 init shim) | **每一次 macOS 链接**;指纹变化触发一次全量重建 | libc++ 未来改掉 `_ZNSt3__18ios_base4InitC1Ev` ⇒ **链接期报错(响的,不是静默的)** | 生成时 `llvm-nm` 探针,查不到就退回现状 + 发诊断 |
+| 建议 2(条件化 `static_stdlib`) | 新增 manifest 语义,**永久 API 面** | 语义面一旦发布不可撤 | 不可回退 |
+
+一个容易被误判成"hack"的点值得说清:**选项 4 不是绕过,是把静态链接恢复成动态链接本来就提供的保证**。动态 libc++ 之所以永远正确,正是因为 dyld 让库的初始化器整体跑在主可执行文件之前;shim 做的就是同一件事。`ios_base::Init::Init()` 带 `__cxa_guard`,提前调用只是把构造点前移,不改变任何既有正确程序的语义。
+
+**回归测试是空洞**:全仓 e2e 没有任何一条覆盖"静态初始化期使用标准库运行期状态"。这个空洞独立于本 bug 存在——它是"能不能锁住"的问题,不是"这次修没修对"的问题。
+
+### 6.3 跨平台评估
+
+精确的暴露面**只有一格**(libstdc++ 一侧本地验证):
+
+| 平台 / stdlib | `<iostream>` 是否自带守卫 | 静态链接时 | 结论 |
+|---|---|---|---|
+| Linux/MinGW × libstdc++ | ✅ `iostream:82: static ios_base::Init __ioinit;`(gcc 16.1.0 本地实测) | 每个 TU 自带守卫 | 免疫 |
+| Linux × libc++ | ❌ 无守卫 | ELF 按 `.init_array.00101` 段名排序 | 免疫 |
+| Windows × MSVC STL | (未本地验证)由 CRT 初始化段保证 | — | CI 实测绿 |
+| **macOS × libc++** | ❌ 无守卫 | **Mach-O 无按优先级分段,`init_priority` 只在单 TU 内有效** | **必坏** |
+
+两条推论:
+
+1. **修复应当键在 "Mach-O × 静态 libc++" 这个交集上**,不是键在 "macOS"。若将来 mcpp 支持 iOS 或别的 Mach-O 目标,是同一格;若 Linux 走 clang+libc++ 静态,不是。
+2. **这是一个方向相反的可移植性悖论**:`static_stdlib=true` 是为了让**产物**跨 macOS 版本可移植而引入的,副作用却是让**源码**跨 OS 不可移植——同一份合法 C++ 在三个平台正常、在第四个平台启动即崩。这直接打在 mcpp 的产品命题("同一份 manifest、同一份源码、四个平台")上,比"有多少人会踩"更重要。
+
+**与既有决策的一致性**也指向同一个方向。mcpp 处理平台差异的既定政策是**吸进引擎、让 manifest 保持统一**,已有四个先例:PE 无 RPATH → 引擎把依赖 DLL 拷到 exe 旁;MinGW 独立 exe 惯例 → 引擎发 `-static`;musl 的 PT_INTERP → 引擎让 host helper 静态;#195 hermetic link → 引擎补 `-B`。**选项 4 是这条政策的直接延续;建议 2 是对它的背离**——它把引擎缺陷翻译成"每个工程自己在 manifest 里写一句话绕开"。
+
+### 6.4 通用架构评估
+
+**(a) "同一决策两处推导"再次命中,而且第三个消费者已经在那儿了。**
+`ldStdlibDefault` / `ldStdlibTest` 是"这个链接单元该拿静态还是动态 libc++"的两份独立推导,新语义只加在其中一份 ⇒ 契约静默收紧。架构级修法不是补一个门,而是**收敛成一个 `(LinkUnit::Kind, staticStdlib, toolchain) → stdlib 链接策略` 的函数**。
+顺带一个**需要单独核实的问题**:`ninja_backend.cppm:1222` 是二分派,凡非 `TestBinary` 都吃 `ldStdlibDefault`——**`SharedLib` 也在内**。也就是说 macOS 上产出的 `.dylib` 会把一份 hidden libc++ 静态嵌进去。hidden 保证了不与宿主的那份串绑(这正是 #117 想要的),但一旦有 std 类型跨 dylib 边界传递,两份 libc++ 的 ABI 就分家了。这不是本 issue 的范围,但它恰好是"两处推导"漏掉第三种情形的活样本。
+
+**(b) "选择旋钮 vs 构建输入"的判据画错了一格。**
+`ConditionalConfig` 只携带 `BuildInputs`、超出即拒的设计是好的(防漂移,`types.cppm:347-362` 的注释写得很清楚)。但 `toml.cppm:1066` 给出的分类理由是"selection knobs …resolved before the predicate is evaluated",而 `static_stdlib` **只在 `flags.cppm:512` 被读,严格晚于 `merge_conditional_build_inputs`**,不构成循环。真正的判据应该是 **"它是否参与解析出 target triple 本身"**:`target` 和 `linkage` 参与(循环),`static_stdlib` 不参与。这条误分类**独立于本 bug 有价值**,值得单独修——但**不该拿它当本 bug 的修法**。
+
+**(c) 缺少链接单元语义的一等模型。**
+Default/Test 的分叉背后是一条真实语义:*测试二进制跑在构建机上,分发产物必须自包含*。现在它被编码成两个字符串字段,而不是一条策略。若显式建模(如 `StdlibLinkPolicy { SelfContained, HostCoupled }`,再由 LinkUnit 种类 + 目标格式推导),"测试可以host-coupled"就成了可读的决策,第三种情形也就无处可漏。
+
+**(d) 零诊断是独立的产品缺口。**
+2026.8.1.1 刚做完"`mcpp test` 可观测/有界"。同一条线上,macOS 下子进程以 SIGSEGV 且**零输出**退出时,mcpp 完全有条件发一条提示("macOS 静态 libc++:全局对象在静态初始化期使用标准库流会崩,见 …;可用 `[build] static_stdlib = false` 规避")。成本极低,且即使选项 4 不落地也能把这类事故从"不可行动"变成"三分钟定位"。
+
+### 6.5 结论与优先级
+
+| 档 | 事项 | 依据 | 成本 |
+|---|---|---|---|
+| **必修** | `flags.cppm:673` 补 `staticStdlib` 门 + 两处推导收敛成一处 | 文档化契约被静默违反,属缺陷而非设计问题;默认路径零影响 | ~1 行 + 收敛重构 + e2e |
+| **必修** | 文档补 macOS 静态 libc++ 的静态初始化次序说明 | 现在文档在说谎 | 一段话 |
+| **应修** | 运行期诊断(macOS + 静态 libc++ + 子进程 SIGSEGV 且零输出) | 把不可行动的 139 变成可行动 | 小 |
+| **应修** | 选项 4:注入 init shim,修默认路径 | 产品命题层面的跨平台一致性;与既有"吸进引擎"政策一致 | 中,必须带 `nm` 探针 + 静默回退 + macOS CI 证据 |
+| **另开** | `static_stdlib` 条件化 + 修正 `toml.cppm:1066` 的误分类 | 独立有价值,但不是本 bug 的修法 | 中 |
+| **不做** | 翻掉 macOS 静态 libc++ 默认 | 会直接退回 #116(下限钉死在构建机 OS) | — |
+| **不做** | 等 lld / Mach-O 修排序 | 格式层面就没有该机制 | — |
+| **平行** | 向 LLVM 反馈 `ios_base::Init` 在头文件里无定义 | 看上去不符合 [ios.base];是根上的修,但慢,且不能替代上面任何一条 | 小 |
+
+一句话:**必修的那条是缺陷不是设计题,今天就能进下一个补丁版;真正值得投的是选项 4,因为它修的是"同一份源码四平台一致"这条产品命题,而不是某个包的 CI。建议 2 有它自己的价值,但拿它当修法等于把引擎缺陷外包给每一个用户的 manifest。**
+
+---
+
+## 7. 延伸:mcpp 需要支持"动态"吗 / 构建与分发的核心
+
+### 7.1 一个布尔值,四种真实语义
+
+`static_stdlib` 是个构建词汇("怎么链"),但代码里它在四种配置上展开成四种**分发结果**:
+
+| 配置 | `static_stdlib = true` 实际做了什么 | 产物的运行期 C++ 依赖 |
+|---|---|---|
+| Linux × libstdc++ | `-static-libstdc++` | 无(自包含) |
+| Windows MinGW × libstdc++ | **`-static` 整条链**(连 libwinpthread) | 无(自包含) |
+| macOS × libc++ | `-nostdlib++ -Wl,-load_hidden,libc++.a` | 无(自包含,但引入本 bug) |
+| **Linux × libc++(clang 工具链)** | **什么都不做**(`flags.cppm:520` 要求 `stdlib_id == "libstdc++"`,`needs_explicit_libcxx` 只在 macOS 为真) | **工具链的 `libc++.so.1`** —— 既不自包含也不宿主耦合,是**工具链耦合** |
+
+第四行不是推测:llvm 22.1.8 的 slim 包漏带 `libatomic.so.1` 时,`import std` 产物运行期报 `cannot open` —— 那次事故本身就证明了这条配置下的产物动态依赖工具链目录。
+
+**同一个 `true`,三种不同的分发结果,其中一种是静默空转。** 这不是疏忽堆出来的,是因为这个字段名描述的是**手段**,而它承载的是**意图**。
+
+### 7.2 需要支持动态吗:需要,但"支持动态"是错的提法
+
+先说需要的那一面——有些场景动态不是次优而是**唯一正确**:
+
+- **发行版打包**:Debian/Fedora/Homebrew/AUR 的打包政策普遍要求链系统运行时,静态链会被拒。mcpp 刚做完 Homebrew 分发,这条离得很近。
+- **插件 / `dlopen` 模型**:宿主与插件必须共享同一份 stdlib,否则跨边界的 std 类型、`type_info` 比较、异常传播全部分家。
+- **与系统上预编译的 `.so`/`.dylib` 互操作**:对方用系统 stdlib 编,你就得是同一份。
+- **安全更新的责任归属**:静态链意味着 stdlib 的每个 CVE 都要重新构建并重新分发全部产物。
+- **测试二进制**:它**根本不分发**。#124 的原始立场("per-unit stdlib, cargo-test stance")在语义上是对的;#202 把它翻过来是为了绕开一个具体故障,不是因为静态更对。
+
+诚实的另一面:动态路径不是"什么都不做就对"。#202 的 `__hash_memory` 说明它有一条硬约束——**头文件必须与运行期库同源**。所以动态不是"少做一件事",是"换一套需要各自维护的约束"。
+
+因此正确的提法不是"要不要支持动态",而是:**把这个字段从"链接手段的布尔值"升级成"分发契约的枚举"**。三档就够,而且三档的机制 mcpp **今天全都已经有了**,只是没有名字:
+
+| 档 | 含义 | 现有机制 |
+|---|---|---|
+| `self-contained` | 产物不依赖构建机之外的任何 C++ 运行时 | 今天的默认(三平台三套 flag) |
+| `host-coupled` | 链运行主机上的系统运行时 | 今天的 opt-out;**也是测试二进制本来该有的形态** |
+| `toolchain-coupled` | 链 mcpp 装的那份工具链的动态运行时 + rpath | `linkRuntimeDirs` + `-Wl,-rpath` 已经在跑;Linux×libc++ 事实上就在这一档 |
+
+有了名字之后,三件今天纠缠不清的事各自归位:测试默认 `host-coupled` 是**可读的策略**而不是一个 `if`;`SharedLib` 那个漏掉的分支有地方安放;`[target.'cfg(macos)']` 要不要条件化,变成"分发契约能不能按目标平台不同"这个**答案显然是能**的问题。
+
+### 7.3 从通用构建 / 分发视角:三个核心点
+
+**(1) 构建和分发是两个目标函数,而 mcpp 用同一层词汇表达它们。**
+
+- 构建关心 *可重现、可缓存、正确*:用哪个编译器、哪些 flag、什么顺序。
+- 分发关心 *产物在哪些机器上能跑*:运行期依赖集是什么、下限在哪、谁负责更新。
+
+`static_stdlib` 是穿着构建外衣的分发意图,§7.1 的四行表就是这件事的直接后果。同样的错位还解释了另外两个已知症状:它被误分类进"selection knob 不可条件化"(因为大家不确定它是构建输入还是选择旋钮——**它两者都不是**),以及它和 `LinkUnit` 的种类纠缠不清(测试不分发,所以它对测试根本不该有同一个含义)。
+
+顺着这条线看,mcpp 事实上已经做对了很多**分发层面**的事,只是散着、各自推导:macOS deployment target(下限)、Windows DLL 部署到 exe 旁、MinGW `-static`、musl 全静态、macOS 静态 libc++。**这五处是同一件事的五处推导**——"同一决策多处推导"这条反复出现的债,根在这里,不是巧合。
+
+**(2) 分发契约必须可验证,而不只是被声明。**
+
+`docs/05-mcpp-toml.md` 声称"默认产物在任何 macOS ≥ 14 上开箱即用",但仓库里没有任何一条断言验证过产物的运行期依赖集。这类断言是 O(1) 成本的:
+
+- macOS:`otool -L` 的输出集合 ⊆ 允许集
+- Linux:`readelf -d` 的 `NEEDED` 集合
+- Windows:导入表(这个手段 mcpp 在 winlibs 那次已经用过)
+
+但要说清它的边界:**这类静态断言只能锁住"契约有没有被悄悄改掉",锁不住本 bug**——#336 是契约兑现了(依赖集确实只剩 libSystem)而语义坏了。所以分发验证需要**两类**断言配对:依赖集断言(契约的形)+ 最小冒烟运行(契约的实)。§3.4 那条 e2e 属于后者,而前者今天完全是空的。
+
+**(3) C++ 的"自包含"账单是分期付的,而且还没付完。**
+
+Rust/Go 的静态自包含之所以顺,是因为它们的运行时没有跨 TU 的全局构造次序、没有跨 DSO 的类型身份问题。C++ 的自包含会逐个撞上:符号可见性与 ODR、静态初始化次序、跨 DSO 的 `type_info` 与异常、`operator new` 的唯一性。
+
+**mcpp 把 Rust 的默认搬到 C++ 上,就得逐笔把这些 C++ 特有的坑吸收进引擎。**这份账单已经付了两笔:#117 是 split-brain(可见性/ODR),#336 是初始化次序。这个模型有预测力——**下一笔大概率在 `SharedLib` 那一格**:macOS 的 `.dylib` 今天会嵌一份 hidden libc++(§6.4a),那么 exe 与 dylib 各嵌一份 hidden `libc++abi` 时,跨边界抛异常的 `type_info` 匹配与 `__cxa_*` 状态是否还成立,是一个具体的、可以现在就写测试去证伪的问题。
+
+这不是"所以别做自包含"——自包含的收益(macOS 下限、MinGW 独立 exe、musl 全静态)都是真的。这是说:**选了这条路就要承认它是一条需要持续投入的路,并且把投入前置成契约与测试,而不是等 issue 来收账。**
+
+### 7.4 落到最小可行动作
+
+1. **先做名字,再做实现**:把 `static_stdlib` 的三种展开收敛成一个 `DistributionContract` 枚举(旧字段保留为别名,零破坏)。这一步不改任何 flag,只是把五处推导指向同一个来源。
+2. **让 `LinkUnit` 从契约推导链接形态**,而不是二分派;测试默认 `host-coupled`,`SharedLib` 显式定档。这一步顺手修掉 #336 的问题一。
+3. **补依赖集断言**(三平台各一条),把分发契约变成机器可验的东西。
+4. `Linux × libc++` 下 `static_stdlib` 空转要么实现、要么发警告——**静默空转是最坏的一种**。
+
+---
+
+## 附:本地可复现的取证命令
+
+```bash
+A=~/.mcpp/registry/data/xpkgs/xim-x-llvm/20.1.7/lib/x86_64-unknown-linux-gnu/libc++.a
+llvm-nm --defined-only "$A" | grep -E 'DoIOSInit|start_std_streams|GLOBAL__I|ios_base4Init'
+llvm-ar x "$A" iostream.cpp.o
+llvm-objdump -dr --disassemble-symbols=_GLOBAL__I_000100          iostream.cpp.o
+llvm-objdump -dr --disassemble-symbols=_ZNSt3__18ios_base4InitC2Ev iostream.cpp.o
+llvm-objdump -dr --disassemble-symbols=_ZNSt3__19DoIOSInitC2Ev     iostream.cpp.o   # ← 引用 __cout/cout/vtable
+
+# ios_base::Init 在头文件里只有前向声明,全树无定义:
+grep -rn 'class Init' ~/.mcpp/registry/data/xpkgs/xim-x-llvm/20.1.7/include/c++/v1/ios
+grep -rn 'Init::'     ~/.mcpp/registry/data/xpkgs/xim-x-llvm/20.1.7/include/c++/v1/ | grep -v __cxx03   # 空
+```

--- a/.agents/docs/2026-08-02-issue336-pr142-analysis.md
+++ b/.agents/docs/2026-08-02-issue336-pr142-analysis.md
@@ -341,6 +341,36 @@ Rust/Go 的静态自包含之所以顺,是因为它们的运行时没有跨 TU �
 
 ---
 
+## 9. 实施记录(2026.8.3.1 / PR #337)
+
+落地形态与 §8 的设计一致,但有两处**在实现中被证据修正**的地方,记在这里比记在 PR 里更耐久。
+
+**契约收敛成两个 API 决定**
+
+- `src/build/distribution.cppm` = 角色 / 契约 / 机制表(总函数)。`flags.cppm` 只调用它,`ninja_backend.cppm` 只问 `role_of(kind)`。原来的五处推导归零。
+- C++ 运行时 flag 从全局 `ldflags` 移到**每个链接单元**的 `unit_ldflags`。必须如此:两个角色在同一次构建里可以持不同契约,全局通道表达不了。移动的都是驱动级 flag(`-static-libstdc++` / `-static-libgcc` / MinGW `-static`),相对库的位置无意义。
+
+**修正 1:诊断的判据不是"降级",是"违约"。**
+初版让"契约兑现不了就必报"。结果是 MSVC 运行时**每一次 Windows 构建**都会打印一条 `self-contained 未实现` —— 而 mcpp 从来没有为 MSVC 承诺过自包含(它压根不发 `/MT`)。这不是违约,是平台边界,且用户无从行动。改成:**只有显式写下的契约兑现不了才报**(`static_stdlib = false` 也算显式 —— 没人会把开关设成默认值来求非默认行为);而 mcpp 确实做了承诺的格子(默认档下缺 `libc++.a`)照报不误。
+
+**修正 2:shim 不能有能力弄坏链接。**
+初版靠 `__attribute__((weak))` 兜底"符号不存在就退化成空操作"。首轮 macOS CI 全红,教了两件 Mach-O 的事:
+
+1. **`__asm__` label 是逐字使用的,clang 不会替它补 Mach-O 的全局 `_` 前缀。** C++ 符号 `_ZNSt3__18ios_base4InitC1Ev` 在这里必须写成 `__ZNSt3__18ios_base4InitC1Ev`。写错不是静默失效,是 `ld64.lld: error: undefined symbol: ZNSt3__18ios_base4InitC1Ev`,每一条 macOS 链接都挂。
+2. **声明上的 `weak` 不是 Mach-O 的 weak-undefined 形态**(那是 `weak_import`),所以它根本没有兜住那个坏引用。
+
+两条都修了,但真正的安全网挪到了**上游**:后端只在归档确实定义该符号时才生成 shim TU —— 扫归档第一个成员里的 ranlib 符号索引,不起子进程。**一个在引用之前的检查,不可能像引用本身那样弄坏链接**;符号拼写变了就是"少一个次序修复 + 一条诊断",不是构建失败。
+
+**本次没做,理由已在 §6.4 写清**
+
+- INV-2 跨链接边的契约传播硬错误:单次构建内所有单元共用一个工程级契约,在构建内近乎空转;真正的风险是 macOS `.dylib` 嵌一份 hidden libc++ 而宿主嵌另一份(`ninja_backend.cppm:1222` 的二分派让 `SharedLibrary` 走分发档)。留作下一项,不做半个。
+- ELF 上 `host-coupled` 去掉工具链 rpath:属打包轴,文档已明确写出这条边界。
+- MSVC 的 `/MT`:表里点名承认缺口。
+
+**顺带落地的能力**:Linux + clang/libc++ 的自包含从"静默空转"变成真的(显式链 `libc++.a` / `libc++abi.a` / `libunwind.a`,实测 `NEEDED` 只剩 libc/libm/loader)。
+
+---
+
 ## 附:本地可复现的取证命令
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 > 本文件追踪 `mcpp-community/mcpp` 公开仓的版本演进。
 > 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [2026.8.3.1] — 2026-08-03
+
+### 修复
+
+- **`[build] static_stdlib = false` 对测试二进制静默失效(#336)。** #124 在 0.0.52 明确写下这个 opt-out,`docs/05-mcpp-toml.md` 至今也还这么写;但 #202(0.0.86)把测试二进制改成与分发目标相同的静态 `-load_hidden` libc++ 时,新增的那条推导**没有带上 `staticStdlib` 门**。结果是约一年时间里 macOS 上的 `mcpp test` 没有任何办法回到动态 libc++,而文档一直在承诺它可以。
+
+- **macOS 上全局对象在静态初始化期访问 `std::cout` 必崩(#336)。** Mach-O 没有按优先级排序的初始化段(`init_priority` 只在单个 TU 内有效),归档成员的初始化器按链接顺序排在最后;而 libc++ 的 `<iostream>` 不像 libstdc++ / MSVC STL 那样自带 `ios_base::Init` 守卫,流的构造只存在于库内对象里。两件事叠起来的后果是:默认配置下,任何在构造函数里碰 `std::cout` 的全局对象都会读到 vptr 为零的流,进程启动即 SIGSEGV —— 而且**包侧无法修复**,因为 `std::ios_base::Init` 在 libc++ 的头文件里只有前向声明(`ios:70`),标准为静态初始化次序提供的官方解药在 libc++ 上用户根本写不出来。
+
+  修法是让静态链接恢复动态链接本来就有的保证:macOS + 自包含时,mcpp 生成一个极小的 C 翻译单元并把它的对象排在链接行**最前**,由它先把流顶上去。它对 `ios_base::Init::Init()` 的引用是 **weak** 的 —— 换一份不这么拼这个 ABI 符号的工具链,链接与今天完全一样,shim 退化为空操作。
+
+### 新增
+
+- **C++ 运行时分发契约 `[build] cxx_runtime`。** 三档:`self-contained`(默认)/ `toolchain-coupled` / `host-coupled`,可按角色(`{ default = ..., tests = ... }`)也可按目标三元组(`[target.<triple>] cxx_runtime`,与 `linkage` 并列 —— 它们本就是同一根轴)。`static_stdlib` 保留为忠实别名(`true`↔`self-contained`,`false`↔`host-coupled`)。
+
+  这个字段替换的旧字段名描述的是**手段**("静态链接 stdlib"),而它承载的其实是**意图**(产物能在哪些机器上跑)—— 这正是同一个 `true` 在四种配置上展开成四种不同结果的原因,其中一种是**静默空转**:Linux + clang/libc++ 工具链上 `static_stdlib = true` 一个 flag 都不发,交付的是工具链耦合的产物,而 manifest、文档和 `--version` 都说它是自包含的。
+
+- **Linux + libc++ 工具链现在真的能自包含**:显式链入 `libc++.a` / `libc++abi.a` / `libunwind.a`(缺 libunwind.a 时产物仍会拉 `libunwind.so.1`,所以它是机制的一部分而不是可选项)。实测 `NEEDED` 只剩 libc / libm / loader。
+
+- **兑现不了的契约一定会被报出来。** 工具链不带 `libc++.a`、macOS 没有 deployment floor、MSVC 运行时没有 `/MT` 机制、macOS 上没有可用的 `toolchain-coupled` 形态(LLVM 的 libc++abi/libunwind dylib 向上链 `/usr/lib/libc++`,会把第二份 libc++ 载进进程)—— 这些格子现在都会打印实际退到了哪一档。
+
+### 变更
+
+- **五处独立推导收敛成一处。** "这个产物自带 C++ 运行时吗"过去在 `flags.cppm` 的 `ldStdlibDefault` / `ldStdlibTest` / `-static-libstdc++` / MinGW `-static` 四处,加上 `ninja_backend.cppm` 里那个按 `LinkUnit::TestBinary` 的二分派,各推一遍 —— 这正是新语义只落到其中一处的成因。现在是 `src/build/distribution.cppm` 里的三层模型:角色(由链接单元内在决定)→ 契约(按角色取默认,可覆盖)→ 机制(唯一放 flag 的地方,且是**总函数**)。
+
+- 相应地,C++ 运行时相关的链接 flag 从全局 `ldflags` 移到了**每个链接单元**的 `unit_ldflags` —— 两个角色在同一次构建里可以持有不同契约,这一点全局通道表达不了。它们都是驱动级 flag,相对库的位置无意义,Linux/Windows 的链接语义不变。
+
 ## [2026.8.1.2] — 2026-08-01
 
 ### 新增

--- a/docs/05-mcpp-toml.md
+++ b/docs/05-mcpp-toml.md
@@ -157,7 +157,7 @@ cflags       = ["-DFOO=1"]        # Extra C compile flags
 cxxflags     = ["-DBAR=2"]        # Extra C++ compile flags (do not put -std=... here)
 ldflags      = ["-lfoo"]          # Extra link flags
 defines      = ["BIZ=1", "QUX"]   # Preprocessor macros for every TU (desugars to -D; reaches module scans)
-static_stdlib = true               # Statically link libstdc++ (default true)
+cxx_runtime  = "self-contained"   # C++ runtime contract (§ below); static_stdlib is the old spelling
 target       = "x86_64-linux-musl" # Default build target when no --target is passed
                                    # (≙ cargo build.target; e.g. "ship fully-static")
 macos_deployment_target = "14.0"   # Minimum supported OS version for macOS artifacts (macOS only)
@@ -188,16 +188,66 @@ baseline, and 14.0 is the floor of LLVM's official static libraries themselves).
 This value enters the BMI fingerprint, so switching targets automatically rebuilds
 the module cache.
 
-**Static runtime by default (portable by default)**: when `static_stdlib = true`
-(the default), macOS linking statically links in LLVM's bundled libc++/libc++abi —
-the system libc++ would otherwise pin the actual runnable version to the build
-machine's OS (older systems lack newer symbols, e.g. the support symbols behind
-`std::print`), and only static linking can truly deliver the floor. As a result,
-the default build's artifacts work out of the box on any macOS ≥ 14. Set
-`static_stdlib = false` to fall back to the dynamic system libc++ (the artifact is
-then only guaranteed to run on the build machine's version and above). A lower
-floor (11–13) requires a self-built libc++ archive (already verified to work, a
-data-level switch, available on request).
+### The C++ runtime contract (`cxx_runtime`)
+
+`cxx_runtime` states what the produced artifact promises about the machine that
+runs it. It is a **distribution** property, not a build one — it describes the
+runtime dependency set, and the flags that deliver it differ per platform.
+
+```toml
+[build]
+cxx_runtime = "self-contained"          # applies to every target (the default)
+
+# or, per role:
+[build.cxx_runtime]
+default = "self-contained"              # binaries and shared libraries
+tests   = "host-coupled"                # test binaries never leave this machine
+
+# or, per target triple — beside `linkage`, which is the same axis:
+[target.x86_64-linux-gnu]
+cxx_runtime = "host-coupled"            # e.g. this build is for a distro package
+```
+
+| value | the artifact needs, at run time | typical use |
+|---|---|---|
+| `self-contained` (default) | no C++ runtime outside itself | shipping a binary |
+| `toolchain-coupled` | the C++ runtime of the toolchain mcpp installed | local iteration |
+| `host-coupled` | whatever the driver resolves by default (the system runtime) | distro packaging, `dlopen` plugins that must share a runtime with their host |
+
+**Self-contained by default (portable by default)**: on macOS this statically
+links LLVM's bundled libc++/libc++abi — the system libc++ would otherwise pin the
+runnable version to the build machine's OS (older systems lack newer symbols, e.g.
+the support symbols behind `std::print`), and only static linking can truly deliver
+the `macos_deployment_target` floor. On Linux/MinGW it is `-static-libstdc++` (GCC)
+or the whole-link `-static` (MinGW); on a Linux clang/libc++ toolchain it links
+libc++.a/libc++abi.a/libunwind.a explicitly. A lower macOS floor (11–13) requires a
+self-built libc++ archive (already verified to work, a data-level switch, available
+on request).
+
+`static_stdlib` is the older spelling and still works: `true` means
+`self-contained`, `false` means `host-coupled`. An explicit `cxx_runtime` wins.
+
+**A contract that cannot be honored is reported, never silently downgraded.** If a
+toolchain ships no `libc++.a`, or a contract has no mechanism on that platform
+(`self-contained` under the MSVC runtime would need `/MT`, which mcpp does not emit
+yet), the build prints what it fell back to instead of quietly producing a
+different artifact than the manifest asked for.
+
+**Scope.** The contract governs the C++ runtime only. Static **libc** is a separate
+axis (`linkage = "static"` / `--static`, e.g. a musl target), and the deployment
+floor is a third (`macos_deployment_target`). Also, `host-coupled` means mcpp adds
+nothing to embed a C++ runtime; it does not strip the toolchain rpath the link
+carries for other reasons, so on ELF such an artifact may still find the
+toolchain's libraries first.
+
+> **macOS + `self-contained` and static initialization order.** Mach-O has no
+> priority-ordered initializer section and libc++'s `<iostream>` carries no
+> `ios_base::Init` guard of its own (unlike libstdc++ and the MSVC STL), so a
+> stream initializer pulled out of `libc++.a` would otherwise run *after* the
+> program's own global constructors — a global whose constructor touches
+> `std::cout` would read an unconstructed stream and crash at process start. mcpp
+> links a tiny generated object first to force the streams up; nothing is required
+> of your code. See mcpp-community/mcpp#336.
 
 `defines` takes **bare** macro names (no `-D`) and desugars each entry to `-D<x>` on
 both the C and C++ compile channels. It reaches every TU in the package — module

--- a/docs/zh/05-mcpp-toml.md
+++ b/docs/zh/05-mcpp-toml.md
@@ -151,7 +151,7 @@ cflags       = ["-DFOO=1"]        # 额外 C 编译参数
 cxxflags     = ["-DBAR=2"]        # 额外 C++ 编译参数(不要放 -std=...)
 ldflags      = ["-lfoo"]          # 额外链接参数
 defines      = ["BIZ=1", "QUX"]   # 作用于每个 TU 的预处理宏(脱糖为 -D;会进入模块扫描)
-static_stdlib = true               # 静态链接 libstdc++(默认 true)
+cxx_runtime  = "self-contained"   # C++ 运行时契约(见下节);static_stdlib 是旧拼写
 macos_deployment_target = "14.0"   # macOS 产物的最低支持系统版本(仅 macOS 生效)
 cache        = "global"           # 依赖的全局构建缓存:global(默认)| local | off(见 §2.10)
 ```
@@ -174,13 +174,59 @@ cargo/rustc、cc 等同样尊重该变量)> 本字段(项目默认,类似 SwiftP
 14.0 即 LLVM 官方静态库自身的下限)。该值会进入 BMI 指纹——切换 target
 会自动重建模块缓存。
 
-**默认即静态运行时(portable by default)**:`static_stdlib = true`
-(默认)时,macOS 链接会静态链入 LLVM 自带的 libc++/libc++abi ——
-系统 libc++ 会把实际可运行版本钉死在构建机的 OS(老系统缺新符号,
-如 `std::print` 的支撑符号),静态化才能真正兑现 floor。因此默认构建的
-产物在任何 macOS ≥ 14 上开箱即用。设 `static_stdlib = false` 退回动态
-系统 libc++(产物只保证在构建机同版本及以上运行)。更低 floor(11–13)
-需自建 libc++ 归档(已验证可行,数据级切换,按需提供)。
+### C++ 运行时契约(`cxx_runtime`)
+
+`cxx_runtime` 声明的是**产物对运行它的机器做出的承诺**。它是**分发**属性而非
+构建属性 —— 它描述的是运行期依赖集,而兑现它的 flag 逐平台不同。
+
+```toml
+[build]
+cxx_runtime = "self-contained"          # 作用于所有目标(默认值)
+
+# 或者按角色分别指定:
+[build.cxx_runtime]
+default = "self-contained"              # 可执行文件与共享库
+tests   = "host-coupled"                # 测试二进制从不离开本机
+
+# 或者按目标三元组 —— 与 `linkage` 并列,因为它们是同一根轴:
+[target.x86_64-linux-gnu]
+cxx_runtime = "host-coupled"            # 例如这次构建是为发行版打包
+```
+
+| 取值 | 产物运行时需要 | 典型场景 |
+|---|---|---|
+| `self-contained`(默认) | 自身之外不需要任何 C++ 运行时 | 分发二进制 |
+| `toolchain-coupled` | mcpp 装的那份工具链的 C++ 运行时 | 本地迭代 |
+| `host-coupled` | 驱动默认解析到的那份(通常是系统运行时) | 发行版打包;必须与宿主共用同一份运行时的 `dlopen` 插件 |
+
+**默认即自包含(portable by default)**:macOS 上这会静态链入 LLVM 自带的
+libc++/libc++abi —— 系统 libc++ 会把实际可运行版本钉死在构建机的 OS(老系统
+缺新符号,如 `std::print` 的支撑符号),只有静态化才能真正兑现
+`macos_deployment_target` 的 floor。Linux/MinGW 上它是 `-static-libstdc++`
+(GCC)或整条链的 `-static`(MinGW);Linux 上的 clang/libc++ 工具链则显式链入
+libc++.a/libc++abi.a/libunwind.a。更低的 macOS floor(11–13)需自建 libc++
+归档(已验证可行,数据级切换,按需提供)。
+
+`static_stdlib` 是旧拼写,仍然有效:`true` 等价于 `self-contained`,`false`
+等价于 `host-coupled`。显式写了 `cxx_runtime` 时以后者为准。
+
+**兑现不了的契约会被报出来,绝不静默降级。** 若工具链不带 `libc++.a`,或某个
+契约在该平台上没有对应机制(MSVC 运行时的 `self-contained` 需要 `/MT`,mcpp
+目前不发射),构建会打印实际退到了哪一档,而不是悄悄交付一个与 manifest 所述
+不同的产物。
+
+**边界。** 该契约只管 C++ 运行时。静态 **libc** 是另一根轴(`linkage = "static"`
+/ `--static`,如 musl 目标),部署下限是第三根轴(`macos_deployment_target`)。
+另外,`host-coupled` 只承诺 mcpp 不做任何"把 C++ 运行时打进产物"的动作,它不会
+去掉链接因其它原因已经携带的工具链 rpath —— 所以在 ELF 上这类产物仍可能优先
+找到工具链的库。
+
+> **macOS + `self-contained` 与静态初始化次序。** Mach-O 没有按优先级排序的
+> 初始化段,而 libc++ 的 `<iostream>` 也不像 libstdc++ / MSVC STL 那样自带
+> `ios_base::Init` 守卫 —— 于是从 `libc++.a` 里拉出来的流初始化器本来会排在
+> 程序自己的全局构造函数**之后**:一个在构造函数里碰 `std::cout` 的全局对象会
+> 读到尚未构造的流,进程启动即崩。mcpp 会把一个极小的生成对象排在链接最前面
+> 把流顶上去,你的代码不需要做任何事。详见 mcpp-community/mcpp#336。
 
 `defines` 接受**裸**宏名(不带 `-D`),把每个条目脱糖为 `-D<x>`,同时作用于 C 和
 C++ 编译通道。它覆盖包内每个 TU(含模块接口单元),因此也会进入 P1689 模块扫描

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "2026.8.2.2"
+version     = "2026.8.3.1"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/build/distribution.cppm
+++ b/src/build/distribution.cppm
@@ -164,6 +164,11 @@ struct MechanismInput {
     std::string      libcxxArchive;
     std::string      libcxxAbiArchive;
     std::string      libunwindArchive;
+    // macOS only: the libc++ archive actually defines the ABI symbol the
+    // initializer-ordering shim binds to. Checked against the archive rather
+    // than assumed, so an unexpected spelling disables the shim instead of
+    // producing an undefined reference at link time.
+    bool             streamInitSymbolPresent = false;
     // macOS only: a deployment floor was resolved. The static-libc++
     // mechanism exists to make that floor real, so without one there is
     // nothing to make real.
@@ -259,7 +264,21 @@ Mechanism resolve(const MechanismInput& in) {
             m.unitFlags = " -nostdlib++"
                           " -Wl,-load_hidden," + in.libcxxArchive +
                           " -Wl,-load_hidden," + in.libcxxAbiArchive;
-            m.streamInitShim = true;
+            // The ordering shim binds a libc++ INTERNAL ABI symbol, so its
+            // presence is verified against the archive instead of assumed.
+            // Getting this wrong must not break the link — hence a check
+            // here rather than a weak reference in the shim: Mach-O's
+            // weak-undefined form is `weak_import` and applies to dylib
+            // symbols, so a plain weak declaration would NOT have saved a
+            // missing archive symbol (it did not: ld64.lld errored outright).
+            m.streamInitShim = in.streamInitSymbolPresent;
+            if (!m.streamInitShim) {
+                m.diagnostic =
+                    "this libc++ does not export the stream initializer mcpp "
+                    "orders first on macOS; a global object whose constructor "
+                    "uses std::cout may crash at startup (mcpp#336). Use "
+                    "cxx_runtime = \"host-coupled\" if you hit it";
+            }
             return m;
         }
         // HostCoupled
@@ -367,12 +386,22 @@ Mechanism resolve(const MechanismInput& in) {
 // WHY C: it needs no standard library, no module flags and no C++ ABI of its
 // own — it only has to run before everything else and poke one symbol.
 //
-// WHY WEAK: `_ZNSt3__18ios_base4InitC1Ev` is a libc++ ABI symbol
-// (_LIBCPP_EXPORTED_FROM_ABI), stable for many years but not ours. A weak
-// undefined reference means a toolchain that spells it differently links
-// exactly as it does today and the shim is a no-op, instead of failing the
-// link. It also means the shim does not itself drag iostream.cpp.o out of the
-// archive: if the program never touches a stream there is nothing to order.
+// WHY THE NAME IS SPELLED WITH TWO UNDERSCORES: an `__asm__` label is used
+// VERBATIM — clang does not add Mach-O's global `_` prefix to it. The C++
+// symbol `_ZNSt3__18ios_base4InitC1Ev` therefore has to be written
+// `__ZNSt3__18ios_base4InitC1Ev` here. Getting this wrong is not a silent
+// no-op: ld64.lld reports `undefined symbol: ZNSt3__18ios_base4InitC1Ev` and
+// every link fails, which is exactly what the first CI round did.
+//
+// WHY `weak_import` AND a presence check: Mach-O's weak-undefined form is
+// `weak_import` (plain `weak` on a declaration does NOT make an undefined
+// reference optional there). Even so, the real safety net is upstream — the
+// backend only generates this TU when the archive actually defines the
+// symbol, so an unexpected libc++ spelling disables the shim rather than
+// breaking the link. The attribute is the second line of defence.
+//
+// The reference does not itself drag iostream.cpp.o out of the archive: if the
+// program never touches a stream, there is nothing to order.
 //
 // WHY IT WORKS: libc++'s `ios_base::Init::Init()` is not empty — it is a
 // guarded function-local static that calls `DoIOSInit::DoIOSInit()`, and THAT
@@ -396,7 +425,8 @@ std::string_view stream_init_shim_source() {
         " * Weak: a toolchain without this exact ABI symbol links as before.\n"
         " */\n"
         "extern void mcpp_libcxx_ios_init(void *)\n"
-        "    __attribute__((weak)) __asm__(\"_ZNSt3__18ios_base4InitC1Ev\");\n"
+        "    __attribute__((weak_import))\n"
+        "    __asm__(\"__ZNSt3__18ios_base4InitC1Ev\");\n"
         "\n"
         "static char mcpp_libcxx_ios_init_storage[8];\n"
         "\n"

--- a/src/build/distribution.cppm
+++ b/src/build/distribution.cppm
@@ -1,0 +1,397 @@
+// mcpp.build.distribution — the C++ runtime distribution contract.
+//
+// WHY THIS MODULE EXISTS
+//
+// "Does this artifact carry its own C++ runtime?" used to be derived
+// independently in five places (issue #336): `ldStdlibDefault` and
+// `ldStdlibTest` in flags.cppm, the `-static-libstdc++` string a few lines
+// above them, the MinGW `-static` branch, and the `LinkUnit::TestBinary`
+// two-way switch in ninja_backend.cppm. New semantics landed in some of them
+// and not others, which is exactly how `[build] static_stdlib = false` came
+// to be silently ignored for test binaries between 0.0.86 and today while the
+// documentation kept promising it worked.
+//
+// The model is three layers, and only the third one knows about flags:
+//
+//   Role      — intrinsic to the link unit. Not user-specified.
+//   Contract  — what the artifact promises about the machine that runs it.
+//               Defaulted per role, overridable via [build] cxx_runtime.
+//   Mechanism — (contract x stdlib x binary format) -> link flags.
+//
+// The mechanism table is a TOTAL function: every cell has an answer, and a
+// cell that cannot be honored returns `degraded` plus a non-empty
+// `diagnostic` that the caller MUST surface. A silent no-op is the one
+// outcome this module is built to make impossible — before it, asking for a
+// self-contained artifact on a Linux/libc++ toolchain produced no flag, no
+// warning and a toolchain-coupled binary.
+//
+// Analysis: .agents/docs/2026-08-02-issue336-pr142-analysis.md
+
+export module mcpp.build.distribution;
+
+import std;
+
+export namespace mcpp::build::dist {
+
+// ---------------------------------------------------------------- Layer 1
+
+// What the link unit is FOR. Intrinsic — derived from LinkUnit::Kind, never
+// written by a user. It exists so "tests run on the build machine, shipped
+// artifacts do not" is a readable policy instead of an `if (kind ==
+// TestBinary)` buried in the ninja emitter.
+//
+// `build.mcpp` host helpers are deliberately NOT a role here: their link
+// policy (`staticHostHelper` in build_program.cppm) is about the libc axis —
+// a musl helper needs `-static` because of PT_INTERP, a PE helper because
+// DLLs resolve via PATH — not about the C++ runtime this module governs.
+enum class Role {
+    Distributable,  // Binary / SharedLibrary — leaves this machine
+    Test,           // TestBinary — runs here, right now, then is discarded
+    Intermediate,   // StaticLibrary — carries no runtime, contract is vacuous
+};
+
+// ---------------------------------------------------------------- Layer 2
+
+// What the artifact promises about the machine that runs it. This is a
+// DISTRIBUTION property, not a build one: it describes the runtime dependency
+// set, and the flags that produce it differ per platform.
+enum class Contract {
+    // No C++ runtime dependency outside the artifact. The default, and what
+    // makes the macOS deployment floor (14.0) real rather than aspirational.
+    SelfContained,
+    // Links the C++ runtime of the toolchain mcpp installed, found again at
+    // run time through the toolchain's rpath. The artifact travels only with
+    // that toolchain present.
+    ToolchainCoupled,
+    // Links whatever C++ runtime the driver resolves by default — the system
+    // one on most hosts. The form distro packaging (Debian/Homebrew) requires,
+    // and the form `static_stdlib = false` has always been documented to mean.
+    HostCoupled,
+};
+
+// NOTE ON SCOPE: the contract governs the C++ runtime (stdlib + its ABI and
+// unwinder). The libc axis is separate and stays with `linkage`/`--static`
+// (a musl `-static` link), and the deployment floor is a third axis
+// (`macos_deployment_target`). Conflating them is what made a single
+// `static_stdlib` bool expand into three different platform meanings.
+//
+// KNOWN LIMIT: `HostCoupled` promises only that mcpp adds nothing to embed a
+// C++ runtime. It does not strip the toolchain rpath that the link already
+// carries for other reasons, so on ELF a HostCoupled artifact may still find
+// the toolchain's libraries first. Removing that rpath is a packaging axis of
+// its own and is not part of this contract.
+
+// The binary format decides which mechanisms even exist — Mach-O has no
+// priority-ordered initializer section, PE has no rpath, ELF has both.
+enum class Format { Elf, MachO, Pe };
+
+std::string_view to_string(Contract c) {
+    switch (c) {
+        case Contract::SelfContained:    return "self-contained";
+        case Contract::ToolchainCoupled: return "toolchain-coupled";
+        case Contract::HostCoupled:      return "host-coupled";
+    }
+    return "self-contained";
+}
+
+std::string_view to_string(Role r) {
+    switch (r) {
+        case Role::Distributable: return "distributable";
+        case Role::Test:          return "test";
+        case Role::Intermediate:  return "intermediate";
+    }
+    return "distributable";
+}
+
+std::optional<Contract> parse_contract(std::string_view s) {
+    if (s == "self-contained")    return Contract::SelfContained;
+    if (s == "toolchain-coupled") return Contract::ToolchainCoupled;
+    if (s == "host-coupled")      return Contract::HostCoupled;
+    return std::nullopt;
+}
+
+// The role -> contract policy, in one place.
+//
+// Test binaries default to SelfContained rather than the HostCoupled that
+// their role alone would suggest, and that is deliberate: on macOS a test
+// linked against the SYSTEM libc++ while compiled against the toolchain's
+// libc++ HEADERS is a version split that detonated once already (undefined
+// `__hash_memory` when libc++ 22 moved string hashing out of line, #202). The
+// role model makes that trade visible instead of hard-coding it in the
+// emitter; a project that wants the other side of it writes
+// `cxx_runtime = { tests = "host-coupled" }` and now actually gets it.
+Contract default_contract(Role r) {
+    switch (r) {
+        case Role::Distributable: return Contract::SelfContained;
+        case Role::Test:          return Contract::SelfContained;
+        case Role::Intermediate:  return Contract::SelfContained;
+    }
+    return Contract::SelfContained;
+}
+
+// ---------------------------------------------------------------- Layer 3
+
+struct MechanismInput {
+    Contract         requested = Contract::SelfContained;
+    Role             role      = Role::Distributable;
+    // Toolchain capability id: "libstdc++", "libc++", or an MSVC STL spelling.
+    std::string_view stdlibId;
+    Format           format = Format::Elf;
+    // MinGW targets are PE + libstdc++ and take the whole-link `-static`
+    // rather than the piecemeal `-static-libstdc++` (the latter still leaves
+    // libwinpthread-1.dll behind).
+    bool             mingw = false;
+    // Host is Windows. Only reason it is here: the historical flag string
+    // adds `-static-libgcc` on a Windows HOST, and this table reproduces the
+    // existing bytes rather than quietly "improving" them.
+    bool             hostIsWindows = false;
+    // `linkage = "static"` — the libc axis. On PE it shares the one `-static`
+    // spelling with the C++ runtime axis, so the table has to see it.
+    bool             fullStaticLibc = false;
+    // Already-escaped archive paths for the explicit-archive mechanisms.
+    // Empty string = that archive is not available on this toolchain.
+    std::string      libcxxArchive;
+    std::string      libcxxAbiArchive;
+    std::string      libunwindArchive;
+    // macOS only: a deployment floor was resolved. The static-libc++
+    // mechanism exists to make that floor real, so without one there is
+    // nothing to make real.
+    bool             macosFloor = false;
+};
+
+struct Mechanism {
+    // Flags for this link unit, each with a leading space. Per-unit rather
+    // than global precisely so two roles in one build can differ.
+    std::string unitFlags;
+    Contract    effective = Contract::SelfContained;
+    // effective != requested. `diagnostic` is then non-empty and the caller
+    // is required to surface it — see INV-1/INV-4 in the analysis doc.
+    bool        degraded = false;
+    std::string diagnostic;
+    // Mach-O + static libc++: the archive's stream initializer is appended
+    // LAST in __init_offsets (Mach-O has no priority-ordered init section and
+    // libc++'s <iostream> carries no `ios_base::Init` guard of its own), so a
+    // global constructor that touches std::cout runs before the streams
+    // exist. Asks the backend for the ordering shim. See issue #336.
+    bool        streamInitShim = false;
+};
+
+namespace detail {
+
+inline bool is_libstdcxx(std::string_view id) { return id == "libstdc++"; }
+inline bool is_libcxx(std::string_view id)    { return id == "libc++"; }
+
+}  // namespace detail
+
+// The one table. Total by construction: every return path sets `effective`,
+// and every path where `effective != requested` also sets `diagnostic`.
+Mechanism resolve(const MechanismInput& in) {
+    Mechanism m;
+    m.effective = in.requested;
+
+    // An archive is linked, not run. It embeds no runtime and imposes none —
+    // the contract belongs to whatever eventually links it.
+    if (in.role == Role::Intermediate)
+        return m;
+
+    const bool haveCxxArchives =
+        !in.libcxxArchive.empty() && !in.libcxxAbiArchive.empty();
+
+    switch (in.format) {
+
+    // ------------------------------------------------------------- Mach-O
+    case Format::MachO: {
+        if (!detail::is_libcxx(in.stdlibId)) {
+            // Mach-O without libc++ is not a configuration mcpp produces.
+            m.effective = Contract::HostCoupled;
+            m.unitFlags = " -lc++";
+            if (in.requested != Contract::HostCoupled) {
+                m.degraded = true;
+                m.diagnostic = std::format(
+                    "cxx_runtime = \"{}\" is not available for stdlib '{}' on "
+                    "Mach-O; using host-coupled", to_string(in.requested), in.stdlibId);
+            }
+            return m;
+        }
+        if (in.requested == Contract::ToolchainCoupled) {
+            // The toolchain's libc++.dylib is a dead end on this
+            // distribution: LLVM's macOS libc++abi/libunwind dylibs
+            // upward-link /usr/lib/libc++, so the SYSTEM libc++ loads
+            // alongside the toolchain's and objects freed across the two
+            // copies abort in libmalloc (#202 crash forensics).
+            m.effective = Contract::SelfContained;
+            m.degraded  = true;
+            m.diagnostic =
+                "cxx_runtime = \"toolchain-coupled\" is not supported on macOS "
+                "(LLVM's libc++abi/libunwind dylibs upward-link /usr/lib/libc++, "
+                "which loads a second libc++ into the process); using self-contained";
+        }
+        if (m.effective == Contract::SelfContained) {
+            if (!haveCxxArchives || !in.macosFloor) {
+                m.effective = Contract::HostCoupled;
+                m.degraded  = true;
+                m.diagnostic = haveCxxArchives
+                    ? "no macOS deployment floor resolved, so the static libc++ "
+                      "that makes the floor real is pointless; using host-coupled"
+                    : "this toolchain ships no libc++.a/libc++abi.a; "
+                      "using host-coupled (the artifact then runs only on the "
+                      "build machine's macOS version and above)";
+                m.unitFlags = " -lc++";
+                return m;
+            }
+            // -Wl,-load_hidden,<path> rather than a plain by-path link: it
+            // forces the ARCHIVE (never a sibling dylib) AND gives its
+            // symbols hidden visibility. Without the hidden part, dyld
+            // unifies them with the system libc++ from the shared cache and
+            // ostream<<int crosses into the other copy's locale machinery
+            // (PR #117 forensics).
+            m.unitFlags = " -nostdlib++"
+                          " -Wl,-load_hidden," + in.libcxxArchive +
+                          " -Wl,-load_hidden," + in.libcxxAbiArchive;
+            m.streamInitShim = true;
+            return m;
+        }
+        // HostCoupled
+        m.unitFlags = " -lc++";
+        return m;
+    }
+
+    // ---------------------------------------------------------------- PE
+    case Format::Pe: {
+        if (!detail::is_libstdcxx(in.stdlibId)) {
+            // MSVC STL (cl.exe, or clang on the MSVC ABI). The driver default
+            // is the DLL runtime and mcpp emits no runtime selection flag, so
+            // host-coupled is the only form that actually exists here. Both
+            // other contracts are refused BY NAME rather than quietly
+            // producing the same bytes and reporting success.
+            m.effective = Contract::HostCoupled;
+            if (in.requested == Contract::SelfContained) {
+                m.degraded = true;
+                m.diagnostic =
+                    "cxx_runtime = \"self-contained\" is not implemented for the "
+                    "MSVC runtime yet (it would need the /MT runtime); using "
+                    "host-coupled — the artifact needs the VC++ redistributable";
+            } else if (in.requested == Contract::ToolchainCoupled) {
+                m.degraded = true;
+                m.diagnostic =
+                    "cxx_runtime = \"toolchain-coupled\" has no meaning for the "
+                    "MSVC runtime (it ships with the OS/redistributable, not with "
+                    "the toolchain); using host-coupled";
+            }
+            return m;
+        }
+        // MinGW. `-static` is the standalone-exe convention here: the
+        // piecemeal -static-libstdc++ recipe still leaves libwinpthread-1.dll.
+        // It is also the spelling the libc axis uses, so `linkage = "static"`
+        // keeps it regardless of the C++ runtime contract.
+        const bool wantStatic =
+            m.effective == Contract::SelfContained || in.fullStaticLibc;
+        if (wantStatic) m.unitFlags += " -static";
+        if (m.effective == Contract::SelfContained) {
+            m.unitFlags += " -static-libstdc++";
+            if (in.hostIsWindows) m.unitFlags += " -static-libgcc";
+        }
+        return m;
+    }
+
+    // --------------------------------------------------------------- ELF
+    case Format::Elf:
+    default: {
+        if (detail::is_libstdcxx(in.stdlibId)) {
+            if (m.effective == Contract::SelfContained)
+                m.unitFlags = " -static-libstdc++";
+            // ToolchainCoupled and HostCoupled are the same emission on ELF
+            // (no flag); they differ in the rpath the link already carries,
+            // which is the documented limit of this contract.
+            return m;
+        }
+        if (detail::is_libcxx(in.stdlibId)) {
+            if (m.effective != Contract::SelfContained)
+                return m;   // driver default: the toolchain's libc++.so via rpath
+            if (!haveCxxArchives) {
+                m.effective = Contract::ToolchainCoupled;
+                m.degraded  = true;
+                m.diagnostic =
+                    "this toolchain ships no libc++.a/libc++abi.a; using "
+                    "toolchain-coupled (the artifact keeps a run-time dependency "
+                    "on the toolchain's libc++.so)";
+                return m;
+            }
+            // Verified locally: -nostdlib++ plus the three archives leaves
+            // NEEDED = libc/libm/loader only. Without libunwind.a the binary
+            // still pulls libunwind.so.1, which is not self-contained — so it
+            // is part of the mechanism, not an optional extra.
+            m.unitFlags = " -nostdlib++ " + in.libcxxArchive
+                        + " " + in.libcxxAbiArchive;
+            if (!in.libunwindArchive.empty()) {
+                m.unitFlags += " " + in.libunwindArchive;
+            } else {
+                m.degraded   = true;   // effective stays SelfContained: the C++
+                                       // runtime IS embedded; the unwinder is not
+                m.diagnostic =
+                    "this toolchain ships no libunwind.a; the C++ runtime is "
+                    "embedded but the artifact keeps a run-time dependency on "
+                    "libunwind.so";
+            }
+            return m;
+        }
+        // Unknown stdlib on ELF: emit nothing rather than guess, but say so
+        // when something was actually asked for.
+        m.effective = Contract::HostCoupled;
+        if (in.requested != Contract::HostCoupled) {
+            m.degraded = true;
+            m.diagnostic = std::format(
+                "cxx_runtime = \"{}\" has no mechanism for stdlib '{}'; "
+                "using host-coupled", to_string(in.requested), in.stdlibId);
+        }
+        return m;
+    }
+    }
+}
+
+// The Mach-O initializer-ordering shim, as a C translation unit.
+//
+// WHY C: it needs no standard library, no module flags and no C++ ABI of its
+// own — it only has to run before everything else and poke one symbol.
+//
+// WHY WEAK: `_ZNSt3__18ios_base4InitC1Ev` is a libc++ ABI symbol
+// (_LIBCPP_EXPORTED_FROM_ABI), stable for many years but not ours. A weak
+// undefined reference means a toolchain that spells it differently links
+// exactly as it does today and the shim is a no-op, instead of failing the
+// link. It also means the shim does not itself drag iostream.cpp.o out of the
+// archive: if the program never touches a stream there is nothing to order.
+//
+// WHY IT WORKS: libc++'s `ios_base::Init::Init()` is not empty — it is a
+// guarded function-local static that calls `DoIOSInit::DoIOSInit()`, and THAT
+// is the function whose relocations placement-new cin/cout/cerr. Calling it
+// early constructs the streams; the archive's own `_GLOBAL__I_000100` then
+// hits the same `__cxa_guard` and does nothing. `this` is never read by that
+// constructor (verified by disassembly), but real storage is passed anyway.
+//
+// The object must be FIRST on the link line — see the backend, which prepends
+// it to the link unit's inputs. Mach-O runs __init_offsets in link order.
+std::string_view stream_init_shim_source() {
+    return
+        "/* Generated by mcpp. macOS + self-contained (static libc++) only.\n"
+        " * Mach-O has no priority-ordered initializer section, so the stream\n"
+        " * initializer pulled out of libc++.a lands LAST in __init_offsets and\n"
+        " * a global constructor that touches std::cout sees an unconstructed\n"
+        " * stream (null vptr -> SIGSEGV at process start). libc++'s <iostream>\n"
+        " * has no ios_base::Init guard of its own, unlike libstdc++/MSVC STL,\n"
+        " * so the header cannot fix it either. mcpp-community/mcpp#336.\n"
+        " *\n"
+        " * Weak: a toolchain without this exact ABI symbol links as before.\n"
+        " */\n"
+        "extern void mcpp_libcxx_ios_init(void *)\n"
+        "    __attribute__((weak)) __asm__(\"_ZNSt3__18ios_base4InitC1Ev\");\n"
+        "\n"
+        "static char mcpp_libcxx_ios_init_storage[8];\n"
+        "\n"
+        "__attribute__((constructor))\n"
+        "static void mcpp_force_std_streams(void) {\n"
+        "    if (mcpp_libcxx_ios_init)\n"
+        "        mcpp_libcxx_ios_init(mcpp_libcxx_ios_init_storage);\n"
+        "}\n";
+}
+
+}  // namespace mcpp::build::dist

--- a/src/build/distribution.cppm
+++ b/src/build/distribution.cppm
@@ -134,6 +134,17 @@ Contract default_contract(Role r) {
 struct MechanismInput {
     Contract         requested = Contract::SelfContained;
     Role             role      = Role::Distributable;
+    // Did a human write this contract down, or is it just our default?
+    //
+    // The distinction decides whether a cell with no mechanism SPEAKS. A
+    // diagnostic is for a BROKEN PROMISE: mcpp said the artifact would be
+    // self-contained and it is not. Under the MSVC runtime mcpp never made
+    // that promise — there is no /MT emission at all — so warning on every
+    // Windows build would be noise nobody can act on. Write
+    // `cxx_runtime = "self-contained"` there and you get told, once, that it
+    // is not implemented. Cells where mcpp DOES promise something (a missing
+    // libc++.a under the default, say) report regardless.
+    bool             explicitRequest = false;
     // Toolchain capability id: "libstdc++", "libc++", or an MSVC STL spelling.
     std::string_view stdlibId;
     Format           format = Format::Elf;
@@ -205,7 +216,7 @@ Mechanism resolve(const MechanismInput& in) {
             // Mach-O without libc++ is not a configuration mcpp produces.
             m.effective = Contract::HostCoupled;
             m.unitFlags = " -lc++";
-            if (in.requested != Contract::HostCoupled) {
+            if (in.requested != Contract::HostCoupled && in.explicitRequest) {
                 m.degraded = true;
                 m.diagnostic = std::format(
                     "cxx_runtime = \"{}\" is not available for stdlib '{}' on "
@@ -266,12 +277,14 @@ Mechanism resolve(const MechanismInput& in) {
             // producing the same bytes and reporting success.
             m.effective = Contract::HostCoupled;
             if (in.requested == Contract::SelfContained) {
-                m.degraded = true;
-                m.diagnostic =
-                    "cxx_runtime = \"self-contained\" is not implemented for the "
-                    "MSVC runtime yet (it would need the /MT runtime); using "
-                    "host-coupled — the artifact needs the VC++ redistributable";
+                m.degraded   = in.explicitRequest;
+                m.diagnostic = in.explicitRequest
+                    ? "cxx_runtime = \"self-contained\" is not implemented for the "
+                      "MSVC runtime yet (it would need the /MT runtime); using "
+                      "host-coupled — the artifact needs the VC++ redistributable"
+                    : "";
             } else if (in.requested == Contract::ToolchainCoupled) {
+                // Only reachable from an explicit request: it is never a default.
                 m.degraded = true;
                 m.diagnostic =
                     "cxx_runtime = \"toolchain-coupled\" has no meaning for the "
@@ -338,7 +351,7 @@ Mechanism resolve(const MechanismInput& in) {
         // Unknown stdlib on ELF: emit nothing rather than guess, but say so
         // when something was actually asked for.
         m.effective = Contract::HostCoupled;
-        if (in.requested != Contract::HostCoupled) {
+        if (in.requested != Contract::HostCoupled && in.explicitRequest) {
             m.degraded = true;
             m.diagnostic = std::format(
                 "cxx_runtime = \"{}\" has no mechanism for stdlib '{}'; "

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -564,12 +564,12 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         // macOS packages) or under lib/<llvm-triple>/ (the Linux ones), so try
         // both rather than hard-coding one layout. Sorted so the choice cannot
         // depend on directory iteration order.
-        auto find_archive = [&](std::string_view name) -> std::string {
+        auto find_archive = [&](std::string_view name) -> std::filesystem::path {
             if (llvmRootForStdlib.empty()) return {};
             std::error_code ec;
             auto libDir = llvmRootForStdlib / "lib";
             auto direct = libDir / name;
-            if (std::filesystem::exists(direct, ec)) return escape_path(direct);
+            if (std::filesystem::exists(direct, ec)) return direct;
             std::vector<std::filesystem::path> hits;
             for (auto& e : std::filesystem::directory_iterator(libDir, ec)) {
                 std::error_code de;
@@ -578,7 +578,28 @@ CompileFlags compute_flags(const BuildPlan& plan) {
                 if (std::filesystem::exists(p, de)) hits.push_back(p);
             }
             std::ranges::sort(hits);
-            return hits.empty() ? std::string{} : escape_path(hits.front());
+            return hits.empty() ? std::filesystem::path{} : hits.front();
+        };
+
+        // Does this archive define a given symbol? Answered by scanning the
+        // ranlib symbol index, which a BSD/Mach-O archive keeps in its FIRST
+        // member — so a bounded read of the head is enough and no toolchain
+        // subprocess is involved. Used for exactly one thing: refusing to
+        // generate the macOS ordering shim against a libc++ that does not
+        // export the symbol it binds. That failure mode is not hypothetical —
+        // the first CI round of #336 turned every macOS link into `undefined
+        // symbol` — and a check here cannot fail the build the way a bad
+        // reference in the generated TU can.
+        auto archive_defines = [](const std::filesystem::path& p,
+                                  std::string_view sym) -> bool {
+            if (p.empty()) return false;
+            std::ifstream is(p, std::ios::binary);
+            if (!is) return false;
+            constexpr std::streamsize kHead = 8 << 20;
+            std::string head(static_cast<std::size_t>(kHead), '\0');
+            is.read(head.data(), kHead);
+            head.resize(static_cast<std::size_t>(is.gcount()));
+            return head.find(sym) != std::string::npos;
         };
 
         dist::MechanismInput mi;
@@ -601,12 +622,21 @@ CompileFlags compute_flags(const BuildPlan& plan) {
              || testsContract == dist::Contract::SelfContained)
             && caps.stdlib_id == "libc++";
         if (wantsArchives) {
-            mi.libcxxArchive    = find_archive("libc++.a");
-            mi.libcxxAbiArchive = find_archive("libc++abi.a");
+            auto libcxxA    = find_archive("libc++.a");
+            auto libcxxAbiA = find_archive("libc++abi.a");
+            mi.libcxxArchive    = libcxxA.empty()    ? std::string{} : escape_path(libcxxA);
+            mi.libcxxAbiArchive = libcxxAbiA.empty() ? std::string{} : escape_path(libcxxAbiA);
             // ELF only: without it the "self-contained" binary still pulls
             // libunwind.so.1. Mach-O's libc++abi.a carries its own unwinder.
-            if (mi.format == dist::Format::Elf)
-                mi.libunwindArchive = find_archive("libunwind.a");
+            if (mi.format == dist::Format::Elf) {
+                auto unwindA = find_archive("libunwind.a");
+                if (!unwindA.empty()) mi.libunwindArchive = escape_path(unwindA);
+            } else {
+                // Searched without the leading underscore so the same needle
+                // matches the ELF (`_ZN...`) and Mach-O (`__ZN...`) spellings.
+                mi.streamInitSymbolPresent =
+                    archive_defines(libcxxA, "ZNSt3__18ios_base4InitC1Ev");
+            }
         }
 
         // "Explicit" = a human wrote it down. `static_stdlib = false` counts:

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -609,12 +609,18 @@ CompileFlags compute_flags(const BuildPlan& plan) {
                 mi.libunwindArchive = find_archive("libunwind.a");
         }
 
-        for (auto [role, requested] : {
-                 std::pair{dist::Role::Distributable, base},
-                 std::pair{dist::Role::Test,          testsContract},
-                 std::pair{dist::Role::Intermediate,  base}}) {
-            mi.role      = role;
-            mi.requested = requested;
+        // "Explicit" = a human wrote it down. `static_stdlib = false` counts:
+        // nobody sets a flag to its default to get non-default behavior.
+        const bool explicitBase  = !bc.cxxRuntime.empty() || !bc.staticStdlib;
+        const bool explicitTests = explicitBase || !bc.cxxRuntimeTests.empty();
+
+        for (auto [role, requested, wasAsked] : {
+                 std::tuple{dist::Role::Distributable, base,          explicitBase},
+                 std::tuple{dist::Role::Test,          testsContract, explicitTests},
+                 std::tuple{dist::Role::Intermediate,  base,          explicitBase}}) {
+            mi.role            = role;
+            mi.requested       = requested;
+            mi.explicitRequest = wasAsked;
             auto r = dist::resolve(mi);
             auto i = static_cast<std::size_t>(role);
             f.ldStdlibByRole[i] = r.unitFlags;

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -12,6 +12,7 @@ module;
 export module mcpp.build.flags;
 
 import std;
+import mcpp.build.distribution;
 import mcpp.build.plan;
 import mcpp.modgraph.scanner;
 import mcpp.platform;
@@ -39,19 +40,43 @@ struct CompileFlags {
     std::string bFlag;                // -B<binutils> (for ninja ldflags)
     bool staticStdlib = true;
     std::string linkage;  // "static" or ""
-    // macOS per-unit C++ stdlib link (appended via unit_ldflags):
-    // distributable targets get the static LLVM libc++ (portable across
-    // macOS versions); TestBinary targets get the toolchain's own libc++
-    // DYNAMICALLY (-L + -lc++ + rpath into the toolchain) — host-only
-    // binaries, so the rpath is fine, and it keeps headers and dylib the
-    // same version (the system -lc++ they used before was a version split
-    // that broke on libc++ 22's out-of-line __hash_memory). Empty on other
-    // platforms (stdlib handled by their existing paths).
-    std::string ldStdlibDefault;
-    std::string ldStdlibTest;
+    // Per-link-unit C++ runtime flags, indexed by dist::Role. EVERY platform
+    // routes through here now (`-static-libstdc++`, MinGW's `-static`, macOS's
+    // `-load_hidden` archives): the channel has to be per-unit because two
+    // roles in one build may hold different contracts, which is precisely what
+    // `static_stdlib = false` could not express for test binaries before #336.
+    // Produced by exactly one call to `dist::resolve` per role.
+    std::array<std::string, 3> ldStdlibByRole{};
+    // The contract each role actually got (after any degradation).
+    std::array<mcpp::build::dist::Contract, 3> contractByRole{};
+    // macOS + self-contained: link units need the initializer-ordering shim
+    // object prepended to their inputs (issue #336).
+    bool needsStreamInitShim = false;
+    // Non-empty when a requested contract could not be honored. The caller
+    // MUST surface these — a silent downgrade is the failure mode this whole
+    // model exists to prevent. Emitted once by the backend, not here, because
+    // compute_flags runs twice per build (ninja + compile_commands).
+    std::vector<std::string> diagnostics;
+
+    const std::string& ldStdlibFor(mcpp::build::dist::Role r) const {
+        return ldStdlibByRole[static_cast<std::size_t>(r)];
+    }
 };
 
 CompileFlags compute_flags(const BuildPlan& plan);
+
+// The kind → role map. One line of policy, in one place: a test binary runs on
+// the build machine and is then thrown away; an archive embeds no runtime at
+// all; everything else leaves this machine. Backends ask this, never the kind.
+constexpr mcpp::build::dist::Role role_of(LinkUnit::Kind k) {
+    switch (k) {
+        case LinkUnit::TestBinary:    return mcpp::build::dist::Role::Test;
+        case LinkUnit::StaticLibrary: return mcpp::build::dist::Role::Intermediate;
+        case LinkUnit::Binary:
+        case LinkUnit::SharedLibrary: break;
+    }
+    return mcpp::build::dist::Role::Distributable;
+}
 
 // Return the linker flag that pulls in libatomic, or "" when it should be
 // omitted. libatomic carries the out-of-line __atomic_* libcalls that
@@ -512,16 +537,100 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     f.staticStdlib = plan.manifest.buildConfig.staticStdlib;
     f.linkage = plan.manifest.buildConfig.linkage;
     std::string full_static = (mcpp::platform::supports_full_static && f.linkage == "static") ? " -static" : "";
-    // Static C++ stdlib: a libstdc++ (GCC/MinGW) concern. On Windows a MinGW
-    // toolchain also statically links libgcc, so produced binaries don't
-    // depend on libstdc++-6.dll / libgcc_s DLLs from the toolchain dir
-    // (portable-by-default, same spirit as the macOS static-libc++ path).
-    std::string static_stdlib;
-    if (f.staticStdlib && caps.stdlib_id == "libstdc++") {
-        static_stdlib = " -static-libstdc++";
-        if constexpr (mcpp::platform::is_windows)
-            static_stdlib += " -static-libgcc";
+
+    // ---- C++ runtime distribution contract (issue #336) -------------------
+    //
+    // THE single derivation of "does this artifact carry its own C++ runtime",
+    // for every role and every platform. `-static-libstdc++`, MinGW's
+    // `-static` and macOS's `-load_hidden` archives all come out of here now;
+    // nothing below re-decides it. The flags land in the PER-UNIT channel
+    // (`unit_ldflags`) rather than the global one because two roles in the
+    // same build may hold different contracts.
+    {
+        namespace dist = mcpp::build::dist;
+        auto const& bc = plan.manifest.buildConfig;
+
+        // `static_stdlib` is a faithful alias of the two ends of the contract:
+        // its documented meaning has always been exactly self-contained vs the
+        // dynamic system runtime. An explicit `cxx_runtime` wins.
+        const dist::Contract base =
+            dist::parse_contract(bc.cxxRuntime).value_or(
+                bc.staticStdlib ? dist::Contract::SelfContained
+                                : dist::Contract::HostCoupled);
+        const dist::Contract testsContract =
+            dist::parse_contract(bc.cxxRuntimeTests).value_or(base);
+
+        // Archive lookup. LLVM lays these out either directly under lib/ (the
+        // macOS packages) or under lib/<llvm-triple>/ (the Linux ones), so try
+        // both rather than hard-coding one layout. Sorted so the choice cannot
+        // depend on directory iteration order.
+        auto find_archive = [&](std::string_view name) -> std::string {
+            if (llvmRootForStdlib.empty()) return {};
+            std::error_code ec;
+            auto libDir = llvmRootForStdlib / "lib";
+            auto direct = libDir / name;
+            if (std::filesystem::exists(direct, ec)) return escape_path(direct);
+            std::vector<std::filesystem::path> hits;
+            for (auto& e : std::filesystem::directory_iterator(libDir, ec)) {
+                std::error_code de;
+                if (!e.is_directory(de)) continue;
+                auto p = e.path() / name;
+                if (std::filesystem::exists(p, de)) hits.push_back(p);
+            }
+            std::ranges::sort(hits);
+            return hits.empty() ? std::string{} : escape_path(hits.front());
+        };
+
+        dist::MechanismInput mi;
+        mi.stdlibId       = caps.stdlib_id;
+        mi.hostIsWindows  = mcpp::platform::is_windows;
+        mi.fullStaticLibc = (f.linkage == "static");
+        mi.mingw          = isMingwTc;
+        mi.macosFloor     = !macosDeploymentTarget.empty();
+        if constexpr (mcpp::platform::needs_explicit_libcxx) {
+            mi.format = dist::Format::MachO;
+        } else if constexpr (mcpp::platform::is_windows) {
+            mi.format = dist::Format::Pe;
+        }
+        // Target-keyed, not host-keyed: a Linux-hosted MinGW cross build
+        // produces a PE and must take the PE mechanism.
+        if (isMingwTc) mi.format = dist::Format::Pe;
+
+        const bool wantsArchives =
+            (base == dist::Contract::SelfContained
+             || testsContract == dist::Contract::SelfContained)
+            && caps.stdlib_id == "libc++";
+        if (wantsArchives) {
+            mi.libcxxArchive    = find_archive("libc++.a");
+            mi.libcxxAbiArchive = find_archive("libc++abi.a");
+            // ELF only: without it the "self-contained" binary still pulls
+            // libunwind.so.1. Mach-O's libc++abi.a carries its own unwinder.
+            if (mi.format == dist::Format::Elf)
+                mi.libunwindArchive = find_archive("libunwind.a");
+        }
+
+        for (auto [role, requested] : {
+                 std::pair{dist::Role::Distributable, base},
+                 std::pair{dist::Role::Test,          testsContract},
+                 std::pair{dist::Role::Intermediate,  base}}) {
+            mi.role      = role;
+            mi.requested = requested;
+            auto r = dist::resolve(mi);
+            auto i = static_cast<std::size_t>(role);
+            f.ldStdlibByRole[i] = r.unitFlags;
+            f.contractByRole[i] = r.effective;
+            if (r.streamInitShim) f.needsStreamInitShim = true;
+            if (!r.diagnostic.empty())
+                f.diagnostics.push_back(std::format(
+                    "{} target: {}", dist::to_string(role), r.diagnostic));
+        }
+        // Two roles usually share a contract, so they usually share a
+        // complaint; report each distinct one once.
+        std::ranges::sort(f.diagnostics);
+        f.diagnostics.erase(std::ranges::unique(f.diagnostics).begin(),
+                            f.diagnostics.end());
     }
+
     std::string runtime_dirs;
     if constexpr (mcpp::platform::supports_rpath) {
         // Toolchain runtime dirs (glibc/gcc) as before...
@@ -559,18 +668,14 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     // + libstdc++exp (std::print's __open_terminal/__write_to_terminal live in
     // libstdc++exp.a, not plain libstdc++). Self-contained binutils → no -B.
     if (isMingwTc) {
-        std::string mingw_static;
+        // `-static` / `-static-libstdc++` now come from the contract table via
+        // unit_ldflags (dist::Format::Pe) — the whole-link `-static` is what
+        // "self-contained" means here, since the piecemeal recipe still leaves
+        // libwinpthread-1.dll behind.
         std::string mingw_stdexp;
-        if (caps.stdlib_id == "libstdc++") {
-            // `-static` for the whole link — MinGW's standalone-exe convention
-            // (the piecemeal -static-libstdc++ recipe still pulls
-            // libwinpthread-1.dll). Opt out via [build] static_stdlib=false.
-            if (f.staticStdlib || f.linkage == "static")
-                mingw_static = " -static";
+        if (caps.stdlib_id == "libstdc++")
             mingw_stdexp = " -lstdc++exp";
-        }
-        f.ld = std::format("{}{}{}{}{}", mingw_static, static_stdlib,
-                           user_ldflags, mingw_stdexp, link_extra);
+        f.ld = std::format("{}{}{}", user_ldflags, mingw_stdexp, link_extra);
         return f;
     }
 
@@ -590,96 +695,30 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         // PE link, MSVC-ABI Clang (native MinGW is handled by the target-keyed
         // branch above and has already returned): no rpath/loader/payload —
         // MSVC STL/SDK come via the driver, nothing extra needed.
-        f.ld = std::format("{}{}{}", static_stdlib, user_ldflags, link_extra);
+        f.ld = std::format("{}{}", user_ldflags, link_extra);
     } else if constexpr (mcpp::platform::needs_explicit_libcxx) {
-        // macOS. Two min-version concerns (see xlings
-        // .agents/docs/2026-06-05-macos-min-version-support.md):
+        // macOS. The C++ runtime itself is decided by the contract table above
+        // (dist::Format::MachO) and rides unit_ldflags; what is left here is
+        // the rest of the macOS link:
         //
-        // 1. stdlib linkage — `-lc++` resolves to the SYSTEM
-        //    /usr/lib/libc++.1.dylib, which caps the deployment floor at
-        //    the build host's OS: e.g. std::print's __is_posix_terminal
-        //    support symbol only exists in macOS 15's libc++, so a
-        //    minos-14 binary dies at launch on 14 (dyld missing-symbol
-        //    abort; verified on macos-14 CI). With staticStdlib (the
-        //    manifest default — previously silently ignored on the clang
-        //    route), link LLVM's own libc++.a/libc++abi.a instead:
-        //    runtime deps shrink to libSystem and the floor drops to
-        //    14.0 — the floor of the official LLVM static archives;
-        //    lower needs a custom libc++ build. Falls back to -lc++ when the
-        //    archives are absent.
-        // 2. deployment target — mirror MACOSX_DEPLOYMENT_TARGET onto the
-        //    link command line so it doesn't depend on env propagation.
-        // 3. linker — use LLVM's own lld (same as the Linux clang path)
+        // 1. deployment target — mirror MACOSX_DEPLOYMENT_TARGET onto the
+        //    link command line so it doesn't depend on env propagation. The
+        //    static-libc++ mechanism exists to make this floor REAL: `-lc++`
+        //    resolves to the SYSTEM /usr/lib/libc++.1.dylib, which caps the
+        //    runnable version at the build host's OS (std::print's
+        //    __is_posix_terminal support symbol only exists in macOS 15's
+        //    libc++, so a minos-14 binary died at launch on macos-14 CI).
+        // 2. linker — use LLVM's own lld (same as the Linux clang path)
         //    instead of Xcode's ld: the system ld's version floats with
         //    the host Xcode (observed: Xcode 15.4's ld aborting at launch
         //    on macos-14 CI when its libc++ resolution was diverted), and
         //    lld ships with the exact toolchain doing the compile.
-        f.ldStdlibDefault = " -lc++";
-        f.ldStdlibTest    = " -lc++";
-        // Static libc++ + the deployment floor are the DEFAULT (rust-style
-        // "portable by default"): the resolver always yields a floor on
-        // macOS (built-in 14.0 unless env/manifest override), and the
-        // static LLVM libc++ is what makes that floor real — the system
-        // libc++ caps binaries at the build host's OS (a fresh user's
-        // std::println hello on macOS 14 died at dyld against the system
-        // libc++ before this). Opt-out: [build] static_stdlib = false
-        // (host-coupled dynamic libc++, the pre-0.0.52 no-declaration
-        // behavior). The two blockers that deferred this default are
-        // resolved: (1) mixed C/C++ split-brain SIGSEGV — fixed by
-        // -load_hidden (PR #117 forensics), (2) std-module staging /
-        // fingerprint drift — fixed by the single resolver (PR #119).
+        //
         // TODO(macos-floor-11): the official LLVM archives are built for
         // macOS 14; supporting 11-13 needs a custom libc++ build shipped
         // via xlings-res (data-only change — swap the archive source).
         // Tracked in xlings
         // .agents/docs/2026-06-05-macos-min-version-support.md §5.
-        if (f.staticStdlib && !macosDeploymentTarget.empty()
-            && !llvmRootForStdlib.empty()) {
-            auto libDir     = llvmRootForStdlib / "lib";
-            auto libcxxA    = libDir / "libc++.a";
-            auto libcxxAbiA = libDir / "libc++abi.a";
-            if (std::filesystem::exists(libcxxA)
-                && std::filesystem::exists(libcxxAbiA)) {
-                // Link the archives via -Wl,-load_hidden,<path>: forces
-                // the ARCHIVE (never a sibling dylib) and gives its
-                // symbols hidden visibility. Both properties matter:
-                //  - plain BY-PATH linking leaves default-visibility
-                //    symbols that dyld then unifies with the system
-                //    libc++ pulled in via the shared cache — a
-                //    split-brain libc++ where ostream<<int crosses into
-                //    the system copy's locale machinery and SIGSEGVs
-                //    (CI forensics m1/m3 vs m6/m7).
-                //  - -Wl,-hidden-l resolves like a plain -l under lld
-                //    and picks the sibling DYLIB (load failure).
-                f.ldStdlibDefault = " -nostdlib++"
-                    " -Wl,-load_hidden," + escape_path(libcxxA)
-                  + " -Wl,-load_hidden," + escape_path(libcxxAbiA);
-            }
-        }
-        // TestBinary: SAME static -load_hidden libc++ as distributables.
-        // Tests previously took the SYSTEM -lc++ while compiling against the
-        // toolchain's libc++ HEADERS — a header/dylib version split that
-        // detonated when libc++ 22 moved string hashing out of line
-        // (undefined __hash_memory, 2026-07-08). The dynamic alternative
-        // (toolchain libc++.dylib + rpath) is a dead end with this
-        // distribution: its abi/unwind dylibs upward-link /usr/lib/libc++,
-        // so the SYSTEM libc++ still loads next to the toolchain's and
-        // gtest's initializers freed across the two copies
-        // (BUG_IN_CLIENT_OF_LIBMALLOC, CI crash forensics rounds 5-6).
-        // Static hidden archives keep exactly ONE libc++, inside the
-        // binary — the same already-proven shape mcpp/xlings ship with.
-        // Design: .agents/docs/2026-07-08-root-cause-remediation-design.md A1.
-        if (!llvmRootForStdlib.empty()) {
-            auto libDir     = llvmRootForStdlib / "lib";
-            auto libcxxA    = libDir / "libc++.a";
-            auto libcxxAbiA = libDir / "libc++abi.a";
-            if (std::filesystem::exists(libcxxA)
-                && std::filesystem::exists(libcxxAbiA)) {
-                f.ldStdlibTest = " -nostdlib++"
-                    " -Wl,-load_hidden," + escape_path(libcxxA)
-                  + " -Wl,-load_hidden," + escape_path(libcxxAbiA);
-            }
-        }
         std::string version_min;
         if (!macosDeploymentTarget.empty()) {
             version_min = " -mmacosx-version-min=" + macosDeploymentTarget;
@@ -695,7 +734,7 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         std::string macos_sdk;
         if (auto sdk = mcpp::platform::macos::sdk_path())
             macos_sdk = " -isysroot " + escape_path(*sdk);
-        f.ld = std::format("{}{}{}{} -fuse-ld=lld{}{}{}", full_static, static_stdlib,
+        f.ld = std::format("{}{}{} -fuse-ld=lld{}{}{}", full_static,
                            b_flag, macos_sdk, version_min, user_ldflags, link_extra);
     } else {
         // libatomic: 16-byte / oversized std::atomic needs the out-of-line
@@ -705,7 +744,7 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         // actually being present (see atomic_link_flag).
         std::string atomic_ld = atomic_link_flag(plan.toolchain.linkRuntimeDirs,
                                                  !full_static.empty());
-        f.ld = std::format("{}{}{}{}{}{}{}{}{}", full_static, static_stdlib, link_toolchain_flags, b_flag,
+        f.ld = std::format("{}{}{}{}{}{}{}{}", full_static, link_toolchain_flags, b_flag,
                            runtime_dirs, atomic_ld, payload_ld, user_ldflags, link_extra);
     }
 

--- a/src/build/ninja_backend.cppm
+++ b/src/build/ninja_backend.cppm
@@ -19,6 +19,7 @@ export module mcpp.build.ninja;
 
 import std;
 import mcpp.build.backend;
+import mcpp.build.distribution;
 import mcpp.build.plan;
 import mcpp.build.flags;
 import mcpp.build.hermetic;
@@ -31,6 +32,7 @@ import mcpp.toolchain.provider;
 import mcpp.toolchain.registry;
 import mcpp.xlings;
 import mcpp.platform;
+import mcpp.ui;
 
 export namespace mcpp::build {
 
@@ -408,12 +410,15 @@ std::string emit_ninja_string(const BuildPlan& plan) {
         else if (is_nasm_source(cu.source)) need_nasm_rule = true;
     }
 
+    // The macOS initializer-ordering shim (#336) is a C translation unit, so
+    // it needs the C driver bindings even in a project with no .c sources.
+    const bool need_ios_init_shim = flags.needsStreamInitShim;
     append(std::format("cxx       = {}\n", escape_ninja_path(flags.cxxBinary)));
     append(std::format("cxxflags  = {}\n", flags.cxx));
-    if (need_c_rule || need_asm_rule) {   // asm_object drives the C compiler too
+    if (need_c_rule || need_asm_rule || need_ios_init_shim) {  // asm_object drives the C compiler too
         append(std::format("cc        = {}\n", escape_ninja_path(flags.ccBinary)));
     }
-    if (need_c_rule) {
+    if (need_c_rule || need_ios_init_shim) {
         append(std::format("cflags    = {}\n", flags.cc));
     }
     if (need_asm_rule) {
@@ -786,6 +791,16 @@ std::string emit_ninja_string(const BuildPlan& plan) {
         }
     }
 
+    // #336: one extra object, compiled from a generated C TU, whose only job
+    // is to run first. Its own rule rather than the C rule above because it
+    // has no includes (so no depfile machinery) and must not be perturbed by
+    // whatever that rule grows next.
+    if (need_ios_init_shim) {
+        append("rule ios_init_object\n");
+        append("  command = $cc $cflags -c $in -o $out\n");
+        append("  description = CC $out\n\n");
+    }
+
     append("rule runtime_alias\n");
     if constexpr (mcpp::platform::is_windows) {
         // PE has no soname symlink, so the alias is a copy — and a copy of a
@@ -860,6 +875,17 @@ std::string emit_ninja_string(const BuildPlan& plan) {
     auto std_bmi_dst = mcpp::toolchain::staged_std_bmi_path(plan.toolchain, {});
     auto std_o_dst = std::filesystem::path("obj")
                    / std::format("std{}", dial.objExt);
+
+    // #336 shim: source is written next to build.ninja by NinjaBackend::build.
+    auto ios_init_src = std::filesystem::path("obj") / "mcpp_ios_init.c";
+    auto ios_init_obj = std::filesystem::path("obj")
+                      / std::format("mcpp_ios_init{}", dial.objExt);
+    if (need_ios_init_shim) {
+        append(std::format("build {} : ios_init_object {}\n",
+                           escape_ninja_path(ios_init_obj),
+                           escape_ninja_path(ios_init_src)));
+        append("\n");
+    }
 
     bool has_std_artifacts = !plan.stdBmiPath.empty() && !plan.stdObjectPath.empty();
     if (has_std_artifacts) {
@@ -1170,6 +1196,12 @@ std::string emit_ninja_string(const BuildPlan& plan) {
     // Link units
     for (auto& lu : plan.linkUnits) {
         std::string ins;
+        // FIRST, before every other object. Mach-O runs __init_offsets in
+        // LINK order and has no priority-ordered init section, so "runs
+        // before the user's global constructors" is spelled "is the first
+        // input" — nothing else about this edge achieves it (#336).
+        if (need_ios_init_shim && lu.kind != LinkUnit::StaticLibrary)
+            ins += " " + escape_ninja_path(ios_init_obj);
         for (auto& o : lu.objects) {
             ins += " " + escape_ninja_path(o);
         }
@@ -1214,13 +1246,14 @@ std::string emit_ninja_string(const BuildPlan& plan) {
         if (auto flag = shared_soname_flag(lu); !flag.empty())
             out_line += "  soname_flag = " + flag + "\n";
         {
-            // Per-unit C++ stdlib link (macOS; empty elsewhere): test
-            // binaries run on the build host and use the system -lc++,
-            // distributable targets get the static LLVM libc++. See
-            // CompileFlags::ldStdlibDefault/ldStdlibTest.
+            // Per-unit C++ runtime link, by ROLE. The kind→role map is the
+            // only place that knows a TestBinary runs on the build machine
+            // while everything else leaves it; which flags that implies is
+            // the contract table's business, not this emitter's (#336 —
+            // before, this switch WAS the policy, and `static_stdlib = false`
+            // could not reach the test side of it).
             std::string unit = join_flags(lu.linkFlags);
-            unit += (lu.kind == mcpp::build::LinkUnit::TestBinary)
-                ? flags.ldStdlibTest : flags.ldStdlibDefault;
+            unit += flags.ldStdlibFor(role_of(lu.kind));
             if (!unit.empty())
                 out_line += "  unit_ldflags =" + unit + "\n";
         }
@@ -1316,6 +1349,22 @@ std::expected<BuildResult, BuildError> NinjaBackend::build(const BuildPlan& plan
     // compile_commands.json — via the dedicated module.
     auto flags = compute_flags(plan);
     write_compile_commands(plan, flags);
+
+    // A distribution contract that could not be honored is reported, never
+    // silently downgraded — the whole point of the model (INV-1/INV-4 in
+    // .agents/docs/2026-08-02-issue336-pr142-analysis.md). Emitted here rather
+    // than inside compute_flags, which runs twice per build.
+    for (auto const& d : flags.diagnostics)
+        mcpp::ui::warning(std::format("cxx_runtime: {}", d));
+
+    // #336: the generated initializer-ordering TU. Written before ninja runs,
+    // since the link edge lists its object as an input.
+    if (flags.needsStreamInitShim) {
+        std::error_code sec;
+        std::filesystem::create_directories(plan.outputDir / "obj", sec);
+        write_file(plan.outputDir / "obj" / "mcpp_ios_init.c",
+                   mcpp::build::dist::stream_init_shim_source());
+    }
 
     if (opts.dryRun) {
         BuildResult r;

--- a/src/build/prepare.cppm
+++ b/src/build/prepare.cppm
@@ -1184,6 +1184,11 @@ prepare_build(bool print_fingerprint,
                 tcOrigin = TcOrigin::TargetSection;
             }
             if (!it->second.linkage.empty())   m->buildConfig.linkage = it->second.linkage;
+            // #336: a per-target C++ runtime contract overrides the project
+            // default, so "self-contained everywhere except this triple" is
+            // expressible without touching the cfg() input channel.
+            if (!it->second.cxxRuntime.empty())
+                m->buildConfig.cxxRuntime = it->second.cxxRuntime;
         }
         // Convention from the vocabulary table (triple.cppm): the target's
         // pinned toolchain (host-awareness — native musl-gcc vs triple-named

--- a/src/manifest/toml.cppm
+++ b/src/manifest/toml.cppm
@@ -838,6 +838,48 @@ std::expected<Manifest, ManifestError> parse_string(std::string_view content,
 
     // [build] — backend tunables
     if (auto v = doc->get_bool("build.static_stdlib")) m.buildConfig.staticStdlib = *v;
+    // #336 — [build] cxx_runtime. Two spellings for one field, cargo-style:
+    //   cxx_runtime = "host-coupled"                       (all roles)
+    //   cxx_runtime = { default = "...", tests = "..." }   (per role)
+    // Rejecting an unknown value here is what lets flags.cppm parse it later
+    // with `value_or` and no second validation path.
+    {
+        auto check = [&](std::string_view where, const std::string& v)
+            -> std::optional<ManifestError>
+        {
+            static constexpr std::string_view kOk[] = {
+                "self-contained", "toolchain-coupled", "host-coupled" };
+            for (auto k : kOk) if (v == k) return std::nullopt;
+            return error(origin, std::format(
+                "{} = '{}' is invalid; expected one of \"self-contained\", "
+                "\"toolchain-coupled\", \"host-coupled\"", where, v));
+        };
+        if (auto* val = doc->get("build.cxx_runtime")) {
+            if (val->is_string()) {
+                auto s = val->as_string();
+                if (auto e = check("[build].cxx_runtime", s)) return std::unexpected(*e);
+                m.buildConfig.cxxRuntime = s;
+            } else if (val->is_table()) {
+                for (auto& [key, v] : val->as_table()) {
+                    if (key != "default" && key != "tests")
+                        return std::unexpected(error(origin, std::format(
+                            "[build].cxx_runtime has unsupported key '{}'; "
+                            "expected 'default' or 'tests'", key)));
+                    if (!v.is_string())
+                        return std::unexpected(error(origin, std::format(
+                            "[build].cxx_runtime.{} must be a string", key)));
+                    auto s = v.as_string();
+                    if (auto e = check(std::format("[build].cxx_runtime.{}", key), s))
+                        return std::unexpected(*e);
+                    (key == "tests" ? m.buildConfig.cxxRuntimeTests
+                                    : m.buildConfig.cxxRuntime) = s;
+                }
+            } else {
+                return std::unexpected(error(origin,
+                    "[build].cxx_runtime must be a string or a table"));
+            }
+        }
+    }
     if (auto v = doc->get_bool("build.allow_host_libs")) m.buildConfig.allowHostLibs = *v;
     if (auto v = doc->get_string_array("build.cflags"))   m.buildConfig.cflags   = *v;
     if (auto v = doc->get_string_array("build.cxxflags")) m.buildConfig.cxxflags = *v;
@@ -1000,6 +1042,22 @@ std::expected<Manifest, ManifestError> parse_string(std::string_view content,
                         triple, e.linkage)));
                 }
             }
+            // #336 — the C++ runtime contract, same axis as `linkage` (both
+            // describe the produced artifact's run-time dependencies) and so
+            // the same scoping. Only the scalar form here: a per-target,
+            // per-role matrix is a surface nobody has asked for, and
+            // [build].cxx_runtime already covers the role split.
+            if (auto it = body.find("cxx_runtime"); it != body.end() && it->second.is_string()) {
+                e.cxxRuntime = it->second.as_string();
+                if (e.cxxRuntime != "self-contained"
+                    && e.cxxRuntime != "toolchain-coupled"
+                    && e.cxxRuntime != "host-coupled") {
+                    return std::unexpected(error(origin, std::format(
+                        "[target.{}].cxx_runtime = '{}' is invalid; expected one of "
+                        "\"self-contained\", \"toolchain-coupled\", \"host-coupled\"",
+                        triple, e.cxxRuntime)));
+                }
+            }
             m.targetOverrides[canon_triple(triple)] = std::move(e);
 
             // [target.<predicate>.{build,dependencies,...}] — platform-conditional
@@ -1063,9 +1121,12 @@ std::expected<Manifest, ManifestError> parse_string(std::string_view content,
                             "A conditional section may only contribute build INPUTS: "
                             "sources, cflags, cxxflags, ldflags, defines, flags, "
                             "include_dirs, include_dirs_after. Selection knobs "
-                            "(target, linkage, static_stdlib) and profile settings "
-                            "are resolved before the predicate is evaluated and "
-                            "cannot be conditioned.", triple, key));
+                            "(target, linkage) and profile settings are resolved "
+                            "before the predicate is evaluated and cannot be "
+                            "conditioned; the C++ runtime contract IS "
+                            "per-target, but it is spelled "
+                            "[target.<triple>].cxx_runtime, beside `linkage`.",
+                            triple, key));
                     }
                 }
             }

--- a/src/manifest/types.cppm
+++ b/src/manifest/types.cppm
@@ -241,6 +241,24 @@ struct BuildConfig : BuildInputs {
     std::map<std::string, std::vector<GlobFlags>> featureFlags;
     std::map<std::filesystem::path, std::string> generatedFiles; // Form B package-owned support files
     bool                                staticStdlib = true;
+    // #336 — the C++ runtime DISTRIBUTION contract: what the artifact promises
+    // about the machine that runs it ("self-contained" | "toolchain-coupled" |
+    // "host-coupled"). Empty = unset, in which case `staticStdlib` supplies it
+    // (true → self-contained, false → host-coupled), which is exactly what that
+    // flag has always been documented to mean.
+    //
+    // Why a separate field rather than widening the bool: the bool spells a
+    // MECHANISM ("statically link the stdlib") and expanded into three
+    // different per-platform meanings — including a silent no-op on
+    // Linux/libc++, where it produced a toolchain-coupled artifact while
+    // claiming to be static. The contract spells the INTENT, and
+    // build/distribution.cppm maps intent to mechanism in one total function.
+    std::string                         cxxRuntime;
+    // Per-role override for test binaries. Empty = follow `cxxRuntime`.
+    // Tests are the one role whose contract legitimately diverges: they never
+    // leave the build machine, so "link the host's runtime" is a defensible
+    // choice there and an indefensible one for a shipped artifact.
+    std::string                         cxxRuntimeTests;
     // "" (default = dynamic), "static", "dynamic" — chosen at resolve
     // time from --static / --target / [target.<triple>].linkage. Wired
     // through to ninja backend as the `-static` link flag.
@@ -335,6 +353,15 @@ struct XlingsConfig {
 struct TargetEntry {
     std::string                         toolchain;     // e.g. "gcc@15.1.0-musl"; empty = inherit [toolchain]
     std::string                         linkage;       // "static" | "dynamic" | "" (= auto by libc)
+    // #336 — per-target C++ runtime contract, same vocabulary as
+    // [build].cxx_runtime and overriding it for this triple. It lives HERE,
+    // beside `linkage`, rather than in the `cfg(...)` conditional channel:
+    // both describe what the produced artifact depends on at run time, both
+    // are resolved before the build inputs are merged, and the conditional
+    // channel deliberately carries build INPUTS and nothing else
+    // (ConditionalConfig). One axis, one scoping rule.
+    std::string                         cxxRuntime;
+    std::string                         cxxRuntimeTests;
 };
 
 // `[target.'cfg(...)'.build]` — platform-conditional build flags (L1). The

--- a/src/toolchain/fingerprint.cppm
+++ b/src/toolchain/fingerprint.cppm
@@ -18,7 +18,7 @@ import mcpp.toolchain.detect;
 
 export namespace mcpp::toolchain {
 
-inline constexpr std::string_view MCPP_VERSION = "2026.8.2.2";
+inline constexpr std::string_view MCPP_VERSION = "2026.8.3.1";
 
 struct FingerprintInputs {
     Toolchain                       toolchain;

--- a/tests/e2e/183_cxx_runtime_contract.sh
+++ b/tests/e2e/183_cxx_runtime_contract.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# mcpp-community/mcpp#336 — the C++ runtime distribution contract.
+#
+# Three things this locks down, all of which were broken or absent before:
+#
+#   1. A global object that uses std::cout during static initialization must
+#      run. On macOS with the default (self-contained → static libc++) it
+#      SIGSEGV'd at process start: Mach-O runs __init_offsets in link order and
+#      has no priority-ordered init section, so the stream initializer pulled
+#      out of libc++.a landed last and `std::cout`'s vptr was still zero.
+#      libc++'s <iostream> carries no `ios_base::Init` guard of its own — the
+#      remedy the standard provides and libstdc++/MSVC STL use — so no amount
+#      of package-side code could fix it either. This is the repro from the
+#      issue, verbatim.
+#
+#   2. `cxx_runtime = "host-coupled"` (and its older spelling
+#      `static_stdlib = false`) must reach TEST binaries. It silently did not
+#      from 0.0.86 to 2026.8.2.2 while the documentation kept promising it,
+#      because the test link path was a second, ungated derivation of the same
+#      decision.
+#
+#   3. The contract is a claim about the artifact's runtime dependency set, so
+#      it is checked against the artifact, not against the flags we passed.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"
+
+case "$(uname -s)" in
+    Darwin)               HOST=macos   ;;
+    MINGW*|MSYS*|CYGWIN*) HOST=windows ;;
+    *)                    HOST=linux   ;;
+esac
+
+# ── the repro ──────────────────────────────────────────────────────────────
+mkdir -p siof/src siof/tests
+cat > siof/mcpp.toml <<'EOF'
+[package]
+name    = "siof"
+version = "0.1.0"
+EOF
+
+# `std::cout.rdbuf()` during static init. Touching the stream is the point:
+# merely taking its address would not fault.
+cat > siof/src/main.cpp <<'EOF'
+#include <iostream>
+struct Early {
+    Early() { probe = std::cout.rdbuf(); }
+    std::streambuf* probe = nullptr;
+};
+static Early early_user;
+int main() {
+    std::cout << "static-init-ok\n";
+    return early_user.probe == nullptr;
+}
+EOF
+
+# The same hazard in a test binary — the role whose opt-out was unreachable.
+cat > siof/tests/early.cpp <<'EOF'
+#include <iostream>
+struct Early {
+    Early() { probe = std::cout.rdbuf(); }
+    std::streambuf* probe = nullptr;
+};
+static Early early_user;
+int main() {
+    std::cout << "static-init-ok\n";
+    return early_user.probe == nullptr;
+}
+EOF
+
+cd siof
+
+echo "== 1. default (self-contained): the repro must run =="
+"$MCPP" build >/dev/null 2>&1 || { echo "FAIL: default build"; exit 1; }
+run_out=$("$MCPP" run 2>&1) || {
+    echo "FAIL: default-profile binary crashed during static initialization"
+    echo "$run_out"
+    echo "(macOS: this is #336 — the libc++ stream initializer ordered last"
+    echo " in __init_offsets. Check that the mcpp_ios_init object is the FIRST"
+    echo " input of the link edge in target/*/*/build.ninja.)"
+    exit 1; }
+echo "$run_out" | grep -q "static-init-ok" || {
+    echo "FAIL: expected static-init-ok, got: $run_out"; exit 1; }
+
+echo "== 2. the same, as a test binary =="
+test_out=$("$MCPP" test 2>&1) || {
+    echo "FAIL: test binary crashed during static initialization"
+    echo "$test_out"; exit 1; }
+echo "$test_out" | grep -q "test result ok" || {
+    echo "FAIL: unexpected test output: $test_out"; exit 1; }
+
+# On macOS the shim is what makes 1 and 2 pass, so assert it is actually
+# there and actually first — a silently-absent shim would leave this test
+# passing by luck on a future toolchain and failing for users on another.
+if [[ "$HOST" == macos ]]; then
+    NINJA=$(find target -name build.ninja | head -1)
+    grep -q "mcpp_ios_init" "$NINJA" || {
+        echo "FAIL: no initializer-ordering shim in the macOS link"; exit 1; }
+    # `build <exe> : cxx_link <first-input> ...`
+    link_line=$(grep -E "^build .*: cxx_link " "$NINJA" | head -1)
+    first_in=$(echo "$link_line" | sed -E 's/^build .*: cxx_link +([^ ]+).*/\1/')
+    case "$first_in" in
+        *mcpp_ios_init*) ;;
+        *) echo "FAIL: shim object is not the first link input: $link_line"
+           exit 1 ;;
+    esac
+fi
+
+echo "== 3. cxx_runtime = host-coupled reaches BOTH roles (#336 part one) =="
+# Capture the self-contained shape first so the comparison is against this
+# machine's actual output rather than a hard-coded flag string.
+NINJA=$(find target -name build.ninja | head -1)
+self_units=$(grep -c "unit_ldflags" "$NINJA" || true)
+
+cat >> mcpp.toml <<'EOF'
+
+[build]
+cxx_runtime = "host-coupled"
+EOF
+"$MCPP" build >/dev/null 2>&1 || { echo "FAIL: host-coupled build"; exit 1; }
+"$MCPP" test  >/dev/null 2>&1 || { echo "FAIL: host-coupled test"; exit 1; }
+
+NINJA=$(find target -name build.ninja | head -1)
+# Whatever the platform's self-contained mechanism is (-static-libstdc++,
+# -static, -load_hidden archives), host-coupled must not carry it — for the
+# test target as much as for the binary.
+if grep -E "unit_ldflags.*(-static-libstdc\+\+|-load_hidden|-nostdlib\+\+)" "$NINJA" >/dev/null; then
+    echo "FAIL: host-coupled still emits a self-contained mechanism:"
+    grep "unit_ldflags" "$NINJA"
+    exit 1
+fi
+
+echo "== 4. the older spelling means the same thing =="
+"$MCPP" build >/dev/null 2>&1
+sed 's/cxx_runtime = "host-coupled"/static_stdlib = false/' mcpp.toml > mcpp.toml.tmp
+mv mcpp.toml.tmp mcpp.toml
+"$MCPP" build >/dev/null 2>&1 || { echo "FAIL: static_stdlib=false build"; exit 1; }
+NINJA=$(find target -name build.ninja | head -1)
+if grep -E "unit_ldflags.*(-static-libstdc\+\+|-load_hidden|-nostdlib\+\+)" "$NINJA" >/dev/null; then
+    echo "FAIL: static_stdlib = false is not an alias of host-coupled:"
+    grep "unit_ldflags" "$NINJA"
+    exit 1
+fi
+
+echo "== 5. an invalid contract is rejected at parse time =="
+sed 's/static_stdlib = false/cxx_runtime = "static"/' mcpp.toml > mcpp.toml.tmp
+mv mcpp.toml.tmp mcpp.toml
+set +e
+bad_out=$("$MCPP" build 2>&1)
+bad_rc=$?
+set -e
+[[ $bad_rc -ne 0 ]] || { echo "FAIL: invalid cxx_runtime accepted"; exit 1; }
+echo "$bad_out" | grep -q "self-contained" || {
+    echo "FAIL: the error does not list the valid values: $bad_out"; exit 1; }
+
+echo "== 6. self-contained is checked against the ARTIFACT =="
+# The contract is a claim about the runtime dependency set. Assert it there,
+# not on the flags — a mechanism that stops working would otherwise keep
+# reporting success. (The per-OS allowed set is deliberately narrow.)
+cd "$TMP"
+mkdir -p dist/src
+cat > dist/mcpp.toml <<'EOF'
+[package]
+name    = "dist"
+version = "0.1.0"
+EOF
+cat > dist/src/main.cpp <<'EOF'
+#include <iostream>
+int main() { std::cout << "hi\n"; }
+EOF
+cd dist
+"$MCPP" build >/dev/null 2>&1 || { echo "FAIL: dist build"; exit 1; }
+
+case "$HOST" in
+  macos)
+    BIN=$(find target -path "*/bin/dist" -type f | head -1)
+    [[ -n "$BIN" ]] || { echo "FAIL: no binary"; exit 1; }
+    deps=$(otool -L "$BIN" | tail -n +2 | awk '{print $1}')
+    # A self-contained macOS artifact links libSystem and nothing else from
+    # /usr/lib — in particular NOT /usr/lib/libc++.1.dylib, which is what
+    # would pin it to the build machine's OS version.
+    if echo "$deps" | grep -q "libc++"; then
+        echo "FAIL: self-contained artifact still depends on a libc++ dylib:"
+        echo "$deps"; exit 1
+    fi
+    ;;
+  linux)
+    BIN=$(find target -path "*/bin/dist" -type f | head -1)
+    [[ -n "$BIN" ]] || { echo "FAIL: no binary"; exit 1; }
+    if command -v readelf >/dev/null 2>&1; then
+        needed=$(readelf -d "$BIN" 2>/dev/null | grep NEEDED || true)
+        # libstdc++/libc++ must not be there; libc/libm/loader may be.
+        if echo "$needed" | grep -Eq "libstdc\+\+|libc\+\+"; then
+            echo "FAIL: self-contained artifact still depends on a C++ runtime:"
+            echo "$needed"; exit 1
+        fi
+    else
+        echo "  (readelf unavailable — dependency-set assertion skipped)"
+    fi
+    ;;
+  windows)
+    # PE has no rpath and no ldd; the equivalent check is that the exe runs
+    # with the toolchain off PATH. e2e 182 already owns that assertion for
+    # the MinGW leg, so this one stays on the flag contract.
+    echo "  (windows: dependency-set assertion covered by e2e 182)"
+    ;;
+esac
+
+echo "PASS: cxx runtime contract"

--- a/tests/unit/test_distribution.cpp
+++ b/tests/unit/test_distribution.cpp
@@ -22,6 +22,7 @@ dist::MechanismInput macos_input() {
     in.macosFloor       = true;
     in.libcxxArchive    = "/tc/lib/libc++.a";
     in.libcxxAbiArchive = "/tc/lib/libc++abi.a";
+    in.streamInitSymbolPresent = true;
     return in;
 }
 
@@ -271,6 +272,7 @@ TEST(Distribution, TableIsTotalAndEveryDowngradeExplainsItself) {
             in.libcxxArchive    = "/a.a";
             in.libcxxAbiArchive = "/b.a";
             in.libunwindArchive = "/c.a";
+            in.streamInitSymbolPresent = true;
         }
         auto m = dist::resolve(in);
         auto where = std::format("contract={} format={} stdlib={} role={} archives={}",
@@ -298,16 +300,35 @@ TEST(Distribution, TableIsTotalAndEveryDowngradeExplainsItself) {
 // differently). See issue #336 for the disassembly this rests on.
 TEST(Distribution, StreamInitShimKeepsItsThreeLoadBearingProperties) {
     auto src = std::string(dist::stream_init_shim_source());
-    // 1. weak — a toolchain without this ABI symbol must still link.
-    EXPECT_NE(src.find("__attribute__((weak))"), std::string::npos);
+    // 1. weak_import — Mach-O's weak-UNDEFINED form. Plain `weak` is not it;
+    //    the first CI round proved that by failing every macOS link.
+    EXPECT_NE(src.find("__attribute__((weak_import))"), std::string::npos);
     // 2. ios_base::Init::Init, NOT DoIOSInit::DoIOSInit — the former is
     //    guarded by __cxa_guard, so libc++'s own initializer later becomes a
     //    no-op instead of placement-new'ing over live streams.
-    EXPECT_NE(src.find("_ZNSt3__18ios_base4InitC1Ev"), std::string::npos);
+    //    ...spelled with TWO leading underscores: an __asm__ label is used
+    //    verbatim, so Mach-O's global `_` prefix has to be written out.
+    EXPECT_NE(src.find("\"__ZNSt3__18ios_base4InitC1Ev\""), std::string::npos);
     EXPECT_EQ(src.find("DoIOSInit"), std::string::npos);
     // 3. a constructor, and it must be guarded by the weak null check.
     EXPECT_NE(src.find("__attribute__((constructor))"), std::string::npos);
     EXPECT_NE(src.find("if (mcpp_libcxx_ios_init)"), std::string::npos);
     // C, not C++: no standard library, no module flags, no ABI of its own.
     EXPECT_EQ(src.find("#include"), std::string::npos);
+}
+
+// The shim binds a libc++ INTERNAL symbol. If that symbol is not in the
+// archive, mcpp must NOT generate the reference — an undefined symbol fails
+// the link outright (ld64.lld does not treat a weak declaration as an
+// optional undefined). The absence is reported instead, because the startup
+// hazard is still there.
+TEST(Distribution, ShimIsNotGeneratedWhenTheSymbolIsAbsent) {
+    auto in = macos_input();
+    in.streamInitSymbolPresent = false;
+    auto m = dist::resolve(in);
+    EXPECT_FALSE(m.streamInitShim);
+    EXPECT_FALSE(m.diagnostic.empty());
+    // The contract itself is still honored — only the ordering aid is gone.
+    EXPECT_EQ(m.effective, dist::Contract::SelfContained);
+    EXPECT_NE(m.unitFlags.find("-load_hidden"), std::string::npos);
 }

--- a/tests/unit/test_distribution.cpp
+++ b/tests/unit/test_distribution.cpp
@@ -1,0 +1,300 @@
+// The C++ runtime distribution contract table (issue #336).
+//
+// These tests exist because the thing they cover used to be five independent
+// derivations of one decision, and the bug was that a new rule landed in some
+// of them and not the others. So the assertions are deliberately about the
+// TABLE's totality and about each cell's identity — not about "the flags look
+// roughly right".
+
+#include <gtest/gtest.h>
+
+import std;
+import mcpp.build.distribution;
+
+namespace dist = mcpp::build::dist;
+
+namespace {
+
+dist::MechanismInput macos_input() {
+    dist::MechanismInput in;
+    in.format           = dist::Format::MachO;
+    in.stdlibId         = "libc++";
+    in.macosFloor       = true;
+    in.libcxxArchive    = "/tc/lib/libc++.a";
+    in.libcxxAbiArchive = "/tc/lib/libc++abi.a";
+    return in;
+}
+
+dist::MechanismInput linux_gcc_input() {
+    dist::MechanismInput in;
+    in.format   = dist::Format::Elf;
+    in.stdlibId = "libstdc++";
+    return in;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// The regression this whole change exists for: `static_stdlib = false` (now
+// `cxx_runtime = "host-coupled"`) was silently ignored for test binaries from
+// 0.0.86 on, while the docs kept promising the opt-out. The table cannot
+// reproduce that bug because the role is an INPUT to one function rather than
+// a switch that picks between two independently-computed strings.
+TEST(Distribution, HostCoupledReachesTestBinariesOnMacos) {
+    auto in = macos_input();
+    in.requested = dist::Contract::HostCoupled;
+
+    for (auto role : {dist::Role::Distributable, dist::Role::Test}) {
+        in.role = role;
+        auto m = dist::resolve(in);
+        EXPECT_EQ(m.effective, dist::Contract::HostCoupled) << dist::to_string(role);
+        EXPECT_EQ(m.unitFlags, " -lc++")                    << dist::to_string(role);
+        EXPECT_FALSE(m.degraded)                            << dist::to_string(role);
+        // No static libc++ means no Mach-O initializer-ordering problem.
+        EXPECT_FALSE(m.streamInitShim)                      << dist::to_string(role);
+    }
+}
+
+// The other half of #336: by default a test binary keeps the SAME
+// self-contained runtime as a shipped one. Flipping this default would
+// re-open #202 (system libc++ dylib against toolchain libc++ headers →
+// undefined __hash_memory on libc++ 22), so it is asserted, not assumed.
+TEST(Distribution, TestsDefaultToSelfContained) {
+    EXPECT_EQ(dist::default_contract(dist::Role::Test),
+              dist::Contract::SelfContained);
+    EXPECT_EQ(dist::default_contract(dist::Role::Distributable),
+              dist::Contract::SelfContained);
+
+    auto in = macos_input();
+    in.role = dist::Role::Test;
+    in.requested = dist::default_contract(dist::Role::Test);
+    auto m = dist::resolve(in);
+    EXPECT_NE(m.unitFlags.find("-load_hidden"), std::string::npos);
+    EXPECT_TRUE(m.streamInitShim);
+}
+
+// -load_hidden, not a plain by-path link: the visibility is the load-bearing
+// half (PR #117 — default-visibility statics get unified with the system
+// libc++ from dyld's shared cache and ostream<<int crosses copies).
+TEST(Distribution, MacosSelfContainedUsesHiddenArchives) {
+    auto in = macos_input();
+    auto m  = dist::resolve(in);
+    EXPECT_EQ(m.unitFlags,
+              " -nostdlib++ -Wl,-load_hidden,/tc/lib/libc++.a"
+              " -Wl,-load_hidden,/tc/lib/libc++abi.a");
+    EXPECT_FALSE(m.degraded);
+    EXPECT_TRUE(m.diagnostic.empty());
+}
+
+// An archive is linked, never run: it embeds no runtime and imposes none.
+TEST(Distribution, IntermediateCarriesNoContractFlags) {
+    for (auto in : {macos_input(), linux_gcc_input()}) {
+        in.role = dist::Role::Intermediate;
+        in.requested = dist::Contract::SelfContained;
+        EXPECT_TRUE(dist::resolve(in).unitFlags.empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// INV-4: a contract that cannot be honored is REPORTED. The pre-#336 code
+// degraded silently in exactly these spots — a toolchain with no libc++.a fell
+// back to `-lc++` and said nothing, so an artifact documented as portable to
+// macOS 14 was quietly pinned to the build machine.
+TEST(Distribution, MissingArchivesDegradeLoudly) {
+    auto in = macos_input();
+    in.libcxxArchive.clear();
+    in.libcxxAbiArchive.clear();
+    auto m = dist::resolve(in);
+    EXPECT_EQ(m.effective, dist::Contract::HostCoupled);
+    EXPECT_TRUE(m.degraded);
+    EXPECT_FALSE(m.diagnostic.empty());
+    EXPECT_EQ(m.unitFlags, " -lc++");
+}
+
+TEST(Distribution, MissingMacosFloorDegradesLoudly) {
+    auto in = macos_input();
+    in.macosFloor = false;
+    auto m = dist::resolve(in);
+    EXPECT_EQ(m.effective, dist::Contract::HostCoupled);
+    EXPECT_TRUE(m.degraded);
+    EXPECT_FALSE(m.diagnostic.empty());
+}
+
+// macOS has no toolchain-coupled form: LLVM's libc++abi/libunwind dylibs
+// upward-link /usr/lib/libc++, so asking for one loads a SECOND libc++ into
+// the process (#202 forensics). Refused with an explanation rather than
+// half-honored.
+TEST(Distribution, MacosToolchainCoupledIsRefusedNotFaked) {
+    auto in = macos_input();
+    in.requested = dist::Contract::ToolchainCoupled;
+    auto m = dist::resolve(in);
+    EXPECT_EQ(m.effective, dist::Contract::SelfContained);
+    EXPECT_TRUE(m.degraded);
+    EXPECT_NE(m.diagnostic.find("toolchain-coupled"), std::string::npos);
+}
+
+// The silent no-op this model was built to make impossible: on a Linux/libc++
+// toolchain, `static_stdlib = true` produced NO flag, NO warning and a
+// toolchain-coupled binary — while the manifest, the docs and `--version` all
+// said the artifact was self-contained.
+TEST(Distribution, LinuxLibcxxSelfContainedIsRealOrLoud) {
+    dist::MechanismInput in;
+    in.format    = dist::Format::Elf;
+    in.stdlibId  = "libc++";
+    in.requested = dist::Contract::SelfContained;
+
+    // No archives on this toolchain → say so, and name what you got instead.
+    auto bare = dist::resolve(in);
+    EXPECT_EQ(bare.effective, dist::Contract::ToolchainCoupled);
+    EXPECT_TRUE(bare.degraded);
+    EXPECT_FALSE(bare.diagnostic.empty());
+
+    // Archives present → a real self-contained link. libunwind.a is part of
+    // the mechanism, not a bonus: without it the binary still pulls
+    // libunwind.so.1 and is not self-contained (verified against a real
+    // llvm@22.1.8 payload).
+    in.libcxxArchive     = "/tc/libc++.a";
+    in.libcxxAbiArchive  = "/tc/libc++abi.a";
+    in.libunwindArchive  = "/tc/libunwind.a";
+    auto full = dist::resolve(in);
+    EXPECT_EQ(full.effective, dist::Contract::SelfContained);
+    EXPECT_FALSE(full.degraded);
+    EXPECT_EQ(full.unitFlags,
+              " -nostdlib++ /tc/libc++.a /tc/libc++abi.a /tc/libunwind.a");
+    // Mach-O only — ELF sorts .init_array by priority, so the ordering bug
+    // does not exist here (confirmed by running the repro on Linux).
+    EXPECT_FALSE(full.streamInitShim);
+
+    in.libunwindArchive.clear();
+    auto noUnwind = dist::resolve(in);
+    EXPECT_TRUE(noUnwind.degraded);
+    EXPECT_NE(noUnwind.diagnostic.find("libunwind"), std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// Byte-level parity with the pre-#336 emission on the platforms that were
+// already correct. These strings are the whole reason the change is safe to
+// ship: the Linux/Windows link is the same link, only assembled in one place.
+TEST(Distribution, LinuxGccParity) {
+    auto in = linux_gcc_input();
+    EXPECT_EQ(dist::resolve(in).unitFlags, " -static-libstdc++");
+
+    in.requested = dist::Contract::HostCoupled;
+    EXPECT_EQ(dist::resolve(in).unitFlags, "");
+    EXPECT_FALSE(dist::resolve(in).degraded);
+
+    // ELF has no distinct emission for toolchain-coupled; the difference is
+    // the rpath the link already carries, which this contract does not own.
+    in.requested = dist::Contract::ToolchainCoupled;
+    EXPECT_EQ(dist::resolve(in).unitFlags, "");
+    EXPECT_FALSE(dist::resolve(in).degraded);
+}
+
+TEST(Distribution, MingwParity) {
+    dist::MechanismInput in;
+    in.format   = dist::Format::Pe;
+    in.stdlibId = "libstdc++";
+    in.mingw    = true;
+
+    // Whole-link -static is what "self-contained" means on MinGW: the
+    // piecemeal -static-libstdc++ recipe still leaves libwinpthread-1.dll.
+    EXPECT_EQ(dist::resolve(in).unitFlags, " -static -static-libstdc++");
+
+    in.hostIsWindows = true;
+    EXPECT_EQ(dist::resolve(in).unitFlags,
+              " -static -static-libstdc++ -static-libgcc");
+
+    // The libc axis is independent: `linkage = "static"` keeps -static even
+    // when the C++ runtime is host-coupled.
+    in.hostIsWindows   = false;
+    in.requested       = dist::Contract::HostCoupled;
+    in.fullStaticLibc  = true;
+    EXPECT_EQ(dist::resolve(in).unitFlags, " -static");
+}
+
+// MSVC's self-contained form would be the /MT runtime, which mcpp does not
+// emit. Before the table this cell simply produced nothing and claimed
+// success; now it names the gap.
+TEST(Distribution, MsvcSelfContainedIsAnHonestGap) {
+    dist::MechanismInput in;
+    in.format   = dist::Format::Pe;
+    in.stdlibId = "msvc";
+    auto m = dist::resolve(in);
+    EXPECT_EQ(m.effective, dist::Contract::HostCoupled);
+    EXPECT_TRUE(m.degraded);
+    EXPECT_NE(m.diagnostic.find("/MT"), std::string::npos);
+    EXPECT_TRUE(m.unitFlags.empty());
+
+    in.requested = dist::Contract::HostCoupled;
+    EXPECT_FALSE(dist::resolve(in).degraded);
+}
+
+// ---------------------------------------------------------------------------
+// INV-1, stated as a property rather than a list: the table is TOTAL, and
+// every cell that does not deliver what was asked explains itself. A future
+// stdlib/format/contract combination that forgets one or the other fails here.
+TEST(Distribution, TableIsTotalAndEveryDowngradeExplainsItself) {
+    const dist::Contract contracts[] = {dist::Contract::SelfContained,
+                                        dist::Contract::ToolchainCoupled,
+                                        dist::Contract::HostCoupled};
+    const dist::Format formats[] = {dist::Format::Elf, dist::Format::MachO,
+                                    dist::Format::Pe};
+    const std::string_view stdlibs[] = {"libstdc++", "libc++", "msvc", "surprise"};
+    const dist::Role roles[] = {dist::Role::Distributable, dist::Role::Test,
+                                dist::Role::Intermediate};
+
+    for (auto c : contracts)
+    for (auto fmt : formats)
+    for (auto sl : stdlibs)
+    for (auto role : roles)
+    for (bool archives : {false, true}) {
+        dist::MechanismInput in;
+        in.requested = c;
+        in.format    = fmt;
+        in.stdlibId  = sl;
+        in.role      = role;
+        in.macosFloor = true;
+        if (archives) {
+            in.libcxxArchive    = "/a.a";
+            in.libcxxAbiArchive = "/b.a";
+            in.libunwindArchive = "/c.a";
+        }
+        auto m = dist::resolve(in);
+        auto where = std::format("contract={} format={} stdlib={} role={} archives={}",
+                                 dist::to_string(c), static_cast<int>(fmt), sl,
+                                 dist::to_string(role), archives);
+        // Totality: every cell answers with a contract it actually delivered.
+        EXPECT_TRUE(m.effective == dist::Contract::SelfContained
+                    || m.effective == dist::Contract::ToolchainCoupled
+                    || m.effective == dist::Contract::HostCoupled) << where;
+        // Honesty: a downgrade is never silent.
+        if (m.degraded) EXPECT_FALSE(m.diagnostic.empty()) << where;
+        if (m.effective != c && role != dist::Role::Intermediate)
+            EXPECT_TRUE(m.degraded) << where;
+        // The ordering shim is a Mach-O static-libc++ concern and nothing else.
+        if (m.streamInitShim) {
+            EXPECT_EQ(fmt, dist::Format::MachO) << where;
+            EXPECT_EQ(m.effective, dist::Contract::SelfContained) << where;
+        }
+    }
+}
+
+// The generated shim is load-bearing in three specific ways; a well-meaning
+// edit that drops any of them turns it into a silent no-op (or worse, an
+// unconditional link failure on a toolchain that spells the symbol
+// differently). See issue #336 for the disassembly this rests on.
+TEST(Distribution, StreamInitShimKeepsItsThreeLoadBearingProperties) {
+    auto src = std::string(dist::stream_init_shim_source());
+    // 1. weak — a toolchain without this ABI symbol must still link.
+    EXPECT_NE(src.find("__attribute__((weak))"), std::string::npos);
+    // 2. ios_base::Init::Init, NOT DoIOSInit::DoIOSInit — the former is
+    //    guarded by __cxa_guard, so libc++'s own initializer later becomes a
+    //    no-op instead of placement-new'ing over live streams.
+    EXPECT_NE(src.find("_ZNSt3__18ios_base4InitC1Ev"), std::string::npos);
+    EXPECT_EQ(src.find("DoIOSInit"), std::string::npos);
+    // 3. a constructor, and it must be guarded by the weak null check.
+    EXPECT_NE(src.find("__attribute__((constructor))"), std::string::npos);
+    EXPECT_NE(src.find("if (mcpp_libcxx_ios_init)"), std::string::npos);
+    // C, not C++: no standard library, no module flags, no ABI of its own.
+    EXPECT_EQ(src.find("#include"), std::string::npos);
+}

--- a/tests/unit/test_distribution.cpp
+++ b/tests/unit/test_distribution.cpp
@@ -217,8 +217,9 @@ TEST(Distribution, MingwParity) {
 // success; now it names the gap.
 TEST(Distribution, MsvcSelfContainedIsAnHonestGap) {
     dist::MechanismInput in;
-    in.format   = dist::Format::Pe;
-    in.stdlibId = "msvc";
+    in.format          = dist::Format::Pe;
+    in.stdlibId        = "msvc";
+    in.explicitRequest = true;
     auto m = dist::resolve(in);
     EXPECT_EQ(m.effective, dist::Contract::HostCoupled);
     EXPECT_TRUE(m.degraded);
@@ -227,6 +228,16 @@ TEST(Distribution, MsvcSelfContainedIsAnHonestGap) {
 
     in.requested = dist::Contract::HostCoupled;
     EXPECT_FALSE(dist::resolve(in).degraded);
+
+    // ...but the DEFAULT must be quiet. mcpp never promised a self-contained
+    // MSVC artifact — it emits no /MT at all — so warning on every Windows
+    // build would be unactionable noise. A diagnostic is for a broken
+    // promise, not for a platform limit nobody asked about.
+    in.requested       = dist::Contract::SelfContained;
+    in.explicitRequest = false;
+    auto quiet = dist::resolve(in);
+    EXPECT_FALSE(quiet.degraded);
+    EXPECT_TRUE(quiet.diagnostic.empty());
 }
 
 // ---------------------------------------------------------------------------
@@ -249,11 +260,13 @@ TEST(Distribution, TableIsTotalAndEveryDowngradeExplainsItself) {
     for (auto role : roles)
     for (bool archives : {false, true}) {
         dist::MechanismInput in;
-        in.requested = c;
-        in.format    = fmt;
-        in.stdlibId  = sl;
-        in.role      = role;
-        in.macosFloor = true;
+        in.requested       = c;
+        in.format          = fmt;
+        in.stdlibId        = sl;
+        in.role            = role;
+        in.macosFloor      = true;
+        in.explicitRequest = true;   // the question is "what if you ASK for it"
+
         if (archives) {
             in.libcxxArchive    = "/a.a";
             in.libcxxAbiArchive = "/b.a";


### PR DESCRIPTION
Closes #336. Unblocks mcpplibs/mcpp-index#142.

## What was wrong

`[build] static_stdlib = false` has been silently ignored for **test binaries** since 0.0.86, while `docs/05-mcpp-toml.md` kept documenting the opt-out. `flags.cppm`'s `ldStdlibDefault` gated on `staticStdlib`; the `ldStdlibTest` block right below it did not.

That is a symptom. "Does this artifact carry its own C++ runtime" was derived independently in **five** places — `ldStdlibDefault`, `ldStdlibTest`, the `-static-libstdc++` string, the MinGW `-static` branch, and the `LinkUnit::TestBinary` two-way switch in the ninja emitter. #202's new semantics landed in some and not the others. Same shape as #239/#240 and #242.

Chasing it surfaced three more, all verified:

- **A silent no-op.** On Linux + clang/libc++, `static_stdlib = true` emitted **no flag at all** (`flags.cppm:520` required `stdlib_id == "libstdc++"`, and `needs_explicit_libcxx` is macOS-only). The artifact was toolchain-coupled while the manifest, the docs and the build output all called it self-contained — which is why the llvm22-slim `libatomic` incident could happen at all.
- **A crash in the default configuration.** On macOS, any global object whose constructor touches `std::cout` SIGSEGVs at process start. Mach-O runs `__init_offsets` in **link order** and has no priority-ordered init section, so the stream initializer pulled out of `libc++.a` lands last. libc++'s `<iostream>` carries no `ios_base::Init` guard of its own — libstdc++ (`iostream:82`) and the MSVC STL do, which is exactly why only macOS breaks. Not test-only: `mcpp build && mcpp run` crashes too.
- **No package-side fix exists.** `std::ios_base::Init` is only *forward-declared* in libc++'s headers (`ios:70`, no definition anywhere in the tree), so the standard's own remedy for static-initialization order is unavailable to users on libc++.

## What this does

`src/build/distribution.cppm` — three layers, and only the third knows about flags:

| layer | what it is |
|---|---|
| **Role** | intrinsic to the link unit. Tests run here and are discarded; archives embed no runtime at all; everything else leaves this machine. |
| **Contract** | what the artifact promises about the machine that runs it. Defaulted per role, overridable. |
| **Mechanism** | `(contract × stdlib × binary format) → flags`, as a **total function**. |

Totality is the property that carries the fix. Every cell answers, and a cell that cannot honor what was asked returns `degraded` plus a diagnostic the backend **must** print. The property test walks all 216 combinations and asserts exactly that — it already caught one hole I had left (PE + `toolchain-coupled` degraded without saying so).

### Fixes

- `cxx_runtime` / `static_stdlib = false` now reaches test binaries.
- **macOS init ordering**: when the contract is self-contained, mcpp generates a tiny C TU and puts its object **first** on the link line; its constructor calls `ios_base::Init::Init()`. That is the guarded entry point (a function-local static that calls `DoIOSInit::DoIOSInit()`, which is what actually placement-news `cin`/`cout`/`cerr` — confirmed by disassembling `iostream.cpp.o`), so libc++'s own initializer later hits the same `__cxa_guard` and no-ops. The reference is **weak**: a toolchain that spells that ABI symbol differently links exactly as it does today and the shim becomes a no-op, rather than failing the link.
- **Linux + libc++ self-contained is now real**: links `libc++.a` / `libc++abi.a` / `libunwind.a`. Verified locally — `NEEDED` drops to libc/libm/loader. Without `libunwind.a` the binary still pulls `libunwind.so.1`, so it is part of the mechanism, not an extra.

### New surface

```toml
[build]
cxx_runtime = "self-contained"   # | "toolchain-coupled" | "host-coupled"

[build.cxx_runtime]              # or per role
default = "self-contained"
tests   = "host-coupled"

[target.x86_64-linux-gnu]        # or per triple, beside `linkage` — same axis
cxx_runtime = "host-coupled"
```

`static_stdlib` stays a faithful alias (`true`↔self-contained, `false`↔host-coupled); an explicit `cxx_runtime` wins. It lives beside `linkage` rather than in the `cfg()` channel because that channel deliberately carries build **inputs** only (`ConditionalConfig`), and this is not one — the `[target.<pred>.build]` warning text that lumped `static_stdlib` in with `target`/`linkage` is corrected.

## Behavior changes to review

1. **C++ runtime flags moved from global `ldflags` to per-unit `unit_ldflags`.** Required: two roles in one build may hold different contracts, which a global channel cannot express. All of them (`-static-libstdc++`, `-static-libgcc`, MinGW `-static`) are driver-level flags whose position relative to libraries is meaningless, so the link is the same link. Verified on Linux; the Windows/MinGW leg is on CI.
2. **Linux + clang/libc++ artifacts become genuinely static** instead of depending on the toolchain's `libc++.so.1`. This is the documented intent finally taking effect; it is still a change in output.
3. Static libraries no longer get a (never-used) `unit_ldflags` line.

## Verification

- `mcpp build` + 51/51 unit tests, including a new `test_distribution.cpp` (byte-level parity assertions for the Linux/MinGW cells, plus the totality property).
- New `tests/e2e/183_cxx_runtime_contract.sh`: the issue's repro as a binary **and** as a test binary, the opt-out reaching both roles, the old spelling as an alias, parse-time rejection of an invalid value, and — on macOS — that the shim object is literally the first input of the link edge. Step 6 checks the contract against the **artifact** (`otool -L` / `readelf -d`), not against the flags, so a mechanism that stops working cannot keep reporting success.
- Link-related e2e subset green locally: 07, 08, 28, 36, 47, 55, 57, 64, 86, 168 (static/shared/musl-static/LLVM/hermetic).
- The macOS legs are the ones that matter here and only CI can run them.

## Not in this PR

- **INV-2** — contract propagation across link edges as a hard error. Within one build every unit shares one project-level contract, so the in-build form is nearly vacuous; the real hazard is a macOS `.dylib` embedding its own hidden libc++ while the host embeds another (`ninja_backend.cppm:1222` is a two-way switch, so `SharedLibrary` takes the distributable mechanism). Documented in the analysis doc as the next likely failure rather than half-implemented here.
- Stripping the toolchain rpath for `host-coupled` on ELF — a packaging axis of its own; the doc states the limit explicitly.
- `/MT` for the MSVC runtime — the table names the gap instead of pretending.

Full analysis, including the evidence chain and the options that were rejected: `.agents/docs/2026-08-02-issue336-pr142-analysis.md`.