### PR TITLE
ci: run fresh-install workflows only in the upstream repo

### DIFF
--- a/.github/workflows/ci-aarch64-fresh-install.yml
+++ b/.github/workflows/ci-aarch64-fresh-install.yml
@@ -11,6 +11,10 @@ name: ci-aarch64-fresh-install
 # Validates that every published aarch64 asset (xlings, mcpp, musl-gcc) lines
 # up and that mcpp can build & run a real `import std` program natively on
 # aarch64 — no cross, no qemu. Runs on GitHub's native ARM64 runner.
+#
+# The job is gated with `github.repository == 'mcpp-community/mcpp'`: the
+# weekly schedule runs on the repository's DEFAULT branch, so forks with a
+# renamed default branch would otherwise burn their Actions quota on the cron.
 
 on:
   workflow_dispatch:
@@ -38,6 +42,7 @@ concurrency:
 jobs:
   fresh-install:
     name: fresh install + native build (aarch64 / glibc)
+    if: ${{ github.repository == 'mcpp-community/mcpp' }}
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     env:

--- a/.github/workflows/ci-fresh-install.yml
+++ b/.github/workflows/ci-fresh-install.yml
@@ -9,6 +9,13 @@ name: ci-fresh-install
 #
 # This workflow tests released mcpp, not PR code.
 # It runs on release publish, manual trigger, and daily schedule.
+#
+# Every job is gated with `github.repository == 'mcpp-community/mcpp'`: the
+# schedule trigger runs on the repository's DEFAULT branch, so a fork that
+# renamed its default branch would otherwise burn its Actions quota on the
+# daily/weekly cron for no value (fresh-install only tests released mcpp).
+# PRs against upstream are unaffected — they run the self-host suites
+# (ci-linux / ci-macos / ci-windows).
 
 on:
   # NOTE: `release: published` never fires from the release pipeline — the
@@ -69,7 +76,7 @@ jobs:
   # Non-workflow_run triggers (manual, cron, PR) skip the wait.
   wait-index:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository == 'mcpp-community/mcpp' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') }}
     timeout-minutes: 20
     outputs:
       version: ${{ steps.resolve.outputs.version }}
@@ -135,7 +142,7 @@ jobs:
   linux-fresh:
     needs: [wait-index]
     name: Linux fresh install
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository == 'mcpp-community/mcpp' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:
@@ -245,7 +252,7 @@ jobs:
   linux-distro-matrix:
     needs: [wait-index]
     name: Linux distro (${{ matrix.distro }})
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository == 'mcpp-community/mcpp' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') }}
     runs-on: ubuntu-24.04
     container:
       image: ${{ matrix.image }}
@@ -338,7 +345,7 @@ jobs:
   macos-fresh:
     needs: [wait-index]
     name: macOS fresh install
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository == 'mcpp-community/mcpp' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') }}
     # macos-14: the support floor (mcpp ≥0.0.50 / xlings ≥0.4.50 ship
     # minos=14.0 static-libc++ binaries). A fresh install passing here
     # is the continuous proof of the macOS 14 floor — and of host-tool
@@ -416,7 +423,7 @@ jobs:
   windows-fresh:
     needs: [wait-index]
     name: Windows fresh install (${{ matrix.image }})
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository == 'mcpp-community/mcpp' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') }}
     runs-on: ${{ matrix.image }}
     timeout-minutes: 30
     strategy:
@@ -499,7 +506,7 @@ jobs:
   windows-nomsvc-fresh:
     needs: [wait-index]
     name: Windows fresh install (no Visual Studio)
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository == 'mcpp-community/mcpp' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') }}
     runs-on: windows-2025
     timeout-minutes: 30
     env:


### PR DESCRIPTION
## Summary
Gate every job in `ci-fresh-install.yml` and `ci-aarch64-fresh-install.yml` with `github.repository == 'mcpp-community/mcpp'`, so the scheduled runs never execute in forks.

## Why
Both workflows have `schedule` triggers:
- `ci-fresh-install.yml`: daily cron (`0 6 * * *`)
- `ci-aarch64-fresh-install.yml`: weekly Monday cron (`0 6 * * 1`)

GitHub runs `schedule`-triggered workflows on the repository's **default branch** and is not affected by the `branches: [main]` filters used by the push/pull_request triggers. A fork that renames its default branch (e.g. `main` → `fork-main` to stop push CI) still gets the cron executing on the renamed branch — wasting the fork's Actions quota and showing failing runs (fresh-install only tests **released** mcpp, so it provides zero value on a fork). Observed on a fork on 2026-08-03 (both workflows) and 2026-08-04 (daily one), all triggered by `schedule`, with no sync/push involved.

The `workflow_run: [release]` trigger is unaffected: it already fires only in the upstream repo, and the repository guard makes the schedule/manual/release paths no-ops on forks.

## Impact on upstream
Identical behavior: all jobs still run on every upstream trigger (release → `workflow_run`, manual, daily/weekly schedule). PRs against upstream are unaffected — they run the self-host suites (`ci-linux` / `ci-macos` / `ci-windows`), which are untouched.

## Test plan
- [ ] YAML syntax validated (both files parse cleanly)
- [ ] Upstream cron still runs as before
- [ ] Forks no longer execute these workflows on schedule