### PR TITLE
fix(subos): prepend 丢掉了调用方的值

### DIFF
--- a/src/build/execute.cppm
+++ b/src/build/execute.cppm
@@ -361,7 +361,15 @@ compute_subos_env(const mcpp::build::BuildPlan& plan) {
     // diagnostic path in doctor.
     if (!info.note.empty())
         mcpp::log::verbose("subos", info.note);
-    return mcpp::xlings::subos::resolve_env(info, dir);
+    // Resolved AGAINST the caller's environment, not in a vacuum: these
+    // entries replace the variable in the child, so a `set` that ignores an
+    // exported value overwrites it and a `prepend` that ignores it drops it.
+    return mcpp::xlings::subos::resolve_env(
+        info, dir, [](std::string_view v) -> std::optional<std::string> {
+            if (const char* e = std::getenv(std::string(v).c_str()))
+                return std::string(e);
+            return std::nullopt;
+        });
 }
 
 // Compile a prepared BuildContext. Shared between `mcpp build` and `mcpp run`
@@ -877,7 +885,13 @@ std::optional<int> try_fast_run(const std::filesystem::path& projectRoot,
         auto subosDir = subos_dir_for_run(std::filesystem::path(match->subosDir));
         if (!subosDir.empty()) {
             auto info = mcpp::xlings::subos::read(subosDir);
-            for (auto& kv : mcpp::xlings::subos::resolve_env(info, subosDir))
+            for (auto& kv : mcpp::xlings::subos::resolve_env(
+                     info, subosDir,
+                     [](std::string_view v) -> std::optional<std::string> {
+                         if (const char* e = std::getenv(std::string(v).c_str()))
+                             return std::string(e);
+                         return std::nullopt;
+                     }))
                 childEnv.push_back(std::move(kv));
         }
     }

--- a/src/xlings/subos_info.cppm
+++ b/src/xlings/subos_info.cppm
@@ -201,8 +201,20 @@ Info read(const std::filesystem::path& subosDir) {
 // never matches and the joined value is a corrupt list. Caught by CI on
 // Windows, not by any amount of reading.
 std::vector<std::pair<std::string, std::string>>
-resolve_env(const Info& info, const std::filesystem::path& subosDir) {
+resolve_env(const Info& info, const std::filesystem::path& subosDir,
+            const std::function<std::optional<std::string>(std::string_view)>&
+                ambient = {}) {
     std::vector<std::pair<std::string, std::string>> out;
+
+    // What the caller's environment already says about a variable.
+    //
+    // The declarations are merged against this, not in a vacuum, because the
+    // result REPLACES the variable in the child (it goes in as extraEnv). A
+    // resolution that ignores the ambient value silently discards it.
+    auto ambient_of = [&](std::string_view var) -> std::optional<std::string> {
+        if (!ambient) return std::nullopt;
+        return ambient(var);
+    };
 
     const std::string subos = subosDir.string();
     auto expand = [&](std::string v) {
@@ -241,7 +253,37 @@ resolve_env(const Info& info, const std::filesystem::path& subosDir) {
             std::pair<std::string, std::string>* hit = nullptr;
             for (auto& kv : out)
                 if (kv.first == d.var) { hit = &kv; break; }
-            if (!hit) { out.emplace_back(d.var, value); continue; }
+            if (!hit) {
+                auto amb = ambient_of(d.var);
+                if (d.op == "set") {
+                    // A `set` is a DEFAULT, not an order. If the caller
+                    // already exported the variable, that wins.
+                    //
+                    // Recipes document this as the escape hatch -- xlings'
+                    // wsl-gl-host-link says in so many words that a user who
+                    // exports GALLIUM_DRIVER=llvmpipe keeps it. Before this,
+                    // the subos value overwrote it and the hatch did not
+                    // exist: `export GALLIUM_DRIVER=llvmpipe; mcpp run` still
+                    // ran with d3d12 and still failed (mcpp#382). An
+                    // environment a user set deliberately is the one piece of
+                    // input a build environment must not quietly overrule.
+                    if (amb && !amb->empty()) { out.emplace_back(d.var, *amb); continue; }
+                    out.emplace_back(d.var, value);
+                    continue;
+                }
+                // `prepend` against the ambient value, not instead of it.
+                // These entries replace the variable in the child, so
+                // emitting the declared value alone DROPS whatever the caller
+                // had -- for a PATH-shaped variable that is the user's whole
+                // search path.
+                if (amb && !amb->empty() && !contains_element(*amb, value))
+                    out.emplace_back(d.var, value + sep + *amb);
+                else if (amb && !amb->empty())
+                    out.emplace_back(d.var, *amb);
+                else
+                    out.emplace_back(d.var, value);
+                continue;
+            }
             if (d.op == "set") { hit->second = value; continue; }
             if (!contains_element(hit->second, value))
                 hit->second = value + sep + hit->second;

--- a/src/xlings/subos_info.cppm
+++ b/src/xlings/subos_info.cppm
@@ -256,18 +256,26 @@ resolve_env(const Info& info, const std::filesystem::path& subosDir,
             if (!hit) {
                 auto amb = ambient_of(d.var);
                 if (d.op == "set") {
-                    // A `set` is a DEFAULT, not an order. If the caller
-                    // already exported the variable, that wins.
+                    // `set` wins, ambient or not.
                     //
-                    // Recipes document this as the escape hatch -- xlings'
-                    // wsl-gl-host-link says in so many words that a user who
-                    // exports GALLIUM_DRIVER=llvmpipe keeps it. Before this,
-                    // the subos value overwrote it and the hatch did not
-                    // exist: `export GALLIUM_DRIVER=llvmpipe; mcpp run` still
-                    // ran with d3d12 and still failed (mcpp#382). An
-                    // environment a user set deliberately is the one piece of
-                    // input a build environment must not quietly overrule.
-                    if (amb && !amb->empty()) { out.emplace_back(d.var, *amb); continue; }
+                    // Deliberately NOT "yield to an exported value". That
+                    // reading was written here first and withdrawn: `set` and
+                    // "default" are two different intentions, and a subos has
+                    // real need of the first -- a variable naming its own
+                    // loader configuration must not be overridable by a stale
+                    // value in the caller's shell. Collapsing them here would
+                    // remove the ability to express it.
+                    //
+                    // It is also not mcpp's vocabulary to redefine. `envs` is
+                    // xlings' wire format; a consumer that quietly gives an op
+                    // a second meaning makes the same subos behave differently
+                    // depending on which tool launched the program.
+                    //
+                    // The escape hatch mcpp#382 asks for (a recipe declaring a
+                    // DEFAULT the user can override) therefore wants a new op
+                    // from xlings, not a reinterpretation of this one. When it
+                    // exists, it is honoured here -- unknown ops are dropped
+                    // today, which is why it has to arrive on both sides.
                     out.emplace_back(d.var, value);
                     continue;
                 }

--- a/tests/unit/test_subos_info.cpp
+++ b/tests/unit/test_subos_info.cpp
@@ -249,4 +249,86 @@ TEST(SubosInfo, UnknownOpIsDroppedLikeXlingsDrops) {
     EXPECT_EQ(env[0].second, "/yes");
 }
 
+// A `set` is a default; an exported value wins.
+//
+// The resolved pairs REPLACE the variable in the child (they go in as
+// extraEnv), so a `set` that ignores the caller's environment overwrites it
+// silently. Recipes are written on the opposite assumption: xlings'
+// wsl-gl-host-link documents that a user who exports GALLIUM_DRIVER=llvmpipe
+// keeps it, and that escape hatch did not exist -- `export
+// GALLIUM_DRIVER=llvmpipe; mcpp run` still ran with the subos value and still
+// failed (mcpp#382).
+TEST(SubosResolveEnv, SetDoesNotOverrideAnExportedValue) {
+    Tmp t;
+    t.write(R"({"workspace":{},"subos_info":{"schema_version":1,"runtime":"glibc@2.39",
+        "envs":{"glibc@2.39":[{"var":"GALLIUM_DRIVER","op":"set","value":"d3d12"}]}}})");
+    auto info = su::read(t.dir);
+    auto out = su::resolve_env(
+        info, t.dir, [](std::string_view v) -> std::optional<std::string> {
+            if (v == "GALLIUM_DRIVER") return std::string("llvmpipe");
+            return std::nullopt;
+        });
+    ASSERT_EQ(out.size(), 1u);
+    EXPECT_EQ(out[0].first, "GALLIUM_DRIVER");
+    EXPECT_EQ(out[0].second, "llvmpipe") << "the user's export must survive";
+}
+
+TEST(SubosResolveEnv, SetAppliesWhenNothingIsExported) {
+    Tmp t;
+    t.write(R"({"workspace":{},"subos_info":{"schema_version":1,"runtime":"glibc@2.39",
+        "envs":{"glibc@2.39":[{"var":"GALLIUM_DRIVER","op":"set","value":"d3d12"}]}}})");
+    auto info = su::read(t.dir);
+    auto out = su::resolve_env(
+        info, t.dir, [](std::string_view) { return std::optional<std::string>{}; });
+    ASSERT_EQ(out.size(), 1u);
+    EXPECT_EQ(out[0].second, "d3d12");
+}
+
+// An empty export is not an export.
+TEST(SubosResolveEnv, EmptyAmbientDoesNotBlockASet) {
+    Tmp t;
+    t.write(R"({"workspace":{},"subos_info":{"schema_version":1,"runtime":"glibc@2.39",
+        "envs":{"glibc@2.39":[{"var":"X","op":"set","value":"v"}]}}})");
+    auto info = su::read(t.dir);
+    auto out = su::resolve_env(
+        info, t.dir, [](std::string_view) { return std::optional<std::string>(""); });
+    ASSERT_EQ(out.size(), 1u);
+    EXPECT_EQ(out[0].second, "v");
+}
+
+// `prepend` prepends TO the caller's value rather than replacing it. Same
+// reason: the pair replaces the variable, so emitting the declared value alone
+// discards whatever search path the user had.
+TEST(SubosResolveEnv, PrependKeepsTheExportedValue) {
+    Tmp t;
+    t.write(R"({"workspace":{},"subos_info":{"schema_version":1,"runtime":"glibc@2.39",
+        "envs":{"glibc@2.39":[{"var":"LD_LIBRARY_PATH","op":"prepend","value":"/sub/lib"}]}}})");
+    auto info = su::read(t.dir);
+    auto out = su::resolve_env(
+        info, t.dir, [](std::string_view v) -> std::optional<std::string> {
+            if (v == "LD_LIBRARY_PATH") return std::string("/user/lib");
+            return std::nullopt;
+        });
+    ASSERT_EQ(out.size(), 1u);
+    const auto sep = mcpp::platform::env::path_list_separator();
+    EXPECT_EQ(out[0].second, std::string("/sub/lib") + sep + "/user/lib");
+}
+
+// Already there: prepending again would grow the list on every nested run.
+TEST(SubosResolveEnv, PrependIsIdempotentAgainstTheExportedValue) {
+    Tmp t;
+    t.write(R"({"workspace":{},"subos_info":{"schema_version":1,"runtime":"glibc@2.39",
+        "envs":{"glibc@2.39":[{"var":"LD_LIBRARY_PATH","op":"prepend","value":"/sub/lib"}]}}})");
+    auto info = su::read(t.dir);
+    const auto sep = mcpp::platform::env::path_list_separator();
+    const auto existing = std::string("/sub/lib") + sep + "/user/lib";
+    auto out = su::resolve_env(
+        info, t.dir, [&](std::string_view v) -> std::optional<std::string> {
+            if (v == "LD_LIBRARY_PATH") return existing;
+            return std::nullopt;
+        });
+    ASSERT_EQ(out.size(), 1u);
+    EXPECT_EQ(out[0].second, existing);
+}
+
 }  // namespace

--- a/tests/unit/test_subos_info.cpp
+++ b/tests/unit/test_subos_info.cpp
@@ -249,52 +249,8 @@ TEST(SubosInfo, UnknownOpIsDroppedLikeXlingsDrops) {
     EXPECT_EQ(env[0].second, "/yes");
 }
 
-// A `set` is a default; an exported value wins.
-//
-// The resolved pairs REPLACE the variable in the child (they go in as
-// extraEnv), so a `set` that ignores the caller's environment overwrites it
-// silently. Recipes are written on the opposite assumption: xlings'
-// wsl-gl-host-link documents that a user who exports GALLIUM_DRIVER=llvmpipe
-// keeps it, and that escape hatch did not exist -- `export
-// GALLIUM_DRIVER=llvmpipe; mcpp run` still ran with the subos value and still
-// failed (mcpp#382).
-TEST(SubosResolveEnv, SetDoesNotOverrideAnExportedValue) {
-    Tmp t;
-    t.write(R"({"workspace":{},"subos_info":{"schema_version":1,"runtime":"glibc@2.39",
-        "envs":{"glibc@2.39":[{"var":"GALLIUM_DRIVER","op":"set","value":"d3d12"}]}}})");
-    auto info = su::read(t.dir);
-    auto out = su::resolve_env(
-        info, t.dir, [](std::string_view v) -> std::optional<std::string> {
-            if (v == "GALLIUM_DRIVER") return std::string("llvmpipe");
-            return std::nullopt;
-        });
-    ASSERT_EQ(out.size(), 1u);
-    EXPECT_EQ(out[0].first, "GALLIUM_DRIVER");
-    EXPECT_EQ(out[0].second, "llvmpipe") << "the user's export must survive";
-}
 
-TEST(SubosResolveEnv, SetAppliesWhenNothingIsExported) {
-    Tmp t;
-    t.write(R"({"workspace":{},"subos_info":{"schema_version":1,"runtime":"glibc@2.39",
-        "envs":{"glibc@2.39":[{"var":"GALLIUM_DRIVER","op":"set","value":"d3d12"}]}}})");
-    auto info = su::read(t.dir);
-    auto out = su::resolve_env(
-        info, t.dir, [](std::string_view) { return std::optional<std::string>{}; });
-    ASSERT_EQ(out.size(), 1u);
-    EXPECT_EQ(out[0].second, "d3d12");
-}
 
-// An empty export is not an export.
-TEST(SubosResolveEnv, EmptyAmbientDoesNotBlockASet) {
-    Tmp t;
-    t.write(R"({"workspace":{},"subos_info":{"schema_version":1,"runtime":"glibc@2.39",
-        "envs":{"glibc@2.39":[{"var":"X","op":"set","value":"v"}]}}})");
-    auto info = su::read(t.dir);
-    auto out = su::resolve_env(
-        info, t.dir, [](std::string_view) { return std::optional<std::string>(""); });
-    ASSERT_EQ(out.size(), 1u);
-    EXPECT_EQ(out[0].second, "v");
-}
 
 // `prepend` prepends TO the caller's value rather than replacing it. Same
 // reason: the pair replaces the variable, so emitting the declared value alone
@@ -329,6 +285,29 @@ TEST(SubosResolveEnv, PrependIsIdempotentAgainstTheExportedValue) {
         });
     ASSERT_EQ(out.size(), 1u);
     EXPECT_EQ(out[0].second, existing);
+}
+
+// `set` wins over an exported value, and that is deliberate.
+//
+// This assertion exists to stop the opposite reading from being reintroduced
+// -- it was, once, as a fix for mcpp#382, and withdrawn: `set` and "a default
+// the user may override" are two intentions, and a subos needs the first for
+// variables naming its own configuration. The escape hatch that issue wants is
+// a NEW op from xlings, whose wire format this is, not a second meaning for
+// this one applied by one consumer.
+TEST(SubosResolveEnv, SetWinsOverAnExportedValue) {
+    Tmp t;
+    t.write(R"({"workspace":{},"subos_info":{"schema_version":1,
+        "runtime":"glibc@2.39",
+        "envs":{"glibc@2.39":[{"var":"GALLIUM_DRIVER","op":"set","value":"d3d12"}]}}})");
+    auto info = su::read(t.dir);
+    auto out = su::resolve_env(
+        info, t.dir, [](std::string_view v) -> std::optional<std::string> {
+            if (v == "GALLIUM_DRIVER") return std::string("llvmpipe");
+            return std::nullopt;
+        });
+    ASSERT_EQ(out.size(), 1u);
+    EXPECT_EQ(out[0].second, "d3d12");
 }
 
 }  // namespace


### PR DESCRIPTION
**修订:只保留 `prepend` 那一半。`set` 的部分已撤回。**

原提案把 `set` 改成「用户已 export 就让位」。撤回,因为它错在两个层面:

1. **`set` 与「默认值」是两种真实不同的意图。** 有些变量 subos 必须说了算 —— 指向它自己 loader 配置的那类,用户 shell 里一个陈旧值就能把环境弄坏。把两者塌成一个,等于从此无法表达前者。
2. **op 词汇表是 xlings 的契约,mcpp 是消费方。** 消费方悄悄给一个 op 加第二种含义,会让同一个 subos 因为「由谁启动」而行为不同 —— 经 `mcpp run` 和经 xlings 自己应用会不一致。

**#382 想要的逃生通道,应当由 xlings 新增一个 op**(「声明默认值,用户可覆盖」),mcpp 认它。现在未知 op 会被丢弃,所以那个 op 必须**两侧同时到位**。本 PR 加了一条断言把「`set` 就是要赢」钉住,免得日后又被「修」回去。

---

## 保留的部分:`prepend` 丢掉了调用方的值

这一条与 xlings 怎么修无关,是 mcpp 自己的实现缺陷。

解析出的键值对**替换**子进程里的变量(作为 extraEnv 进去)。`prepend` 却只发出声明值,把调用方原有内容整个丢掉 —— 对 PATH 形状的变量,丢掉的是用户的整条搜索路径。没人报过。

现在它接在调用方的值前面,且对已存在元素幂等(嵌套运行不会让列表增长)。空值不算「用户设过」。

单测 15 条(prepend 2 条 + `set` 语义 1 条);全量 67/67;e2e 200 通过。
