### PR TITLE
fix(build): 多段 glob 源文件路径在 Windows 上保持原生分隔符 (#390)

### DIFF
--- a/src/build/compile_commands.cppm
+++ b/src/build/compile_commands.cppm
@@ -142,16 +142,28 @@ std::vector<std::string> split_flags(std::string_view s) {
 
 namespace {
 
+// The CDB's path contract: NATIVE separators, unconditionally. Every
+// ingestion point (manifest globs, include_dirs, build.mcpp directives) is
+// normalized at the source, but this is the LAST line — a path that slips
+// through with a mixed `root\a/b` spelling (MSVC keeps input `/` verbatim)
+// breaks CLion, and no amount of "all ingestion points are covered" can be
+// proven. make_preferred() is a no-op on POSIX.
+std::string native_string(const std::filesystem::path& p) {
+    auto n = p;
+    n.make_preferred();
+    return n.string();
+}
+
 std::vector<std::string> local_include_args(const CompileUnit& cu) {
     std::vector<std::string> args;
     args.reserve(cu.localIncludeDirs.size());
     for (auto const& inc : cu.localIncludeDirs) {
-        args.push_back("-I" + inc.string());
+        args.push_back("-I" + native_string(inc));
     }
     // #249: after-dirs keep their -idirafter spelling in the compile DB so
     // tooling (clangd) reproduces the compiler's search order.
     for (auto const& inc : cu.localIncludeDirsAfter) {
-        args.push_back("-idirafter" + inc.string());
+        args.push_back("-idirafter" + native_string(inc));
     }
     return args;
 }
@@ -186,7 +198,7 @@ std::string emit_compile_commands(const BuildPlan& plan, const CompileFlags& fla
                             : isCSource   ? flags.cc
                                           : flags.cxx;
 
-        auto output_path = (plan.outputDir / cu.object).string();
+        auto output_path = native_string(plan.outputDir / cu.object);
 
         // Build arguments array.
         nlohmann::json args = nlohmann::json::array();
@@ -198,13 +210,13 @@ std::string emit_compile_commands(const BuildPlan& plan, const CompileFlags& fla
         for (auto& f : package_flag_args(cu, isCSource))
             args.push_back(std::move(f));
         args.push_back("-c");
-        args.push_back(cu.source.string());
+        args.push_back(native_string(cu.source));
         args.push_back("-o");
         args.push_back(output_path);
 
         nlohmann::json entry;
-        entry["directory"] = plan.projectRoot.string();
-        entry["file"] = cu.source.string();
+        entry["directory"] = native_string(plan.projectRoot);
+        entry["file"] = native_string(cu.source);
         entry["arguments"] = std::move(args);
         entry["output"] = output_path;
 
@@ -222,11 +234,25 @@ std::string merge_compile_commands(
     if (freshJ.is_discarded() || !freshJ.is_array())
         return std::string(fresh);
 
+    // Dedup key = the file's PATH, spelled the way a fresh plan spells it
+    // (native separators). A prior CDB written before the mixed-separator
+    // fix (#390) carries `root\generated/modules\x.cppm` entries that are
+    // the SAME file as the fresh `root\generated\modules\x.cppm` — a literal
+    // string comparison would keep both and the user's upgrade would not
+    // visibly fix anything. Normalizing makes the merge self-healing: the
+    // stale mixed entry is skipped on the first `mcpp build` after upgrade.
+    // fileExists still probes the raw spelling — Windows accepts both.
+    auto norm_key = [](std::string_view f) {
+        auto p = std::filesystem::path(std::string(f)).lexically_normal();
+        p.make_preferred();
+        return p.string();
+    };
+
     // Files the current plan already covers — those entries are authoritative.
     std::set<std::string> freshFiles;
     for (auto const& e : freshJ) {
         if (e.contains("file") && e["file"].is_string())
-            freshFiles.insert(e["file"].get<std::string>());
+            freshFiles.insert(norm_key(e["file"].get<std::string>()));
     }
 
     // Keep fresh order, then append still-valid prior entries the plan doesn't
@@ -238,7 +264,7 @@ std::string merge_compile_commands(
         for (auto const& e : existingJ) {
             if (!e.contains("file") || !e["file"].is_string()) continue;
             auto f = e["file"].get<std::string>();
-            if (freshFiles.contains(f)) continue;             // fresh wins
+            if (freshFiles.contains(norm_key(f))) continue;       // fresh wins
             if (!fileExists(std::filesystem::path(f))) continue;  // pruned
             merged.push_back(e);
         }

--- a/src/build/compile_commands.cppm
+++ b/src/build/compile_commands.cppm
@@ -142,12 +142,18 @@ std::vector<std::string> split_flags(std::string_view s) {
 
 namespace {
 
-// The CDB's path contract: NATIVE separators, unconditionally. Every
-// ingestion point (manifest globs, include_dirs, build.mcpp directives) is
-// normalized at the source, but this is the LAST line — a path that slips
-// through with a mixed `root\a/b` spelling (MSVC keeps input `/` verbatim)
-// breaks CLion, and no amount of "all ingestion points are covered" can be
-// proven. make_preferred() is a no-op on POSIX.
+// NATIVE separators for every path this emitter SPELLS ITSELF. Each ingestion
+// point (manifest globs, include_dirs, build.mcpp directives) is normalized at
+// the source, but this is the last line for the fields the CDB schema defines
+// — a path that slips through with a mixed `root\a/b` spelling (MSVC keeps
+// input `/` verbatim) breaks CLion, and "all ingestion points are covered" is
+// not a claim that can be proven once and stay true.
+//
+// It is NOT a whole-argv guarantee: the flag strings (split_flags(f.cxx), the
+// package cflags/cxxflags) pass through untouched, because normalizing an
+// arbitrary flag payload is unsafe — `-DPATH="/etc/x"` holds real slashes.
+// Those channels are normalized where they are ingested instead.
+// make_preferred() is a no-op on POSIX.
 std::string native_string(const std::filesystem::path& p) {
     auto n = p;
     n.make_preferred();

--- a/src/build/directives.cppm
+++ b/src/build/directives.cppm
@@ -366,7 +366,10 @@ const Def* find_by_tag(std::string_view tag) {
 }
 
 std::string abs_against(const fs::path& base, std::string_view p) {
-    fs::path pp(p);
+    // Native spelling (see mcpp::modgraph::native_path_from_generic): a
+    // directive path like `generated/modules/x` would otherwise stay mixed
+    // on MSVC and leak into include flags / the CDB.
+    fs::path pp = mcpp::modgraph::native_path_from_generic(p);
     if (pp.is_relative()) pp = base / pp;
     return pp.lexically_normal().string();
 }

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -317,7 +317,13 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     // once ninja hands the resolved command line to the shell.
     std::vector<std::string> includeTokens;
     for (auto& inc : plan.manifest.buildConfig.includeDirs) {
-        std::filesystem::path p = inc.has_root_path() ? inc : (plan.projectRoot / inc);
+        // make_preferred: a multi-segment TOML entry like `generated/inc`
+        // keeps its `/` on MSVC, and the bare `projectRoot / inc` join would
+        // be MIXED — reaching both the ninja command line and the CDB's
+        // arguments (via f.cxx → split_flags). Same rule as every other
+        // manifest-path ingestion point (#390); no-op on POSIX.
+        auto p = inc.has_root_path() ? inc : (plan.projectRoot / inc);
+        p.make_preferred();
         includeTokens.push_back(include_token(d, p));
     }
     // #249: `[build] include_dirs_after` — searched AFTER the toolchain's
@@ -327,8 +333,8 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     // (documented degradation; clang-MSVC uses the gnu dialect).
     const bool msvcInclude = d.includePrefix == std::string_view("/I");
     for (auto& inc : plan.manifest.buildConfig.includeDirsAfter) {
-        std::filesystem::path ip(inc);
-        std::filesystem::path p = ip.has_root_path() ? ip : (plan.projectRoot / ip);
+        auto p = inc.has_root_path() ? inc : (plan.projectRoot / inc);
+        p.make_preferred();
         includeTokens.push_back(
             include_token(d, p, msvcInclude ? "/I" : "-idirafter"));
     }

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -315,16 +315,24 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     // ninja-$-escape and shell-quote per token (#234) so an include dir
     // whose name contains a space can't silently split into two shell words
     // once ninja hands the resolved command line to the shell.
-    std::vector<std::string> includeTokens;
-    for (auto& inc : plan.manifest.buildConfig.includeDirs) {
-        // make_preferred: a multi-segment TOML entry like `generated/inc`
-        // keeps its `/` on MSVC, and the bare `projectRoot / inc` join would
-        // be MIXED — reaching both the ninja command line and the CDB's
-        // arguments (via f.cxx → split_flags). Same rule as every other
-        // manifest-path ingestion point (#390); no-op on POSIX.
+    // The one place this file turns a manifest include entry into a path.
+    // make_preferred: a multi-segment TOML entry like `generated/inc` keeps
+    // its `/` on MSVC, and the bare `projectRoot / inc` join would be MIXED —
+    // reaching both the ninja command line and the CDB's arguments (via
+    // f.cxx → split_flags). Same rule as every other manifest-path ingestion
+    // point (#390); no-op on POSIX. ONE lambda because the same join is needed
+    // four times in this function — {include_dirs, include_dirs_after} × {the
+    // C/C++ token list, the NASM one} — and re-deriving it per site is how the
+    // two channels drifted apart in the first place.
+    auto abs_native = [&](const std::filesystem::path& inc) {
         auto p = inc.has_root_path() ? inc : (plan.projectRoot / inc);
         p.make_preferred();
-        includeTokens.push_back(include_token(d, p));
+        return p;
+    };
+
+    std::vector<std::string> includeTokens;
+    for (auto& inc : plan.manifest.buildConfig.includeDirs) {
+        includeTokens.push_back(include_token(d, abs_native(inc)));
     }
     // #249: `[build] include_dirs_after` — searched AFTER the toolchain's
     // system dirs via -idirafter (gcc+clang), so entries can't shadow
@@ -333,10 +341,8 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     // (documented degradation; clang-MSVC uses the gnu dialect).
     const bool msvcInclude = d.includePrefix == std::string_view("/I");
     for (auto& inc : plan.manifest.buildConfig.includeDirsAfter) {
-        auto p = inc.has_root_path() ? inc : (plan.projectRoot / inc);
-        p.make_preferred();
         includeTokens.push_back(
-            include_token(d, p, msvcInclude ? "/I" : "-idirafter"));
+            include_token(d, abs_native(inc), msvcInclude ? "/I" : "-idirafter"));
     }
     std::string include_flags;
     for (auto& t : includeTokens) {
@@ -535,17 +541,22 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     // re-spelt with -I regardless of dialect (nasm ≥2.14 inserts a missing
     // path separator itself); DWARF debug info exists on ELF only.
     if (!plan.nasmPath.empty()) {
+        // Same abs_native join as the C/C++ channel above — one decision, one
+        // implementation. Two knock-on effects, both wanted: the entry is now
+        // spelt with native separators (#390), and the "already rooted?" test
+        // becomes has_root_path() instead of is_absolute(), so a root-relative
+        // `/x` entry is left alone here exactly as it is for the C/C++ include
+        // list. The two predicates only differ on Windows, and only for that
+        // spelling — where NASM disagreeing with the compiler about the SAME
+        // `include_dirs` key was the bug, not the feature.
         std::string nasm_includes;
         for (auto& inc : plan.manifest.buildConfig.includeDirs) {
-            auto abs = inc.is_absolute() ? inc : (plan.projectRoot / inc);
-            nasm_includes += " -I" + escape_path(abs);
+            nasm_includes += " -I" + escape_path(abs_native(inc));
         }
         // #249: nasm has no system header dirs to defer to — after-dirs
         // degrade to plain -I appended at the end.
         for (auto& inc : plan.manifest.buildConfig.includeDirsAfter) {
-            std::filesystem::path ip(inc);
-            auto abs = ip.is_absolute() ? ip : (plan.projectRoot / ip);
-            nasm_includes += " -I" + escape_path(abs);
+            nasm_includes += " -I" + escape_path(abs_native(inc));
         }
         std::string nasm_debug;
         if (prof.debug && plan.nasmFormat.starts_with("elf"))

--- a/src/build/plan.cppm
+++ b/src/build/plan.cppm
@@ -220,6 +220,14 @@ make_plan(const mcpp::manifest::Manifest&         manifest,
          // simply makes those units uncacheable.
          const std::vector<std::filesystem::path>& storeRoots = {});
 
+// Expand one manifest `include_dirs` entry against the project root — the
+// #249 consistency join + the expand_dir_glob the dep path uses. Exported
+// (like modgraph's glob_literal_prefix) so unit tests can assert its
+// native-separator contract directly; see the definition below.
+std::vector<std::filesystem::path>
+expand_manifest_include_entry(const std::filesystem::path& root,
+                              const std::filesystem::path& inc);
+
 } // namespace mcpp::build
 
 namespace mcpp::build {
@@ -368,6 +376,8 @@ std::vector<std::string> shared_library_link_flags(
     return flags;
 }
 
+}  // namespace
+
 // #249 consistency fix: expand include_dirs entries with the same
 // `expand_dir_glob` the dep path (prepare.cppm) uses, so a main-manifest
 // `include_dirs = ["*/include"]` glob works identically here. For a literal
@@ -375,15 +385,33 @@ std::vector<std::string> shared_library_link_flags(
 // whereas this helper historically joined unconditionally — keep the plain
 // join as a fallback so an -I for a dir created later (e.g. by a build
 // step) isn't silently dropped.
+//
+// Deliberately OUTSIDE the anonymous namespace: it is exported for its unit
+// test (like modgraph's glob_literal_prefix), and the two
+// local_include_dirs_*_for_manifest consumers below ride along so a single
+// namespace split serves the whole trio.
 std::vector<std::filesystem::path>
 expand_manifest_include_entry(const std::filesystem::path& root,
                               const std::filesystem::path& inc)
 {
-    if (inc.is_absolute()) return { inc };
+    if (inc.is_absolute()) {
+        // A TOML value like `C:/SDL2/include` keeps its `/` on MSVC — make
+        // it native so the CDB's -I (via local_include_args) is uniform.
+        auto n = inc;
+        n.make_preferred();
+        return { std::move(n) };
+    }
     const auto glob = inc.generic_string();
     auto expanded = mcpp::modgraph::expand_dir_glob(root, glob);
-    if (expanded.empty() && glob.find('*') == std::string::npos)
-        expanded.push_back(root / inc);
+    if (expanded.empty() && glob.find('*') == std::string::npos) {
+        // Same native-spelling rule for the bare join (see above): `root / p`
+        // with a multi-segment `generated/inc` is MIXED on MSVC, and this
+        // fallback exists precisely for dirs like `generated/` that a later
+        // build step creates — the #390 shape.
+        auto joined = root / inc;
+        joined.make_preferred();
+        expanded.push_back(std::move(joined));
+    }
     return expanded;
 }
 
@@ -411,6 +439,8 @@ local_include_dirs_after_for_manifest(const std::filesystem::path& root,
     }
     return dirs;
 }
+
+namespace {
 
 void append_unique_path(std::vector<std::filesystem::path>& out,
                         std::filesystem::path path)

--- a/src/build/prepare.cppm
+++ b/src/build/prepare.cppm
@@ -2997,11 +2997,13 @@ prepare_build(bool print_fingerprint,
         std::vector<std::filesystem::path> dirs;
         for (auto const& inc : manifest.buildConfig.includeDirs) {
             if (inc.is_absolute()) {
-                // Native spelling (see native_path_from_generic): a TOML
-                // `C:/SDL2/include` stays mixed on MSVC and leaks into the
-                // CDB's -I otherwise.
-                appendUniquePath(dirs,
-                    mcpp::modgraph::native_path_from_generic(inc.generic_string()));
+                // Native spelling: a TOML `C:/SDL2/include` stays mixed on
+                // MSVC and leaks into the CDB's -I otherwise. Direct
+                // make_preferred — no generic_string round trip, which can
+                // throw for names the ANSI codepage cannot spell (mcpp#230).
+                auto n = inc;
+                n.make_preferred();
+                appendUniquePath(dirs, std::move(n));
                 continue;
             }
             for (auto& dir : mcpp::modgraph::expand_dir_glob(
@@ -3021,8 +3023,9 @@ prepare_build(bool print_fingerprint,
         std::vector<std::filesystem::path> dirs;
         for (auto const& inc : manifest.buildConfig.includeDirsAfter) {
             if (inc.is_absolute()) {
-                appendUniquePath(dirs,
-                    mcpp::modgraph::native_path_from_generic(inc.generic_string()));
+                auto n = inc;
+                n.make_preferred();
+                appendUniquePath(dirs, std::move(n));
                 continue;
             }
             for (auto& dir : mcpp::modgraph::expand_dir_glob(

--- a/src/build/prepare.cppm
+++ b/src/build/prepare.cppm
@@ -16,6 +16,7 @@ import mcpp.platform.axis;
 import mcpp.libs.json;
 import mcpp.log;
 import mcpp.manifest;
+import mcpp.modgraph.glob;
 import mcpp.modgraph.graph;
 import mcpp.modgraph.scanner;
 import mcpp.modgraph.validate;
@@ -2996,7 +2997,11 @@ prepare_build(bool print_fingerprint,
         std::vector<std::filesystem::path> dirs;
         for (auto const& inc : manifest.buildConfig.includeDirs) {
             if (inc.is_absolute()) {
-                appendUniquePath(dirs, inc);
+                // Native spelling (see native_path_from_generic): a TOML
+                // `C:/SDL2/include` stays mixed on MSVC and leaks into the
+                // CDB's -I otherwise.
+                appendUniquePath(dirs,
+                    mcpp::modgraph::native_path_from_generic(inc.generic_string()));
                 continue;
             }
             for (auto& dir : mcpp::modgraph::expand_dir_glob(
@@ -3016,7 +3021,8 @@ prepare_build(bool print_fingerprint,
         std::vector<std::filesystem::path> dirs;
         for (auto const& inc : manifest.buildConfig.includeDirsAfter) {
             if (inc.is_absolute()) {
-                appendUniquePath(dirs, inc);
+                appendUniquePath(dirs,
+                    mcpp::modgraph::native_path_from_generic(inc.generic_string()));
                 continue;
             }
             for (auto& dir : mcpp::modgraph::expand_dir_glob(

--- a/src/modgraph/glob.cppm
+++ b/src/modgraph/glob.cppm
@@ -12,6 +12,30 @@ import std;
 
 export namespace mcpp::modgraph {
 
+// Convert a manifest-style path or glob prefix (always spelled with the
+// generic `/` separator) to the platform's native spelling.
+//
+// MSVC's std::filesystem::path preserves the separators of the string it
+// was constructed from instead of normalizing them, so wrapping a raw
+// `generated/modules` in a path and joining it with `root / p` yields the
+// MIXED `C:\...\generated/modules` — and the directory-walk children built
+// on top of that stay mixed. `.string()` then carries the mixed form into
+// `compile_commands.json` (its `file` / `-c` fields), which CLion refuses
+// to parse. Ninja never notices because it renders everything via
+// generic_string(); the CDB is the first `.string()` consumer.
+//
+// POSIX is untouched (its native separator already is `/`). Replacing only
+// `/` is also safe for already-native Windows input: it never contains `/`.
+std::filesystem::path native_path_from_generic(std::string_view s) {
+    constexpr char kSep = std::filesystem::path::preferred_separator;
+    if (kSep == '/') return std::filesystem::path(s);
+    std::string p(s);
+    for (auto& c : p) {
+        if (c == '/') c = kSep;
+    }
+    return std::filesystem::path(std::move(p));
+}
+
 // Does `candidate` match `glob`, interpreted relative to `root`?
 //
 // Supports "**" (any number of directory levels) and "*" (within one segment).

--- a/src/modgraph/glob.cppm
+++ b/src/modgraph/glob.cppm
@@ -24,16 +24,12 @@ export namespace mcpp::modgraph {
 // to parse. Ninja never notices because it renders everything via
 // generic_string(); the CDB is the first `.string()` consumer.
 //
-// POSIX is untouched (its native separator already is `/`). Replacing only
-// `/` is also safe for already-native Windows input: it never contains `/`.
+// POSIX is untouched (`make_preferred()` is a no-op there, and it is also
+// safe for already-native Windows input, which never contains `/`).
 std::filesystem::path native_path_from_generic(std::string_view s) {
-    constexpr char kSep = std::filesystem::path::preferred_separator;
-    if (kSep == '/') return std::filesystem::path(s);
-    std::string p(s);
-    for (auto& c : p) {
-        if (c == '/') c = kSep;
-    }
-    return std::filesystem::path(std::move(p));
+    std::filesystem::path p(s);
+    p.make_preferred();
+    return p;
 }
 
 // Does `candidate` match `glob`, interpreted relative to `root`?

--- a/src/modgraph/scanner.cppm
+++ b/src/modgraph/scanner.cppm
@@ -268,7 +268,12 @@ std::filesystem::path glob_literal_prefix(std::string_view glob) {
         ? glob : glob.substr(0, wildcard);
     auto slash = literal.find_last_of('/');
     if (slash == std::string_view::npos) return {};
-    return std::filesystem::path(literal.substr(0, slash));
+    // Native separators, not the raw generic form: MSVC keeps the input's
+    // `/` verbatim, and `root / p` plus the directory walk then propagate a
+    // MIXED `root\generated/modules` into every downstream path — which is
+    // what `compile_commands.json`'s `file` field showed on Windows for
+    // multi-segment globs. See mcpp::modgraph::native_path_from_generic.
+    return native_path_from_generic(literal.substr(0, slash));
 }
 
 // mcpp#228: `{a,b}` alternation, recursively. Finds the first top-level `{`,
@@ -442,7 +447,9 @@ std::vector<std::filesystem::path> expand_dir_glob(const std::filesystem::path& 
     // expand_glob) — include_dirs entries are meant to name one literal
     // directory each; a caller wanting alternatives lists multiple entries.
     if (glob.find('*') == std::string_view::npos) {
-        auto p = root / std::filesystem::path(glob);
+        // Native spelling (see native_path_from_generic — a raw `a/b` would
+        // come back mixed from .string() on MSVC).
+        auto p = root / native_path_from_generic(glob);
         if (std::filesystem::is_directory(p, ec)) out.push_back(p);
         return out;
     }
@@ -682,7 +689,10 @@ local_include_dirs_for(const std::filesystem::path& root,
     std::vector<std::filesystem::path> dirs;
     for (auto const& inc : manifest.buildConfig.includeDirs) {
         if (inc.is_absolute()) {
-            dirs.push_back(inc);
+            // A TOML value like `C:/SDL2/include` keeps its `/` on MSVC —
+            // normalize so the CDB's -I comes out native (mixed separators
+            // break CLion). See mcpp::modgraph::native_path_from_generic.
+            dirs.push_back(native_path_from_generic(inc.generic_string()));
             continue;
         }
         for (auto& d : expand_dir_glob(root, inc.generic_string())) {
@@ -701,7 +711,7 @@ local_include_dirs_after_for(const std::filesystem::path& root,
     std::vector<std::filesystem::path> dirs;
     for (auto const& inc : manifest.buildConfig.includeDirsAfter) {
         if (inc.is_absolute()) {
-            dirs.push_back(inc);
+            dirs.push_back(native_path_from_generic(inc.generic_string()));
             continue;
         }
         for (auto& d : expand_dir_glob(root, inc.generic_string())) {
@@ -738,7 +748,10 @@ void scan_one_into(ScanResult& result,
             // Literal absolute entry — e.g. a dependency build.mcpp's OUT_DIR
             // generated source, which lives OUTSIDE the (possibly read-only)
             // package root. No glob expansion; taken as-is when it exists.
-            if (std::filesystem::path gp(g); gp.is_absolute()) {
+            // Native spelling: a raw `C:/abs/x.cppm` would stay mixed on MSVC
+            // (see native_path_from_generic) and leak into the CDB.
+            auto gp = native_path_from_generic(g);
+            if (gp.is_absolute()) {
                 std::error_code aec;
                 if (std::filesystem::is_regular_file(gp, aec)) all_files.insert(gp);
                 continue;

--- a/src/modgraph/scanner.cppm
+++ b/src/modgraph/scanner.cppm
@@ -501,10 +501,18 @@ namespace {
 
 // has_root_path: leave absolute AND root-relative ("/x" on Windows)
 // spellings alone — only genuinely root-less paths are project-relative.
+// Both branches normalize to NATIVE separators: a `-Ithird_party/inc` cxxflag
+// would otherwise come back as `C:\proj\third_party/inc` on MSVC (path keeps
+// the input `/` verbatim) and reach the CDB's arguments via packageCxxflags.
 std::string rewrite_rel_copy(const std::string& p, const std::filesystem::path& root) {
     std::filesystem::path fp(p);
-    if (fp.has_root_path()) return p;
-    return (root / fp).string();
+    if (fp.has_root_path()) {
+        fp.make_preferred();
+        return fp.string();
+    }
+    auto joined = root / fp;
+    joined.make_preferred();
+    return joined.string();
 }
 
 void rewrite_rel(std::string& p, const std::filesystem::path& root) {
@@ -691,8 +699,12 @@ local_include_dirs_for(const std::filesystem::path& root,
         if (inc.is_absolute()) {
             // A TOML value like `C:/SDL2/include` keeps its `/` on MSVC —
             // normalize so the CDB's -I comes out native (mixed separators
-            // break CLion). See mcpp::modgraph::native_path_from_generic.
-            dirs.push_back(native_path_from_generic(inc.generic_string()));
+            // break CLion). Direct make_preferred, no generic_string round
+            // trip: the narrow conversion can throw for names the ANSI
+            // codepage cannot spell (mcpp#230).
+            auto n = inc;
+            n.make_preferred();
+            dirs.push_back(std::move(n));
             continue;
         }
         for (auto& d : expand_dir_glob(root, inc.generic_string())) {
@@ -711,7 +723,9 @@ local_include_dirs_after_for(const std::filesystem::path& root,
     std::vector<std::filesystem::path> dirs;
     for (auto const& inc : manifest.buildConfig.includeDirsAfter) {
         if (inc.is_absolute()) {
-            dirs.push_back(native_path_from_generic(inc.generic_string()));
+            auto n = inc;
+            n.make_preferred();
+            dirs.push_back(std::move(n));
             continue;
         }
         for (auto& d : expand_dir_glob(root, inc.generic_string())) {

--- a/src/modgraph/scanner.cppm
+++ b/src/modgraph/scanner.cppm
@@ -507,6 +507,12 @@ namespace {
 std::string rewrite_rel_copy(const std::string& p, const std::filesystem::path& root) {
     std::filesystem::path fp(p);
     if (fp.has_root_path()) {
+        // Nothing to re-spell → hand back the ORIGINAL bytes rather than
+        // round-tripping them through path's narrow conversion, which throws
+        // std::system_error for names the ANSI codepage cannot express
+        // (mcpp#230 — see path_matches_glob). A rooted path with no '/' is
+        // already native on both platform families.
+        if (p.find('/') == std::string::npos) return p;
         fp.make_preferred();
         return fp.string();
     }

--- a/tests/e2e/47_cdb_prebuilt_module_path_abs.sh
+++ b/tests/e2e/47_cdb_prebuilt_module_path_abs.sh
@@ -22,6 +22,17 @@ cd app
 cdb=compile_commands.json
 [[ -f "$cdb" ]] || { echo "FAIL: no $cdb generated"; exit 1; }
 
+# jq-independent early guard for the stray-quote bug: before the CDB
+# splitter understood shell quoting, flags.cppm's ninja-side quoting leaked
+# into the raw JSON as `\"-fprebuilt-module-path=...` (Windows) / `'-...`
+# (POSIX). The GCC flow emits no such flag at all, so no-match is the
+# expected pass there.
+if grep -q '\\"-fprebuilt-module-path' "$cdb" \
+    || grep -q "'-fprebuilt-module-path" "$cdb"; then
+    echo "FAIL: -fprebuilt-module-path retains shell quoting in raw CDB"
+    exit 1
+fi
+
 command -v jq >/dev/null 2>&1 || {
     echo "SKIP: jq not on PATH (preinstalled on GitHub-hosted runners)"
     exit 0
@@ -60,6 +71,16 @@ while IFS= read -r v; do
     # → clangd fails to find the BMI.
     if [[ "$v" == *'$:'* || "$v" == *'$ '* || "$v" == *'$$'* ]]; then
         echo "FAIL: value retains ninja escape sequence ('\$:' / '\$ ' / '\$\$') — must be plain path in CDB"
+        fail=1
+    fi
+
+    # Nor shell quoting: the flags string is assembled for the NINJA command
+    # line, where shell_quote_arg wraps every token containing a Windows `\`
+    # in double quotes — and those quotes used to land VERBATIM in the CDB
+    # (`"-fprebuilt-module-path=C:\...\pcm.cache"`), which clangd execs
+    # literally and cannot resolve. The CDB splitter must have undone them.
+    if [[ "$v" == '"'* || "$v" == "'"* || "$v" == *'"' || "$v" == *"'" ]]; then
+        echo "FAIL: value retains shell quoting: '$v'"
         fail=1
     fi
 

--- a/tests/e2e/76_compile_commands_generated.sh
+++ b/tests/e2e/76_compile_commands_generated.sh
@@ -55,26 +55,36 @@ grep -qE '"command"|"arguments"' "$cdb" || {
 # The minimal project's source (src/main.cpp) must have an entry.
 grep -q 'main\.cpp' "$cdb" || { echo "FAIL: $cdb has no entry for src/main.cpp"; cat "$cdb"; exit 1; }
 
+# The multi-segment glob must ACTUALLY have contributed an entry — if the
+# glob silently missed, every separator assertion below is vacuous green.
+grep -q 'extra\.cpp' "$cdb" || {
+    echo "FAIL: $cdb has no entry for generated/modules/extra.cpp — multi-segment glob missed"
+    cat "$cdb"; exit 1
+}
+
 # Deeper structural validation when a JSON parser is available (GitHub-hosted
-# runners ship python3). Skips cleanly where it isn't, keeping the grep checks
-# above as the portable baseline.
+# runners ship python3). Explicitly reports the skip where it isn't, so a
+# silent pass can never masquerade as validation coverage.
 if command -v python3 >/dev/null 2>&1; then
     python3 - "$cdb" <<'PY' || exit 1
-import json, sys, os
+import json, sys
 d = json.load(open(sys.argv[1], encoding="utf-8"))
 assert isinstance(d, list) and d, "CDB must be a non-empty JSON array"
 for e in d:
     assert "file" in e and "directory" in e, "entry missing file/directory: %r" % e
     assert ("command" in e) or ("arguments" in e), "entry missing command/arguments: %r" % e
-    # Native separators on Windows: a multi-segment manifest glob used to
-    # yield MIXED `root\generated/modules\x.cppm` file paths (MSVC's path
-    # keeps the `/` from the glob prefix), which CLion refuses to parse.
-    # Ninja hides the problem (it renders generic_string()); the CDB is
-    # the .string() consumer.
-    if os.name == "nt" and "/" in e["file"]:
-        raise AssertionError("file must use native separators on Windows: %r" % e["file"])
+    # Platform-independent mixed-separator check: the #390 bug spelled a
+    # Windows file as `root\generated/modules\x.cppm` (MSVC's path keeps the
+    # `/` from the manifest glob prefix, and the directory walk propagates
+    # it). On POSIX a backslash never appears in a path, so the assertion is
+    # trivially true there and catches exactly the bug on Windows — no
+    # os.name / platform sniffing needed.
+    f = e["file"]
+    assert not ("\\" in f and "/" in f), "mixed separators in file: %r" % f
 print("  json validation OK (%d entries)" % len(d))
 PY
+else
+    echo "SKIP: python3 not on PATH — JSON validation not run"
 fi
 
 echo "OK"

--- a/tests/e2e/76_compile_commands_generated.sh
+++ b/tests/e2e/76_compile_commands_generated.sh
@@ -16,6 +16,21 @@ trap "rm -rf $TMP" EXIT
 cd "$TMP"
 "$MCPP" new app > /dev/null
 cd app
+
+# A second source reached through a MULTI-SEGMENT glob (literal prefix
+# "generated/modules") — the shape that used to leak MIXED separators into
+# the CDB's `file`/`-c` on Windows (`root\generated/modules\extra.cpp`),
+# because MSVC's std::filesystem::path keeps the `/` from the manifest glob.
+mkdir -p generated/modules
+cat > generated/modules/extra.cpp <<'EOF'
+int mcpp_extra_anchor() { return 1; }
+EOF
+cat >> mcpp.toml <<'EOF'
+
+[build]
+sources = ["src/**/*.cpp", "generated/modules/**/*.cpp"]
+EOF
+
 "$MCPP" build > /dev/null
 
 cdb=compile_commands.json
@@ -45,12 +60,19 @@ grep -q 'main\.cpp' "$cdb" || { echo "FAIL: $cdb has no entry for src/main.cpp";
 # above as the portable baseline.
 if command -v python3 >/dev/null 2>&1; then
     python3 - "$cdb" <<'PY' || exit 1
-import json, sys
+import json, sys, os
 d = json.load(open(sys.argv[1], encoding="utf-8"))
 assert isinstance(d, list) and d, "CDB must be a non-empty JSON array"
 for e in d:
     assert "file" in e and "directory" in e, "entry missing file/directory: %r" % e
     assert ("command" in e) or ("arguments" in e), "entry missing command/arguments: %r" % e
+    # Native separators on Windows: a multi-segment manifest glob used to
+    # yield MIXED `root\generated/modules\x.cppm` file paths (MSVC's path
+    # keeps the `/` from the glob prefix), which CLion refuses to parse.
+    # Ninja hides the problem (it renders generic_string()); the CDB is
+    # the .string() consumer.
+    if os.name == "nt" and "/" in e["file"]:
+        raise AssertionError("file must use native separators on Windows: %r" % e["file"])
 print("  json validation OK (%d entries)" % len(d))
 PY
 fi

--- a/tests/unit/test_build_flags.cpp
+++ b/tests/unit/test_build_flags.cpp
@@ -97,8 +97,18 @@ TEST(BuildFlagsAtomic, StaticLinkEmittedWhenArchivePresent) {
 // BOTH the joined spelling (`-iquotehdr`) and the separated spelling
 // (`-isystem` followed by a standalone next element). All four of these
 // project-relative paths must resolve to the same "/proj/hdr" target.
+//
+// The expected spelling is NATIVE (#390): `-I/abs/hdr` written with forward
+// slashes keeps them on MSVC, and the old expectation `(root / "hdr").string()`
+// was itself the mixed `"/proj\hdr"` shape this family of bugs produced.
+// make_preferred() makes the expectation platform-correct on both sides.
 TEST(BuildFlags, NormalizeIncludeFlagsRewritesFullIncludeFamily) {
     std::filesystem::path root = "/proj";
+    auto expected = [](const std::filesystem::path& p) {
+        auto n = p;
+        n.make_preferred();
+        return n.string();
+    };
     std::vector<std::string> flags = {
         "-Ihdr", "-iquotehdr", "-isystem", "hdr", "-idirafterhdr",
     };
@@ -106,26 +116,32 @@ TEST(BuildFlags, NormalizeIncludeFlagsRewritesFullIncludeFamily) {
     mcpp::modgraph::normalize_include_flags(root, flags);
 
     ASSERT_EQ(flags.size(), 5u);
-    EXPECT_EQ(flags[0], "-I" + (root / "hdr").string());
-    EXPECT_EQ(flags[1], "-iquote" + (root / "hdr").string());
+    EXPECT_EQ(flags[0], "-I" + expected(root / "hdr"));
+    EXPECT_EQ(flags[1], "-iquote" + expected(root / "hdr"));
     EXPECT_EQ(flags[2], "-isystem");                       // prefix itself untouched
-    EXPECT_EQ(flags[3], (root / "hdr").string());          // separated element rewritten
-    EXPECT_EQ(flags[4], "-idirafter" + (root / "hdr").string());
+    EXPECT_EQ(flags[3], expected(root / "hdr"));           // separated element rewritten
+    EXPECT_EQ(flags[4], "-idirafter" + expected(root / "hdr"));
 }
 
 // Absolute paths and root-relative spellings are left alone (matches the
-// pre-#226 -I behavior), for both the joined and separated forms.
+// pre-#226 -I behavior), for both the joined and separated forms — only the
+// separator spelling is normalized to native (#390; a no-op on POSIX).
 TEST(BuildFlags, NormalizeIncludeFlagsLeavesAbsolutePathsAlone) {
     std::filesystem::path root = "/proj";
+    auto expected = [](const std::filesystem::path& p) {
+        auto n = p;
+        n.make_preferred();
+        return n.string();
+    };
     std::vector<std::string> flags = {
         "-I/abs/hdr", "-isystem", "/abs/hdr", "-DKEEP",
     };
 
     mcpp::modgraph::normalize_include_flags(root, flags);
 
-    EXPECT_EQ(flags[0], "-I/abs/hdr");
+    EXPECT_EQ(flags[0], "-I" + expected("/abs/hdr"));
     EXPECT_EQ(flags[1], "-isystem");
-    EXPECT_EQ(flags[2], "/abs/hdr");
+    EXPECT_EQ(flags[2], expected("/abs/hdr"));
     EXPECT_EQ(flags[3], "-DKEEP");
 }
 

--- a/tests/unit/test_compile_commands.cpp
+++ b/tests/unit/test_compile_commands.cpp
@@ -2,6 +2,9 @@
 
 import std;
 import mcpp.build.compile_commands;
+import mcpp.build.flags;
+import mcpp.build.plan;
+import mcpp.libs.json;
 
 using namespace mcpp::build;
 
@@ -93,6 +96,27 @@ TEST(CompileCommandsMerge, MalformedExistingFallsBackToFresh) {
     EXPECT_NE(merged.find("-O2"), std::string::npos) << merged;
 }
 
+// #390 self-heal: a CDB written BEFORE the mixed-separator fix spells the
+// same file with the generic `/` spelling (`/p/generated/modules/a.cpp` —
+// on Windows this is exactly `root\generated/modules\a.cpp` vs the native
+// `root\generated\modules\a.cpp`). The merge key is the NORMALIZED path, so
+// the stale entry is recognized as the same file and dropped on the first
+// build after upgrade — the user never has to delete compile_commands.json
+// by hand. (On POSIX the two spellings are byte-identical; the test then
+// still verifies the plain fresh-wins contract.)
+TEST(CompileCommandsMerge, NormalizedFileKeysHealStaleSeparatorSpellings) {
+    auto p = std::filesystem::path("/p") / "generated" / "modules" / "a.cpp";
+    auto fresh    = cdb({ entry(p.string(), "-O2-FRESH") });
+    auto existing = cdb({ entry(p.generic_string(), "-O0-STALE") });
+
+    auto merged = merge_compile_commands(
+        fresh, existing, [](const std::filesystem::path&) { return true; });
+
+    EXPECT_EQ(count(merged, "generated"), 1u) << merged;
+    EXPECT_NE(merged.find("-O2-FRESH"), std::string::npos) << merged;
+    EXPECT_EQ(merged.find("-O0-STALE"), std::string::npos) << merged;
+}
+
 // ── CDB arguments must be argv, not shell words ─────────────────────────────
 //
 // A consumer (clangd) execs `arguments` LITERALLY — no shell. So a token that
@@ -171,4 +195,40 @@ TEST(CompileCommandsArgs, InnerQuotesAreNotStripped) {
     ASSERT_EQ(out.size(), 1u);
     EXPECT_EQ(out[0], R"(-DGREETING="hi")");
     EXPECT_FALSE(is_quoted(out[0]));
+}
+
+// ── Emitted paths use native separators, unconditionally ────────────────────
+//
+// The last line of the #390 defence: every ingestion point is normalized at
+// the source, but a path that still slips through with a mixed spelling
+// (MSVC keeps the input `/` verbatim) would land in `file`/`-c`/`-o`/`-I`
+// and break CLion. emit_compile_commands therefore makes ALL of them native
+// — make_preferred(), a no-op on POSIX.
+TEST(CompileCommandsEmit, EmittedPathsUseNativeSeparators) {
+    BuildPlan plan;
+    plan.projectRoot = "/p";
+    plan.outputDir = "/p/target";
+    plan.compileUnits.push_back({
+        // A path whose spelling carries `/` segments (what the manifest
+        // glob ingestion used to produce on MSVC).
+        .source = std::filesystem::path("C:/Users/x/src/main.cpp"),
+        .object = std::filesystem::path("obj") / "main.o",
+        .packageName = "demo",
+    });
+    CompileFlags flags;
+    flags.cxxBinary = std::filesystem::path("/usr/bin/g++");
+
+    auto j = nlohmann::json::parse(emit_compile_commands(plan, flags));
+    auto const& e = j[0];
+    if constexpr (std::filesystem::path::preferred_separator == '\\') {
+        EXPECT_EQ(e["file"].get<std::string>(), "C:\\Users\\x\\src\\main.cpp");
+        EXPECT_EQ(e["directory"].get<std::string>(), "\\p");
+        EXPECT_EQ(e["output"].get<std::string>(), "\\p\\target\\obj\\main.o");
+        for (auto const& a : e["arguments"]) {
+            if (a.is_string() && a.get<std::string>().starts_with("-"))
+                EXPECT_EQ(a.get<std::string>().find('/'), std::string::npos);
+        }
+    } else {
+        EXPECT_EQ(e["file"].get<std::string>(), "C:/Users/x/src/main.cpp");
+    }
 }

--- a/tests/unit/test_compile_commands.cpp
+++ b/tests/unit/test_compile_commands.cpp
@@ -11,12 +11,22 @@ using namespace mcpp::build;
 namespace {
 
 // Build a single CDB entry as JSON text. `flag` is a marker we can grep for.
+//
+// Serialized THROUGH nlohmann, never hand-formatted: a Windows `file` value
+// carries backslashes, and `\g` (from `...\generated\...`) is not a legal JSON
+// escape. A format-string version produced text that no parser accepts, which
+// merge_compile_commands answers by returning `fresh` verbatim — every
+// assertion below then passes without the code under test ever running.
 std::string entry(std::string_view file, std::string_view flag) {
     // Keep the file path out of `arguments` so it appears exactly once (in
     // "file") — lets tests count entries per file unambiguously.
-    return std::format(
-        R"({{"directory":"/p","file":"{}","arguments":["g++","{}","-c","src.cpp"],"output":"o"}})",
-        file, flag);
+    nlohmann::json e;
+    e["directory"] = "/p";
+    e["file"]      = std::string(file);
+    e["arguments"] = nlohmann::json::array(
+        { "g++", std::string(flag), "-c", "src.cpp" });
+    e["output"]    = "o";
+    return e.dump();
 }
 
 std::string cdb(std::initializer_list<std::string> entries) {
@@ -28,6 +38,12 @@ std::string cdb(std::initializer_list<std::string> entries) {
         first = false;
     }
     s += "\n]\n";
+    // A fixture that does not PARSE makes every merge test vacuously green
+    // (merge_compile_commands short-circuits to `fresh` on a discarded parse),
+    // so the fixture itself is checked here rather than trusted. Tests that
+    // WANT malformed input pass it directly, not through this builder.
+    EXPECT_FALSE(nlohmann::json::parse(s, nullptr, /*allow_exceptions=*/false)
+                     .is_discarded()) << s;
     return s;
 }
 
@@ -96,18 +112,24 @@ TEST(CompileCommandsMerge, MalformedExistingFallsBackToFresh) {
     EXPECT_NE(merged.find("-O2"), std::string::npos) << merged;
 }
 
-// #390 self-heal: a CDB written BEFORE the mixed-separator fix spells the
-// same file with the generic `/` spelling (`/p/generated/modules/a.cpp` —
-// on Windows this is exactly `root\generated/modules\a.cpp` vs the native
-// `root\generated\modules\a.cpp`). The merge key is the NORMALIZED path, so
-// the stale entry is recognized as the same file and dropped on the first
-// build after upgrade — the user never has to delete compile_commands.json
-// by hand. (On POSIX the two spellings are byte-identical; the test then
-// still verifies the plain fresh-wins contract.)
+// #390 self-heal: a CDB written BEFORE the mixed-separator fix spells the same
+// file differently from the way a fresh plan spells it. Because the merge key
+// is the NORMALIZED path, the stale entry is recognized as the same file and
+// dropped on the first build after upgrade — the user never has to delete
+// compile_commands.json by hand.
+//
+// The stale spelling deliberately differs from fresh on EVERY platform: the
+// `/./` segment needs lexically_normal to collapse (POSIX included), and on
+// Windows the `/` separators need make_preferred on top. A stale value of just
+// `p.generic_string()` would be byte-identical to fresh on POSIX, and the
+// literal-string key this test exists to replace would pass it unchanged.
 TEST(CompileCommandsMerge, NormalizedFileKeysHealStaleSeparatorSpellings) {
     auto p = std::filesystem::path("/p") / "generated" / "modules" / "a.cpp";
+    auto stale = "/p/generated/./modules/a.cpp";
+    ASSERT_NE(p.string(), stale) << "fixture must differ from the fresh spelling";
+
     auto fresh    = cdb({ entry(p.string(), "-O2-FRESH") });
-    auto existing = cdb({ entry(p.generic_string(), "-O0-STALE") });
+    auto existing = cdb({ entry(stale, "-O0-STALE") });
 
     auto merged = merge_compile_commands(
         fresh, existing, [](const std::filesystem::path&) { return true; });
@@ -197,38 +219,60 @@ TEST(CompileCommandsArgs, InnerQuotesAreNotStripped) {
     EXPECT_FALSE(is_quoted(out[0]));
 }
 
-// ── Emitted paths use native separators, unconditionally ────────────────────
+// ── Emitted paths use native separators ─────────────────────────────────────
 //
 // The last line of the #390 defence: every ingestion point is normalized at
 // the source, but a path that still slips through with a mixed spelling
-// (MSVC keeps the input `/` verbatim) would land in `file`/`-c`/`-o`/`-I`
-// and break CLion. emit_compile_commands therefore makes ALL of them native
-// — make_preferred(), a no-op on POSIX.
+// (MSVC keeps the input `/` verbatim) would land in the CDB and break CLion.
+//
+// Scope, precisely: the emitter owns the CDB schema's path fields (`file`,
+// `directory`, `output`) and the argv positions it builds itself (`-c`'s and
+// `-o`'s values, plus `-I`/`-idirafter` from localIncludeDirs). The flag
+// STRINGS — split_flags(f.cxx) and the package cflags/cxxflags — pass through
+// untouched and stay the ingestion points' responsibility; normalizing an
+// arbitrary flag payload is not safe (`-DPATH="/etc/x"` holds real slashes).
 TEST(CompileCommandsEmit, EmittedPathsUseNativeSeparators) {
     BuildPlan plan;
     plan.projectRoot = "/p";
     plan.outputDir = "/p/target";
     plan.compileUnits.push_back({
-        // A path whose spelling carries `/` segments (what the manifest
-        // glob ingestion used to produce on MSVC).
+        // Paths whose spelling carries `/` segments — what the manifest glob
+        // and the include_dirs channels used to produce on MSVC.
         .source = std::filesystem::path("C:/Users/x/src/main.cpp"),
         .object = std::filesystem::path("obj") / "main.o",
         .packageName = "demo",
+        .localIncludeDirs      = { std::filesystem::path("C:/proj/generated/inc") },
+        .localIncludeDirsAfter = { std::filesystem::path("C:/proj/third_party/inc") },
     });
     CompileFlags flags;
     flags.cxxBinary = std::filesystem::path("/usr/bin/g++");
 
     auto j = nlohmann::json::parse(emit_compile_commands(plan, flags));
     auto const& e = j[0];
+
+    // Assert on the two include tokens by name. The earlier shape of this
+    // test ("no `-`-prefixed argument may contain `/`") looked stronger but
+    // was vacuous — with no flags configured, the only `-` tokens are the
+    // bare `-c` and `-o`, which have no path in them at all.
+    auto arg_with = [&](std::string_view pre) {
+        for (auto const& a : e["arguments"]) {
+            auto s = a.get<std::string>();
+            if (s.starts_with(pre)) return s;
+        }
+        return std::string{};
+    };
+    const auto inc      = arg_with("-I");
+    const auto incAfter = arg_with("-idirafter");
+
     if constexpr (std::filesystem::path::preferred_separator == '\\') {
         EXPECT_EQ(e["file"].get<std::string>(), "C:\\Users\\x\\src\\main.cpp");
         EXPECT_EQ(e["directory"].get<std::string>(), "\\p");
         EXPECT_EQ(e["output"].get<std::string>(), "\\p\\target\\obj\\main.o");
-        for (auto const& a : e["arguments"]) {
-            if (a.is_string() && a.get<std::string>().starts_with("-"))
-                EXPECT_EQ(a.get<std::string>().find('/'), std::string::npos);
-        }
+        EXPECT_EQ(inc,      "-IC:\\proj\\generated\\inc");
+        EXPECT_EQ(incAfter, "-idirafterC:\\proj\\third_party\\inc");
     } else {
         EXPECT_EQ(e["file"].get<std::string>(), "C:/Users/x/src/main.cpp");
+        EXPECT_EQ(inc,      "-IC:/proj/generated/inc");
+        EXPECT_EQ(incAfter, "-idirafterC:/proj/third_party/inc");
     }
 }

--- a/tests/unit/test_modgraph.cpp
+++ b/tests/unit/test_modgraph.cpp
@@ -167,9 +167,9 @@ TEST(Scanner, GlobLiteralPrefixDerivation) {
 // into a MIXED `root\a/b` — which used to leak into compile_commands.json
 // (`file` / `-c` for every source under a multi-segment glob) and break CLion.
 // glob_literal_prefix must return NATIVE separators so the walk and everything
-// downstream is native too.
+// downstream is native too. (The generic spelling is already locked down by
+// Scanner.GlobLiteralPrefixDerivation above.)
 TEST(Scanner, GlobLiteralPrefixUsesNativeSeparators) {
-    EXPECT_EQ(glob_literal_prefix("a/b/c.cpp").generic_string(), "a/b");
     if constexpr (std::filesystem::path::preferred_separator == '\\') {
         EXPECT_EQ(glob_literal_prefix("a/b/c.cpp").string(), "a\\b");
         EXPECT_EQ(glob_literal_prefix("a/b/c.cpp").string().find('/'),
@@ -757,6 +757,9 @@ TEST(Scanner, PerGlobFlagsMatchBraceAlternation) {
 
 // G8b: relative -I flags are root-relative in the manifest but ninja runs
 // with cwd = output dir — the scanner absolutizes them on every unit.
+// The absolute spelling is NORMALIZED to native separators (#390): MSVC's
+// path keeps the input `/` verbatim, and `-I/abs/path` written with forward
+// slashes used to survive into the CDB's arguments as a mixed path.
 TEST(Scanner, RelativeIncludeFlagsAbsolutized) {
     auto dir = make_tempdir("mcpp-scanner-relinc");
     write(dir / "src" / "a.cpp", "int a();\n");
@@ -774,8 +777,11 @@ TEST(Scanner, RelativeIncludeFlagsAbsolutized) {
     ASSERT_EQ(res.graph.units.size(), 1u);
     auto& fl = res.graph.units[0].packageCxxflags;
     EXPECT_EQ(fl[0], "-I" + (dir / "inc").string());
-    EXPECT_EQ(fl[1], "-I/abs/path");   // absolute stays
-    EXPECT_EQ(fl[2], "-DKEEP");        // non-include untouched
+    if constexpr (std::filesystem::path::preferred_separator == '\\')
+        EXPECT_EQ(fl[1], "-I\\abs\\path");   // absolute stays, but native
+    else
+        EXPECT_EQ(fl[1], "-I/abs/path");     // absolute stays
+    EXPECT_EQ(fl[2], "-DKEEP");              // non-include untouched
 
     std::filesystem::remove_all(dir);
 }

--- a/tests/unit/test_modgraph.cpp
+++ b/tests/unit/test_modgraph.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 import std;
+import mcpp.modgraph.glob;
 import mcpp.modgraph.graph;
 import mcpp.modgraph.scanner;
 import mcpp.modgraph.validate;
@@ -151,7 +152,7 @@ TEST(Scanner, GlobLiteralPrefixDerivation) {
     // Wildcard already in the first segment: no literal directory to bound to.
     EXPECT_EQ(glob_literal_prefix("**/*.c"), "");
     // No wildcard at all: the full parent directory path is the prefix.
-    EXPECT_EQ(glob_literal_prefix("a/b/c.cpp"), "a/b");
+    EXPECT_EQ(glob_literal_prefix("a/b/c.cpp").generic_string(), "a/b");
     // Truncate back to the last COMPLETE '/' before the first wildcard char —
     // "x*.cpp" is a partial segment, not a real directory named "x".
     EXPECT_EQ(glob_literal_prefix("src/x*.cpp"), "src");
@@ -159,6 +160,72 @@ TEST(Scanner, GlobLiteralPrefixDerivation) {
     // globs are desugared before reaching this helper — see its comment in
     // scanner.cppm), so the prefix truncates at the last '/' before it.
     EXPECT_EQ(glob_literal_prefix("a/{x,y}/z"), "a");
+}
+
+// MSVC's std::filesystem::path preserves the separators of the string it was
+// constructed from, so a raw `a/b` prefix stays generic and `root / p` turns
+// into a MIXED `root\a/b` — which used to leak into compile_commands.json
+// (`file` / `-c` for every source under a multi-segment glob) and break CLion.
+// glob_literal_prefix must return NATIVE separators so the walk and everything
+// downstream is native too.
+TEST(Scanner, GlobLiteralPrefixUsesNativeSeparators) {
+    EXPECT_EQ(glob_literal_prefix("a/b/c.cpp").generic_string(), "a/b");
+    if constexpr (std::filesystem::path::preferred_separator == '\\') {
+        EXPECT_EQ(glob_literal_prefix("a/b/c.cpp").string(), "a\\b");
+        EXPECT_EQ(glob_literal_prefix("a/b/c.cpp").string().find('/'),
+                  std::string::npos);
+    }
+}
+
+// The exported converter itself — both spelling directions.
+TEST(Glob, NativePathFromGeneric) {
+    auto p = mcpp::modgraph::native_path_from_generic("a/b/c");
+    EXPECT_EQ(p.generic_string(), "a/b/c");
+    if constexpr (std::filesystem::path::preferred_separator == '\\') {
+        EXPECT_EQ(p.string(), "a\\b\\c");
+        // Already-native input is untouched.
+        EXPECT_EQ(mcpp::modgraph::native_path_from_generic("C:\\x\\y").string(),
+                  "C:\\x\\y");
+    }
+}
+
+// The end-to-end shape of the reported bug: a source under a multi-segment
+// glob (`generated/modules/**/*.cppm`) must come out of expand_glob with
+// NATIVE separators on Windows — the mixed `root\generated/modules\a.cppm`
+// was what compile_commands.json's `file` field showed before the fix.
+TEST(Scanner, ExpandGlobMultiSegmentPrefixUsesNativeSeparators) {
+    auto dir = make_tempdir("mcpp-scanner-multi");
+    write(dir / "generated" / "modules" / "a.cppm", "export module a;\n");
+
+    auto files = expand_glob(dir, "generated/modules/**/*.cppm");
+
+    ASSERT_EQ(files.size(), 1u);
+    if constexpr (std::filesystem::path::preferred_separator == '\\') {
+        EXPECT_EQ(files[0].string().find('/'), std::string::npos) << files[0];
+    }
+    EXPECT_EQ(files[0].generic_string(),
+              (dir / "generated" / "modules" / "a.cppm").generic_string());
+
+    std::filesystem::remove_all(dir);
+}
+
+// Same contract for the INCLUDE-DIR channel (expand_dir_glob): a multi-segment
+// `third_party/inc` entry must yield a native path or the CDB's -I carries the
+// mixed form.
+TEST(Scanner, ExpandDirGlobMultiSegmentUsesNativeSeparators) {
+    auto dir = make_tempdir("mcpp-scanner-dirglob");
+    std::filesystem::create_directories(dir / "third_party" / "inc");
+
+    auto dirs = expand_dir_glob(dir, "third_party/inc");
+
+    ASSERT_EQ(dirs.size(), 1u);
+    if constexpr (std::filesystem::path::preferred_separator == '\\') {
+        EXPECT_EQ(dirs[0].string().find('/'), std::string::npos) << dirs[0];
+    }
+    EXPECT_EQ(dirs[0].generic_string(),
+              (dir / "third_party" / "inc").generic_string());
+
+    std::filesystem::remove_all(dir);
 }
 
 // mcpp#225: expand_glob must bound its walk to the glob's literal directory

--- a/tests/unit/test_ninja_backend.cpp
+++ b/tests/unit/test_ninja_backend.cpp
@@ -5,6 +5,7 @@ import mcpp.build.compile_commands;
 import mcpp.build.flags;
 import mcpp.build.ninja;
 import mcpp.build.plan;
+import mcpp.libs.json;
 import mcpp.manifest;
 import mcpp.toolchain.dialect;
 import mcpp.toolchain.model;
@@ -163,8 +164,11 @@ TEST(NinjaBackend, CxxFlagsIncludeBuildIncludeDirs) {
     EXPECT_NE(flags.cxx.find(escaped_include_flag(plan.projectRoot / "include")),
               std::string::npos)
         << flags.cxx;
-    EXPECT_NE(flags.cxx.find(escaped_include_flag(
-                  plan.projectRoot / std::filesystem::path{"third_party/imgui"})),
+    // #390: a multi-segment entry is normalized to NATIVE separators before
+    // the -I token is built (a mixed `...\third_party/imgui` used to reach
+    // the CDB through f.cxx). Build the expected path natively too.
+    auto imgui = plan.projectRoot / "third_party" / "imgui";
+    EXPECT_NE(flags.cxx.find(escaped_include_flag(imgui)),
               std::string::npos)
         << flags.cxx;
 }
@@ -1148,8 +1152,22 @@ TEST(NinjaBackend, CachedUnitsStillAppearInCompileCommands) {
     auto flags = compute_flags(plan);
     auto cdb = emit_compile_commands(plan, flags);
 
-    EXPECT_NE(cdb.find("/store/dep/src/dep.c"), std::string::npos) << cdb;
-    EXPECT_NE(cdb.find("src/main.cpp"), std::string::npos) << cdb;
+    // #390: the emitter spells every path natively, so the expected source
+    // spelling is make_preferred'ed (a no-op on POSIX). Compared on the
+    // DECODED file field — the raw JSON text doubles every backslash.
+    auto dep = std::filesystem::path("/store/dep/src/dep.c");
+    dep.make_preferred();
+    auto main = std::filesystem::path("src/main.cpp");
+    main.make_preferred();
+    auto j = nlohmann::json::parse(cdb);
+    bool sawDep = false, sawMain = false;
+    for (auto const& e : j) {
+        auto f = e["file"].get<std::string>();
+        sawDep  = sawDep  || f == dep.string();
+        sawMain = sawMain || f == main.string();
+    }
+    EXPECT_TRUE(sawDep) << cdb;
+    EXPECT_TRUE(sawMain) << cdb;
 }
 
 // Replacing a package's compile edges with stage edges also removes the ordering
@@ -1227,4 +1245,32 @@ TEST(NinjaBackend, NoStagedPhonyWhenNothingIsCached) {
     });
     auto ninja = emit_ninja_string(plan);
     EXPECT_EQ(ninja.find("_mcpp_staged_cache"), std::string::npos) << ninja;
+}
+
+// #390: the main-manifest include channel's fallback join — `root / inc` for
+// a directory a build step will create LATER (the `generated/inc` shape) —
+// must spell its result NATIVELY on Windows. MSVC keeps the `/` of a TOML
+// `generated/inc` verbatim, so the bare join yields `C:\proj\generated/inc`,
+// which reaches the CDB's -I via local_include_args and breaks CLion. Same
+// rule for an absolute entry written with forward slashes (`C:/SDL2/include`).
+// (The existing-directory path runs through expand_dir_glob, covered by
+// Scanner.ExpandDirGlobMultiSegmentUsesNativeSeparators.)
+TEST(Plan, ExpandManifestIncludeEntryNativeSpelling) {
+    namespace fs = std::filesystem;
+    auto root = fs::temp_directory_path() / "mcpp-plan-inc-entry";
+    fs::remove_all(root);
+    fs::create_directories(root);   // generated/inc deliberately does NOT exist
+
+    auto fb = expand_manifest_include_entry(root, fs::path("generated/inc"));
+    ASSERT_EQ(fb.size(), 1u);
+    if constexpr (fs::path::preferred_separator == '\\')
+        EXPECT_EQ(fb[0].string().find('/'), std::string::npos) << fb[0];
+    EXPECT_EQ(fb[0], root / "generated" / "inc");
+
+    auto abs = expand_manifest_include_entry(root, fs::path("C:/SDL2/include"));
+    ASSERT_EQ(abs.size(), 1u);
+    if constexpr (fs::path::preferred_separator == '\\')
+        EXPECT_EQ(abs[0].string(), "C:\\SDL2\\include");
+
+    fs::remove_all(root);
 }

--- a/tests/unit/test_ninja_backend.cpp
+++ b/tests/unit/test_ninja_backend.cpp
@@ -173,6 +173,32 @@ TEST(NinjaBackend, CxxFlagsIncludeBuildIncludeDirs) {
         << flags.cxx;
 }
 
+// #390: the NASM include list is built from the SAME `[build] include_dirs`
+// key as the C/C++ one, so it must absolutize and spell entries identically —
+// it used to re-derive the join on its own (and with a different "already
+// rooted?" predicate). Nothing here is nasm-specific except the channel: the
+// point is that one manifest key cannot produce two different paths.
+TEST(NinjaBackend, NasmIncludeDirsMatchTheCxxChannelSpelling) {
+    auto plan = minimal_plan();
+    plan.nasmPath = "/usr/bin/nasm";
+    plan.manifest.buildConfig.includeDirs      = {"third_party/imgui"};
+    plan.manifest.buildConfig.includeDirsAfter = {"generated/inc"};
+
+    auto flags = compute_flags(plan);
+
+    auto native = [](std::filesystem::path p) { p.make_preferred(); return p; };
+    auto imgui = native(plan.projectRoot / "third_party" / "imgui");
+    auto gen   = native(plan.projectRoot / "generated" / "inc");
+
+    // Absolutized against projectRoot, natively spelt, and -I for BOTH keys
+    // (nasm has no system-header chain to defer to, so after-dirs degrade).
+    EXPECT_NE(flags.nasm.find(escaped_include_flag(imgui)), std::string::npos)
+        << flags.nasm;
+    EXPECT_NE(flags.nasm.find(escaped_include_flag(gen)), std::string::npos)
+        << flags.nasm;
+    EXPECT_EQ(flags.nasm.find("-idirafter"), std::string::npos) << flags.nasm;
+}
+
 // #249: a compile unit's localIncludeDirsAfter emit as -idirafter into the
 // same $local_includes variable, APPENDED after the -I entries. -idirafter
 // dirs are searched after the toolchain's system dirs (gcc+clang), so a dep


### PR DESCRIPTION
## Summary

`compile_commands.json` 在 Windows 上对多段 glob 源(`generated/modules/**/*.cppm`)输出混合分隔符路径 `...\generated/modules\x.cppm`,CLion 无法解析。根因:MSVC 的 `std::filesystem::path` 保留输入 `/` 原样,`glob_literal_prefix` 用原始 glob 串构造 path 后,`root / prefix` 与目录迭代把混合形式传入 `CompileUnit::source` → CDB 的 `file`/`-c`(ninja 因一律 `generic_string()` 不受影响)。

### 修复(含 review 补全)

- **摄入点归一化**(收敛同一决策的全部推导,不依赖「摄入点找全」):
  - `modgraph/glob.cppm` 新增 `native_path_from_generic`(`make_preferred` 实现),应用于 `glob_literal_prefix` / `expand_dir_glob` 快速路径 / `scan_one_into` 绝对源分支
  - `directives.cppm::abs_against`(build.mcpp 指令路径;归一化会改写拼写 → 声明输入指纹一次性失效 → 一次多余重建,预期行为)
  - `plan.cppm::expand_manifest_include_entry`(绝对分支 + `generated/` 裸拼接回退 —— 正是 #390 场景;该函数从匿名命名空间提出并导出以供单测)
  - `scanner.cppm::rewrite_rel_copy`(`[build] cxxflags = ["-Ithird_party/inc"]` 通道)
  - `flags.cppm` `[build] include_dirs` 全局 cxxflags 通道
  - include_dirs 绝对分支直接 `make_preferred`,不再 `generic_string()` 窄串往返(ANSI 代码页拼不出的名字会抛,mcpp#230)
- **emitter 兜底**:`emit_compile_commands` 对 `file` / `directory` / `-c` / `-o` / `-I` 统一 `make_preferred`,对 CDB 契约给出无条件保证。
- **P2 合并去重自愈**:`merge_compile_commands` 去重键改为归一化路径(`lexically_normal` + `make_preferred`),旧 CDB 的混合拼写与 fresh 原生拼写视为同一文件 → 升级后第一次真正重建即自愈,无需手删 CDB。已在注入旧条目的工程上实测(重建后混合条目归零)。
- 引号问题由 8.8.4 修复(#385),本 PR 不再重复,但为其补了 jq 无关的 e2e 47 回归断言。

### 测试

- 单测 +4:`NormalizedFileKeysHealStaleSeparatorSpellings`(合并自愈)、`EmittedPathsUseNativeSeparators`(emitter 兜底)、`Plan.ExpandManifestIncludeEntryNativeSpelling`、`Scanner.RelativeIncludeFlagsAbsolutized` 平台化;另更新受归一化影响的既有断言(build_flags / ninja_backend)。
- e2e 76:多段 glob 源 + `extra.cpp` 必须入 CDB 的 grep 守卫 + 平台无关混合分隔符断言(消掉 `os.name` 依赖,避免 MSYS python 假绿)+ python3 缺失时显式 SKIP。
- 实测:cmscript 重建后 9 个混合分隔符条目与 38 个带引号参数全部归零;带旧 CDB 的注入工程重建后混合条目归零。

Closes #390

## Test plan

- [x] `mcpp build` 自举成功(Windows, clang)
- [x] `mcpp test`:68/68 通过(含新增单测)
- [x] e2e 47、76 通过(76 的 python 校验段本机用 `python` 复核正/反两例)
- [ ] CI(linux / macOS / windows)e2e 与单测待跑
