### PR TITLE
fix: E0006 Upgrade 提示按安装布局区分 + AUR 特别关照（bump 至 v2026.8.8.4、新增 mcpp-git）

### DIFF
--- a/scripts/aur/README.md
+++ b/scripts/aur/README.md
@@ -1,18 +1,20 @@
 # AUR packaging
 
-Arch Linux packaging for mcpp. Two packages, same runtime layout:
+Arch Linux packaging for mcpp. Three packages, same runtime layout:
 
 | Package | What it installs | Pick it when |
 | --- | --- | --- |
 | [`mcpp-bin`](mcpp-bin/) | the **prebuilt** release binary (what [`install.sh`](../../install.sh) downloads) | you just want mcpp, fast |
-| [`mcpp-m`](mcpp-m/) | mcpp **built from source**, bootstrapped with `mcpp-bin` | you want a from-source build |
+| [`mcpp-m`](mcpp-m/) | mcpp **built from source**, bootstrapped with `mcpp-bin` | you want a from-source build of a release |
+| [`mcpp-git`](mcpp-git/) | mcpp **built from the git master**, bootstrapped with `mcpp-bin` | you want to track master (rolling) and never lag the index floor |
 
 ```sh
 yay -S mcpp-bin      # prebuilt
 yay -S mcpp-m        # from source (pulls mcpp-bin as a build dep)
+yay -S mcpp-git      # from git master (pulls mcpp-bin as a build dep)
 ```
 
-The two `conflict` with each other, so only one can be installed at a time.
+The three `conflict` with each other, so only one can be installed at a time.
 Supported architectures: `x86_64`, `aarch64`.
 
 ### Why not just `mcpp`?
@@ -20,9 +22,10 @@ Supported architectures: `x86_64`, `aarch64`.
 The name `mcpp` is already taken by **`extra/mcpp`** — Matsui's C preprocessor,
 an unrelated long-standing official Arch package that owns `/usr/bin/mcpp`. The
 AUR refuses to host any package whose `pkgname` (or `provides`) collides with an
-official-repo package, so our packages are `mcpp-bin` / `mcpp-m`. They still
-install the `mcpp` command at `/usr/bin/mcpp`, so both `conflicts=('mcpp')` with
-that preprocessor — you can have our mcpp or the preprocessor, not both.
+official-repo package, so our packages are `mcpp-bin` / `mcpp-m` / `mcpp-git`.
+They still install the `mcpp` command at `/usr/bin/mcpp`, so all three
+`conflicts=('mcpp')` with that preprocessor — you can have our mcpp or the
+preprocessor, not both.
 
 ## Layout & why the wrapper exists
 
@@ -52,30 +55,39 @@ user already exported, so a custom home or xlings still works.
 First `mcpp build`/`mcpp run` bootstraps the sandbox (downloads ninja, patchelf
 and the default toolchain into `~/.mcpp`) — expected, and only once per user.
 
-### How the `mcpp-m` source package builds
+### How the `mcpp-m` / `mcpp-git` source packages build
 
-mcpp is self-hosting. The `mcpp-m` PKGBUILD uses the installed `mcpp-bin` as the
-bootstrap compiler and runs `mcpp build --target <arch>-linux-musl` — the same
+mcpp is self-hosting. Both source PKGBUILDs use the installed `mcpp-bin` as the
+bootstrap compiler and run `mcpp build --target <arch>-linux-musl` — the same
 path [`release.yml`](../../.github/workflows/release.yml) ships. mcpp downloads
 its own pinned toolchain (it does **not** use the host gcc), so the build needs
 network access, like the upstream release build.
+
+`mcpp-m` builds a pinned release tarball; `mcpp-git` checks out `master` from
+the official repo (`source = mcpp::git+…`, `sha256sums = SKIP`) and derives a
+monotonic `pkgver` from `git describe` (tag + commit distance). Because it
+tracks master, `mcpp-git` can never lag the index floor the way `mcpp-bin` does
+between releases — at the cost of tracking bleeding-edge master.
 
 ## Files
 
 ```
 scripts/aur/
   README.md            this file
-  update.sh            bump BOTH packages to a release version
+  update.sh            bump the release-pinned packages (mcpp-bin, mcpp-m)
   mcpp-bin/{PKGBUILD, .SRCINFO, mcpp.sh}
   mcpp-m/{PKGBUILD, .SRCINFO, mcpp.sh}
+  mcpp-git/{PKGBUILD, .SRCINFO, mcpp.sh}
 ```
 
-`mcpp.sh` is identical in both dirs (each AUR repo must be self-contained);
-`update.sh` keeps them in sync.
+`mcpp.sh` is identical in all three dirs (each AUR repo must be self-contained);
+`update.sh` keeps `mcpp-bin`/`mcpp-m` in sync. `mcpp-git` has no checksums to
+bump (VCS source) and is not touched by `update.sh`.
 
 ## Releasing a new version
 
-After a GitHub release is published (and mirrored), bump both packages:
+After a GitHub release is published (and mirrored), bump the release-pinned
+packages (`mcpp-bin`, `mcpp-m`; `mcpp-git` tracks master and needs no bump):
 
 ```sh
 scripts/aur/update.sh            # uses [package].version from mcpp.toml

--- a/scripts/aur/mcpp-bin/.SRCINFO
+++ b/scripts/aur/mcpp-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = mcpp-bin
 	pkgdesc = Modern C++ build & package management tool (prebuilt binary)
-	pkgver = 0.0.65
+	pkgver = 2026.8.8.4
 	pkgrel = 1
 	url = https://github.com/mcpp-community/mcpp
 	arch = x86_64
@@ -12,9 +12,9 @@ pkgbase = mcpp-bin
 	options = !strip
 	source = mcpp.sh
 	sha256sums = SKIP
-	source_x86_64 = mcpp-0.0.65-linux-x86_64.tar.gz::https://github.com/mcpp-community/mcpp/releases/download/v0.0.65/mcpp-0.0.65-linux-x86_64.tar.gz
-	sha256sums_x86_64 = 0d1d16aae05e4d7c59a00a2621abc4b99421b9821d2145c139fabf95fcf93409
-	source_aarch64 = mcpp-0.0.65-linux-aarch64.tar.gz::https://github.com/mcpp-community/mcpp/releases/download/v0.0.65/mcpp-0.0.65-linux-aarch64.tar.gz
-	sha256sums_aarch64 = 20dd7a8be657bf2e32dcffcf10b758e34fe740fcdb1ceb374822d5ee25cb4a52
+	source_x86_64 = mcpp-2026.8.8.4-linux-x86_64.tar.gz::https://github.com/mcpp-community/mcpp/releases/download/v2026.8.8.4/mcpp-2026.8.8.4-linux-x86_64.tar.gz
+	sha256sums_x86_64 = a8f30fc73fae75381cdd734d204e6c04a24c55365cdf8bb6da07c3aa663c8f9f
+	source_aarch64 = mcpp-2026.8.8.4-linux-aarch64.tar.gz::https://github.com/mcpp-community/mcpp/releases/download/v2026.8.8.4/mcpp-2026.8.8.4-linux-aarch64.tar.gz
+	sha256sums_aarch64 = e0d63de0f6e0111f47df00e9135baf437aed2bcdb883dbb658880d9ee4418e27
 
 pkgname = mcpp-bin

--- a/scripts/aur/mcpp-bin/PKGBUILD
+++ b/scripts/aur/mcpp-bin/PKGBUILD
@@ -5,7 +5,7 @@
 # how this is published to the AUR and how to bump it (scripts/aur/update.sh).
 
 pkgname=mcpp-bin
-pkgver=0.0.65
+pkgver=2026.8.8.4
 pkgrel=1
 pkgdesc="Modern C++ build & package management tool (prebuilt binary)"
 arch=('x86_64' 'aarch64')
@@ -28,8 +28,8 @@ source_aarch64=("mcpp-${pkgver}-linux-aarch64.tar.gz::${_relbase}/mcpp-${pkgver}
 source=("mcpp.sh")
 
 sha256sums=('SKIP')
-sha256sums_x86_64=('0d1d16aae05e4d7c59a00a2621abc4b99421b9821d2145c139fabf95fcf93409')
-sha256sums_aarch64=('20dd7a8be657bf2e32dcffcf10b758e34fe740fcdb1ceb374822d5ee25cb4a52')
+sha256sums_x86_64=('a8f30fc73fae75381cdd734d204e6c04a24c55365cdf8bb6da07c3aa663c8f9f')
+sha256sums_aarch64=('e0d63de0f6e0111f47df00e9135baf437aed2bcdb883dbb658880d9ee4418e27')
 
 package() {
     local _src="${srcdir}/mcpp-${pkgver}-linux-${CARCH}"

--- a/scripts/aur/mcpp-git/.SRCINFO
+++ b/scripts/aur/mcpp-git/.SRCINFO
@@ -1,0 +1,21 @@
+pkgbase = mcpp-git
+	pkgdesc = Modern C++ build & package management tool (git master)
+	pkgver = 2026.8.8.4
+	pkgrel = 1
+	url = https://github.com/mcpp-community/mcpp
+	arch = x86_64
+	arch = aarch64
+	license = Apache-2.0
+	makedepends = mcpp-bin
+	makedepends = git
+	depends = git
+	conflicts = mcpp-bin
+	conflicts = mcpp-m
+	conflicts = mcpp
+	options = !strip
+	source = mcpp::git+https://github.com/mcpp-community/mcpp.git
+	source = mcpp.sh
+	sha256sums = SKIP
+	sha256sums = SKIP
+
+pkgname = mcpp-git

--- a/scripts/aur/mcpp-git/PKGBUILD
+++ b/scripts/aur/mcpp-git/PKGBUILD
@@ -1,19 +1,24 @@
 # Maintainer: mcpp-community <x.d2learn.org@gmail.com>
 #
-# mcpp-m — mcpp built from source, bootstrapped with the prebuilt `mcpp-bin`.
-# mcpp is self-hosting: the mcpp-bin compiler builds this release's own
-# source (the same `mcpp build --target <arch>-linux-musl` path release.yml
-# ships). For the prebuilt-only package, install `mcpp-bin` instead.
+# mcpp-git — mcpp built from the upstream git repository (rolling master),
+# bootstrapped with the prebuilt `mcpp-bin`. Same self-hosted build as
+# `mcpp-m`, but tracks master instead of a pinned release — so it can never
+# lag the index floor (E0006) the way `mcpp-bin` does between releases.
+#
+# Rolling master is bleeding-edge: prefer `mcpp-bin` for stable use.
 #
 # NB: the AUR/official name `mcpp` is taken by Matsui's C preprocessor
-# (extra/mcpp), so this package is `mcpp-m`. It still installs the `mcpp`
+# (extra/mcpp), so this package is `mcpp-git`. It still installs the `mcpp`
 # command at /usr/bin/mcpp, hence the conflict with that preprocessor.
 # See scripts/aur/README.md.
 
-pkgname=mcpp-m
+pkgname=mcpp-git
+# Static seed only — real builds override it via pkgver() below. Kept at the
+# current release so the AUR listing doesn't look ancient; actual version is
+# whatever master reports at build time.
 pkgver=2026.8.8.4
 pkgrel=1
-pkgdesc="Modern C++ build & package management tool (built from source)"
+pkgdesc="Modern C++ build & package management tool (git master)"
 arch=('x86_64' 'aarch64')
 url="https://github.com/mcpp-community/mcpp"
 license=('Apache-2.0')
@@ -22,23 +27,33 @@ depends=('git')
 # mcpp-bin is the bootstrap compiler; it also supplies the bundled xlings we
 # ship at runtime. git is needed for toolchain/index sync during the build.
 makedepends=('mcpp-bin' 'git')
-# mcpp-bin = same tool (mutually exclusive); mcpp = the C preprocessor that
-# also owns /usr/bin/mcpp.
-conflicts=('mcpp-bin' 'mcpp')
+# mcpp-bin / mcpp-m = the same tool (mutually exclusive); mcpp = the C
+# preprocessor that also owns /usr/bin/mcpp.
+conflicts=('mcpp-bin' 'mcpp-m' 'mcpp')
 # We strip the built ELF ourselves; don't let makepkg re-strip the vendored
 # xlings binary (a prebuilt third-party artifact).
 options=('!strip')
 
-source=("mcpp-${pkgver}.tar.gz::https://github.com/mcpp-community/mcpp/archive/v${pkgver}.tar.gz"
+source=("mcpp::git+https://github.com/mcpp-community/mcpp.git"
         "mcpp.sh")
-sha256sums=('07f8233d3f18565c52607816a82c9facda3a7ed11c67d3772e42bd84cb54476a'
+sha256sums=('SKIP'
             'SKIP')
+
+# Rolling master has no stable release number. Pacman only needs a
+# monotonically increasing pkgver, so derive one from the closest tag plus the
+# commit distance (AUR -git convention): v2026.8.8.4-5-g<hash> →
+# 2026.8.8.4.5.g<hash>. The binary's own version comes from the checked-out
+# source (src/version.cppm), independent of pkgver.
+pkgver() {
+    cd "${srcdir}/mcpp"
+    git describe --long --tags | sed 's/^v//; s/-/./g'
+}
 
 # mcpp downloads its own pinned toolchain (gcc/ninja/patchelf) into the build
 # sandbox — it does not use the host gcc. This needs network access at build
 # time, like the upstream release build.
 build() {
-    cd "${srcdir}/mcpp-${pkgver}"
+    cd "${srcdir}/mcpp"
 
     case "$CARCH" in
         x86_64)  _target=x86_64-linux-musl  ;;
@@ -67,15 +82,15 @@ build() {
 }
 
 package() {
-    # Same /opt + wrapper layout as mcpp-bin (see scripts/aur/README.md for
-    # why the per-user wrapper exists instead of a /usr/bin symlink).
+    # Same /opt + wrapper layout as mcpp-bin / mcpp-m (see scripts/aur/README.md
+    # for why the per-user wrapper exists instead of a /usr/bin symlink).
     install -Dm755 "${srcdir}/stage/bin/mcpp"            "${pkgdir}/opt/mcpp/bin/mcpp"
     install -Dm755 "${srcdir}/stage/registry/bin/xlings" "${pkgdir}/opt/mcpp/registry/bin/xlings"
 
     install -Dm755 "${srcdir}/mcpp.sh" "${pkgdir}/usr/bin/mcpp"
 
-    install -Dm644 "${srcdir}/mcpp-${pkgver}/LICENSE" \
+    install -Dm644 "${srcdir}/mcpp/LICENSE" \
         "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
-    install -Dm644 "${srcdir}/mcpp-${pkgver}/README.md" \
+    install -Dm644 "${srcdir}/mcpp/README.md" \
         "${pkgdir}/usr/share/doc/${pkgname}/README.md"
 }

--- a/scripts/aur/mcpp-git/mcpp.sh
+++ b/scripts/aur/mcpp-git/mcpp.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# mcpp launcher (Arch / AUR mcpp-bin package).
+#
+# The AUR package installs mcpp's self-contained tree read-only under
+# /opt/mcpp (shared by every user). But mcpp WRITES its registry sandbox,
+# BMI/metadata caches, logs and downloaded toolchains into MCPP_HOME at
+# runtime — that has to be a per-user, writable location, never /opt.
+#
+# mcpp resolves MCPP_HOME from the binary's real path (/proc/self/exe, which
+# resolves symlinks), so a plain /usr/bin symlink would make MCPP_HOME land in
+# the root-owned /opt tree and every command would fail to write. This wrapper
+# fixes that by pinning the two env knobs the binary honors:
+#
+#   MCPP_HOME            — per-user home (default ~/.mcpp, same as install.sh)
+#   MCPP_VENDORED_XLINGS — the bundled xlings under /opt, which mcpp copies
+#                          into $MCPP_HOME/registry/bin/xlings on first run
+#
+# Both respect a value the user already exported, so power users can still
+# point mcpp at a custom home or xlings.
+set -eu
+
+MCPP_OPT="/opt/mcpp"
+
+export MCPP_HOME="${MCPP_HOME:-$HOME/.mcpp}"
+export MCPP_VENDORED_XLINGS="${MCPP_VENDORED_XLINGS:-$MCPP_OPT/registry/bin/xlings}"
+
+exec "$MCPP_OPT/bin/mcpp" "$@"

--- a/scripts/aur/mcpp-m/.SRCINFO
+++ b/scripts/aur/mcpp-m/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = mcpp-m
 	pkgdesc = Modern C++ build & package management tool (built from source)
-	pkgver = 0.0.65
+	pkgver = 2026.8.8.4
 	pkgrel = 1
 	url = https://github.com/mcpp-community/mcpp
 	arch = x86_64
@@ -12,7 +12,7 @@ pkgbase = mcpp-m
 	conflicts = mcpp-bin
 	conflicts = mcpp
 	options = !strip
-	source = mcpp-0.0.65.tar.gz::https://github.com/mcpp-community/mcpp/archive/v0.0.65.tar.gz
+	source = mcpp-2026.8.8.4.tar.gz::https://github.com/mcpp-community/mcpp/archive/v2026.8.8.4.tar.gz
 	source = mcpp.sh
 	sha256sums = 07f8233d3f18565c52607816a82c9facda3a7ed11c67d3772e42bd84cb54476a
 	sha256sums = SKIP

--- a/src/pm/index_contract.cppm
+++ b/src/pm/index_contract.cppm
@@ -21,6 +21,7 @@ export module mcpp.pm.index_contract;
 
 import std;
 import mcpp.libs.toml;
+import mcpp.platform.fs;          // self_exe_path (distro-layout detection)
 import mcpp.version_req;
 import mcpp.version;                 // MCPP_VERSION (leaf — see that module)
 
@@ -43,6 +44,13 @@ read_index_contract(const std::filesystem::path& indexRoot);
 // client by being malformed).
 std::optional<std::string>
 floor_violation(std::string_view minMcpp, std::string_view ownVersion);
+
+// Pure: E0006 message with the Upgrade advice suited to the install layout
+// (`distroManaged` is detected once by the caller via self_exe_path). The
+// plain one-liner misleads users of the other install methods — an AUR install
+// plus the install.sh command installs a second copy that does not update the
+// running binary.
+std::string e0006_message(std::string violation, bool distroManaged);
 
 // Pure predicate — no reporting, no registration, no dedup. For callers that
 // need to ask "would this tree be usable?" without the side effects of
@@ -118,6 +126,26 @@ read_index_contract(const std::filesystem::path& indexRoot)
     return c;
 }
 
+// Upgrade advice embedded in the E0006 message. mcpp supports several install
+// methods (xlings is the recommended default; install.sh / AUR / Homebrew are
+// alternatives), and each lands in a different place. A single hardcoded
+// one-liner misleads users of the other methods — e.g. an AUR install plus the
+// install.sh command installs a SECOND copy that does not update the running
+// binary. So the message names the method and how to upgrade IT.
+namespace {
+constexpr std::string_view kInstallShUpgrade =
+    "  Upgrade:  re-run the install.sh one-liner\n"
+    "             curl -fsSL https://github.com/mcpp-community/mcpp/"
+    "releases/latest/download/install.sh | bash\n";
+constexpr std::string_view kDistroUpgrade =
+    "  Upgrade:  this is a distro-managed install (AUR) — update the package\n"
+    "             with your AUR helper (e.g. 'paru -Syu mcpp-bin' or\n"
+    "             'yay -Syu mcpp-bin'). The install.sh one-liner installs a\n"
+    "             separate copy and will NOT update this one.\n";
+constexpr std::string_view kXlingsUpgrade =
+    "  Upgrade:  'xlings update mcpp' (recommended default installer)\n";
+} // namespace
+
 std::optional<std::string>
 floor_violation(std::string_view minMcpp, std::string_view ownVersion)
 {
@@ -128,11 +156,37 @@ floor_violation(std::string_view minMcpp, std::string_view ownVersion)
     if (*have >= *need) return std::nullopt;
     return std::format(
         "index requires mcpp >= {} but this is mcpp {} [E0006]\n"
-        "  Upgrade:  curl -fsSL https://github.com/mcpp-community/mcpp/"
-        "releases/latest/download/install.sh | bash\n"
+        "{}"
         "  Details:  mcpp explain E0006   "
         "(override for debugging: MCPP_INDEX_FLOOR=ignore)",
-        minMcpp, ownVersion);
+        minMcpp, ownVersion, kInstallShUpgrade);
+}
+
+// Pure: swap the Upgrade advice for the install layout the caller detected.
+std::string e0006_message(std::string violation, bool distroManaged)
+{
+    if (distroManaged) {
+        auto pos = violation.find(kInstallShUpgrade);
+        if (pos != std::string::npos)
+            violation.replace(pos, kInstallShUpgrade.size(), kDistroUpgrade);
+    }
+    // Append the recommended installer note to every layout.
+    violation += kXlingsUpgrade;
+    return violation;
+}
+
+// Impure (reads /proc/self/exe): true when the running binary sits under the
+// distro-managed tree (/opt/mcpp — the AUR layout). install.sh / xlings
+// installs keep the binary inside $MCPP_HOME (~/.mcpp) instead.
+bool distro_managed_install()
+{
+#if defined(_WIN32) || defined(__APPLE__)
+    return false;
+#else
+    std::error_code ec;
+    auto self = mcpp::platform::fs::self_exe_path();
+    return self.string().find("/opt/mcpp/") != std::string::npos;
+#endif
 }
 
 bool index_usable(const std::filesystem::path& indexRoot)
@@ -192,15 +246,17 @@ check_index_floor(const std::filesystem::path& indexRoot)
     auto violation = floor_violation(c->minMcpp, mcpp::MCPP_VERSION);
     if (!violation) return std::nullopt;
 
+    auto message = e0006_message(*violation, distro_managed_install());
+
     // Record BEFORE the dedup return: the fact must be queryable no matter how
     // many times this root is opened, while the message is printed only once.
     // Deriving "was anything unusable?" from "did we print?" is what made the
     // second and later reads indistinguishable from an ordinary miss.
     if (!index_marked_unusable(indexRoot))
-        unusable_registry().push_back({indexRoot, *violation});
+        unusable_registry().push_back({indexRoot, message});
     else
         return std::nullopt;          // already reported — stay quiet
-    return violation;
+    return message;
 }
 
 } // namespace mcpp::pm

--- a/tests/unit/test_index_contract.cpp
+++ b/tests/unit/test_index_contract.cpp
@@ -14,6 +14,31 @@ TEST(IndexContract, FloorViolationOrdering) {
     EXPECT_NE(v->find("0.0.85"), std::string::npos);
 }
 
+// The Upgrade advice must tell the user which install method THEY have. A
+// single hardcoded install.sh one-liner misleads distro (AUR) users into
+// installing a second copy that does not update the running binary.
+TEST(IndexContract, E0006MessageSwitchesUpgradeAdviceByLayout) {
+    using mcpp::pm::floor_violation;
+    using mcpp::pm::e0006_message;
+    auto violation = floor_violation("2026.8.3.3", "2026.7.28.2");
+    ASSERT_TRUE(violation.has_value());
+
+    // Non-distro (install.sh / xlings) layout keeps the install.sh one-liner
+    // and always appends the recommended-installer note.
+    auto script = e0006_message(*violation, /*distroManaged=*/false);
+    EXPECT_NE(script.find("install.sh"), std::string::npos);
+    EXPECT_EQ(script.find("distro-managed"), std::string::npos);
+    EXPECT_NE(script.find("xlings update mcpp"), std::string::npos);
+    EXPECT_NE(script.find("E0006"), std::string::npos);
+
+    // Distro (AUR) layout swaps in the package-manager advice.
+    auto distro = e0006_message(*violation, /*distroManaged=*/true);
+    EXPECT_NE(distro.find("distro-managed"), std::string::npos);
+    EXPECT_EQ(distro.find("re-run the install.sh one-liner"), std::string::npos);
+    EXPECT_NE(distro.find("xlings update mcpp"), std::string::npos);
+    EXPECT_NE(distro.find("E0006"), std::string::npos);
+}
+
 // The floor compares mcpp's OWN version, so the date scheme (YYYY.M.D.N) has
 // to be ordered on all four segments. While parse_version truncated at three,
 // every release of a given day compared equal and the floor let a too-old mcpp


### PR DESCRIPTION
## 摘要

E0006 的 `Upgrade:` 提示只给一个写死的 `install.sh` 命令，对其它安装方式（AUR）有误导：已装 `mcpp-bin` 的用户照做会在 `~/.mcpp` 装出**第二份**，且 `install.sh` 不会更新 `/opt/mcpp` 里正在运行的那份二进制——"更新无效"的错觉（详见 #394）。

本 PR 让提示按**安装布局**给出正确指引，并顺带给 Arch 用户一份"特别关照"：

## 改动 1：E0006 提示按安装布局区分（`src/pm/index_contract.cppm`）

- 用 `self_exe_path()` 检测二进制是否落在发行版管理目录（`/opt/mcpp`，即 AUR 布局）；
- 是 → 提示改用 AUR helper 更新（`paru -Syu mcpp-bin` 或 `yay -Syu mcpp-bin`），并说明 install.sh 装的是另一份、不会更新这份；
- 否（install.sh / xlings）→ 保持原 install.sh 提示（输出不变）；
- 两种布局**都追加**推荐默认安装器注记：`'xlings update mcpp' (recommended default installer)`；
- 纯函数 `floor_violation` 契约不变；新增导出纯函数 `e0006_message(violation, distroManaged)`，便于单测。

测试：`tests/unit/test_index_contract.cpp` 新增 `E0006MessageSwitchesUpgradeAdviceByLayout`；`mcpp test` 全量 68/68 通过。

## 改动 2：AUR 特别关照 😋（`scripts/aur/`）

- **bump `mcpp-bin` / `mcpp-m` 至 v2026.8.8.4**（经 `update.sh`，真实 sha256）——消除"低于索引下限"导致的 E0006；
- **新增 `mcpp-git`**（VCS 包，`source` 直接拉官方仓库 master，复用 `mcpp-m` 的 `mcpp-bin` 自举骨架与 `/opt`+wrapper 布局）——滚动跟踪 master，永不滞后；`pkgver()` 用 `git describe` 取 tag+提交距离；
- `scripts/aur/README.md` 同步文档（三包布局、`mcpp-git` 说明、`update.sh` 只负责 release-pinned 包）。

> 建议（可选）：AUR 可考虑正式收录 `mcpp-git`，作为 `mcpp-bin` 滞后期的滚动选项——想尝鲜的滚动玩家用之，稳定用户继续 `mcpp-bin`。

tips: 我就是想尝鲜的滚动玩家之一 😋

## 相关

- Fixes #394
