### PR TITLE
test(e2e): stop the wine teardown from failing a passing test

### DIFF
--- a/tests/e2e/102_mingw_cross_wine.sh
+++ b/tests/e2e/102_mingw_cross_wine.sh
@@ -9,7 +9,28 @@
 set -e
 
 TMP=$(mktemp -d)
-trap "rm -rf $TMP" EXIT
+
+# `wine` leaves a wineserver running after the process it launched exits, and
+# that server keeps writing into $WINEPREFIX. A plain `rm -rf` in the EXIT trap
+# therefore races it and can fail with "Directory not empty" — AFTER the test
+# has already printed OK. Under `set -e` that failing trap becomes the script's
+# exit status, so a passing test reports as a red job (observed on main at
+# 0006ce6, run 31336526583: the log ends `OK` then `rm: cannot remove
+# '…/wineprefix': Directory not empty`).
+#
+# So: shut the server down first and wait for it, and never let cleanup decide
+# the verdict. By the time this runs the verdict is already printed; a failure
+# to delete a temp directory is not a statement about mcpp.
+cleanup() {
+    local status=$?
+    if [[ -n "${WINEPREFIX:-}" ]] && command -v wineserver >/dev/null 2>&1; then
+        wineserver -k >/dev/null 2>&1 || true
+        wineserver -w >/dev/null 2>&1 || true
+    fi
+    rm -rf "$TMP" 2>/dev/null || true
+    return $status
+}
+trap cleanup EXIT
 cd "$TMP"
 
 "$MCPP" new crosswin


### PR DESCRIPTION
`cross-build-test` 在 main 的 `0006ce6` 上是红的（run [31336526583](https://github.com/mcpp-community/mcpp/actions/runs/31336526583/job/93303185689)），日志结尾是：

```
OK
rm: cannot remove '/tmp/tmp.XgyezkVtrY/wineprefix': Directory not empty
```

**测试是过的。** `wine` 在它启动的进程退出之后仍然留着一个 wineserver，而那个 server 会继续往 `$WINEPREFIX` 里写，于是 EXIT trap 里的 `rm -rf` 和它抢。在 `set -e` 下，trap 的非零状态变成脚本的退出码 —— 一个绿的测试因此报成红的 job，而它报的还是一个临时目录的事，不是 mcpp 的事。

改法：删之前先关掉 wineserver 并等它退出；同时让清理**保留测试已经挣到的状态**。清理跑在结论打印之后，它没有资格改结论。

全仓只有这一个测试用 `WINEPREFIX`。