### PR TITLE
fix(diagnostics): stop promising a remedy that does not work (2026.8.15.3)

### DIFF
--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "2026.8.15.2"
+version     = "2026.8.15.3"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/platform/runtime_binding.cppm
+++ b/src/platform/runtime_binding.cppm
@@ -284,7 +284,8 @@ resolve_runtime_binding(
             "       Where the C runtime comes from a payload, there is now no "
             "declared runtime to bind to — mcpp declines to guess a version, so "
             "the link falls back to the host and the hermeticity check will say "
-            "so. `xlings self update` writes the block.",
+            "so. Only a SubOS created by a current xlings carries the block "
+            "(openxlings/xlings#547).",
             selection.subosName,
             info.note.empty() ? "no `subos_info` block" : info.note));
     } else if (info.schema > mcpp::xlings::subos::kSupportedSchema) {

--- a/src/platform/xlings/subos_info.cppm
+++ b/src/platform/xlings/subos_info.cppm
@@ -146,8 +146,10 @@ Info read(const std::filesystem::path& subosDir) {
         info.note = std::format(
             "subos '{}' does not describe itself (no `{}` block), so programs "
             "run from here get no environment it declares — a GL application "
-            "will not find its drivers. A newer xlings writes this block; "
-            "`xlings self update` adds it",
+            "will not find its drivers. A SubOS created by a current xlings "
+            "carries it; an existing one is NOT backfilled by `self update` or "
+            "`self doctor --fix` (openxlings/xlings#547), so recreating the "
+            "SubOS is what supplies it today",
             subosDir.string(), kBlock);
         return info;
     }

--- a/src/toolchain/lifecycle.cppm
+++ b/src/toolchain/lifecycle.cppm
@@ -615,8 +615,10 @@ export int toolchain_install(const mcpp::config::GlobalConfig& cfg,
             // the install itself succeeded.
             mcpp::ui::warning(std::format(
                 "installed, but not bound to a C runtime: {}.\n"
-                "         Run `xlings self update` to write the SubOS "
-                "description, then re-run this command to complete the wiring.",
+                "         The install itself succeeded. To complete the wiring, "
+                "use a SubOS created by a current xlings — an existing one is "
+                "not backfilled (openxlings/xlings#547) — then re-run this "
+                "command.",
                 fixed->skippedReason));
         }
 

--- a/src/version.cppm
+++ b/src/version.cppm
@@ -31,6 +31,6 @@ import std;
 
 export namespace mcpp {
 
-inline constexpr std::string_view MCPP_VERSION = "2026.8.15.2";
+inline constexpr std::string_view MCPP_VERSION = "2026.8.15.3";
 
 } // namespace mcpp

--- a/tests/unit/test_post_install.cpp
+++ b/tests/unit/test_post_install.cpp
@@ -160,8 +160,8 @@ TEST(PostInstallFixup, ADeclaredRuntimeThatCannotBeHonouredStillFails) {
 // No marker may be written for a fixup that did not happen. The marker is a
 // content fingerprint whose whole job is to answer "were these inputs ever
 // applied"; one written for "we did nothing" reads back as "already applied",
-// and the fixup would then never run again — including on the day the user runs
-// `xlings self update` and the identity finally becomes knowable.
+// and the fixup would then never run again — including on the day the user
+// moves to a SubOS that does describe itself and the identity becomes knowable.
 TEST(PostInstallFixup, ASkippedFixupLeavesNoMarkerBehind) {
     if constexpr (!mcpp::platform::is_linux) {
         GTEST_SKIP() << "the runtime binding gate is Linux-only";


### PR DESCRIPTION
2026.8.15.2 的沙箱真实验证抓到的 —— 它修好了 #427 的硬失败,于是那条降级建议**第一次
真正被用户看到**,也第一次被验证:**它不管用**。

同一个沙箱实测:

```
xlings self update          # 2026.7.27.3 -> 2026.8.14.1
→ subos_info 仍然不存在
xlings self doctor --fix    # ▸ healed 129
→ subos_info 仍然不存在
```

`xlings subos` 没有 repair / refresh 子命令(`new use list remove info stop`),
所以**已存在的 SubOS 没有任何受支持的途径拿到这个块**。新版 xlings 只在**创建**
SubOS 时写它,不回填。已开 openxlings/xlings#547。

三处措辞改为陈述事实并指向该 issue:

* `subos_info.cppm` 的 note
* `runtime_binding.cppm` 的降级说明
* `lifecycle.cppm` 的安装后提示

⚠️ 这句话不是新加的 —— 它出自 xlings 写进块里的原始措辞,mcpp 一直在转述。
**把「上游这么说」当成「这是对的」转述给用户,和自己写错一样。**

## 2026.8.15.2 的验证结论(供参考)

| 项 | 结果 |
|---|---|
| #427 沙箱硬失败 | ✅ 消失,构建推进到真正的位置,诊断链完整(原因 → 后果 → 补救) |
| #426 纯 C 共享库 | ✅ `NEEDED` 只剩 `libc.so.6`,规则为 `c_shared` |
| 正常 C++ 路径 | ✅ `mcpp run` → `eco-ok` |
| 两端镜像资产 | ✅ GitHub / GitCode 四件逐字节相同 |