### PR TITLE
test(e2e): 239 could pass or skip, never fail

### DIFF
--- a/tests/e2e/239_msvc_managed_toolset.sh
+++ b/tests/e2e/239_msvc_managed_toolset.sh
@@ -36,16 +36,30 @@ restore() {
 trap restore EXIT
 cd "$TMP"
 
-# 1) install it. This runs BEFORE the discoverability check below, so that a
-#    runner which cannot reach the index skips instead of failing an assertion
-#    about a list the index would have filled in.
+# 0) Decide SKIP here, from a positive check, and never again.
+#
+#    ⚠️ This used to be decided AFTER the install by pattern-matching the
+#    failure text, and one of the patterns was `*"index"*`. Nearly every mcpp
+#    command prints "package index" somewhere, so every genuine install
+#    failure took the skip branch: the test could pass or skip, never fail.
+#
+#    It hid a real one. `tar -xf "C:\...vsix"` fails under GNU tar, which
+#    reads `C:` as a hostname ("Cannot connect to C: resolve failed"); the
+#    install ran for 135 seconds, failed, and this script reported PASS.
+#
+#    A skip has to be decided by what is ABSENT before the work starts, not by
+#    what the failure looked like afterwards.
+if ! "$MCPP" toolchain list 2>&1 | grep -qi "msvc"; then
+    echo "SKIP: this index offers no msvc toolset (offline runner?)"
+    exit 0
+fi
+
+# 1) install it. Any failure from here on is a FAILURE.
 rc=0; out=$("$MCPP" toolchain install msvc "$TOOLSET" 2>&1) || rc=$?
 if [[ $rc -ne 0 ]]; then
-    case "$out" in
-        *"index"*|*"network"*|*"resolve"*|*"offline"*|*"connect"*|*"not found"*)
-            echo "SKIP: xim:msvc@$TOOLSET unreachable: $out"; exit 0 ;;
-        *)  echo "FAIL: install msvc $TOOLSET: $out"; exit 1 ;;
-    esac
+    echo "FAIL: install msvc $TOOLSET (rc=$rc):"
+    echo "$out"
+    exit 1
 fi
 [[ "$out" == *"$TOOLSET"* ]] \
     || { echo "FAIL: install did not report the toolset: $out"; exit 1; }


### PR DESCRIPTION
## Summary

The skip was decided **after** the install, by pattern-matching the failure text, and one of the patterns was `*"index"*`. Nearly every mcpp command prints "package index" somewhere, so **every genuine install failure took the skip branch**.

It hid a real one, on the first Windows run where the package was actually installable:

```
tar: Cannot connect to C: resolve failed
tar -xf "C:\Users\...\.payloads\Microsoft.VC...vsix" -C "..."
[error] msvc installed but registered none of the programs it declares
```

The install ran for **135 seconds**, failed, and this script printed `PASS`.

## Fix

Skip is decided **before** the work, by a positive check for the thing whose absence would make the test impossible (no msvc row in `toolchain list`). Everything after that is a failure, and the output is printed rather than folded into a one-line message.

> A skip decided by the shape of a failure is not a skip; it is a way of not looking.

The recipe-side fix for what it hid is openxlings/xim-pkgindex#632 (GNU tar reads `C:` as a hostname; bsdtar does not, which is why the index's own `windows-test` passed).

## Test plan

- [x] `bash -n` clean
- [ ] `ci-windows-e2e` — 239 now either runs for real or skips for a stated, checkable reason