### PR TITLE
chore: bump version to 2026.8.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 > 本文件追踪 `mcpp-community/mcpp` 公开仓的版本演进。
 > 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [2026.8.16.2] — 2026-08-16
+
+### 修复
+
+- **装好的 msvc toolset 在 `mcpp toolchain list` 里不出现。**
+
+  枚举问的是 `toolchain_frontend(root / "bin", pkg)`,而 cl.exe 在
+  `VC/Tools/MSVC/<ver>/bin/Host<h>/<arch>/` —— 深四层。拿不到就 `continue`,
+  于是每一个 msvc payload 都装得好好的、然后**看不见**。
+
+  这个布局有三个地方需要知道:安装知道、构建知道、列表不知道 ——
+  一条规则被内联抄了第三份时的典型结果。三者现在共用
+  `payload_frontend(payloadRoot, pkg, family)`。
+
+  `2026.8.16.1` 带着这条(tag 打在修复之前),其余部分不受影响 ——
+  install / build / default / remove 都是好的,只有 list 少一行。
+
 ## [2026.8.16.1] — 2026-08-16
 
 ### 工具链

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version     = "2026.8.16.1"
+version     = "2026.8.16.2"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/version.cppm
+++ b/src/version.cppm
@@ -31,6 +31,6 @@ import std;
 
 export namespace mcpp {
 
-inline constexpr std::string_view MCPP_VERSION = "2026.8.16.1";
+inline constexpr std::string_view MCPP_VERSION = "2026.8.16.2";
 
 } // namespace mcpp


### PR DESCRIPTION
## Summary

Ships #436: **an installed msvc toolset was invisible in `mcpp toolchain list`.**

The `v2026.8.16.1` tag was cut before that fix landed, so `latest` currently carries it. Everything else in `.1` is fine — install, build, `default` and `remove` all work; only the listing row was missing.

```
$ mcpp toolchain list     # 2026.8.16.1
     llvm 20.1.7          <- the installed msvc 14.44.35207 is simply absent

$ mcpp toolchain list     # 2026.8.16.2
     msvc 14.44.35207
```

## Test plan

- [x] `mcpp.toml` and `src/version.cppm` bumped in one commit; `check_version_pins.sh` passes
- [x] `mcpp build` → the fresh binary reports `mcpp 2026.8.16.2`
- [x] `.xlings.json` bootstrap pin untouched (still `2026.8.15.1`, a published version)