### PR TITLE
fix(xlings): the remedy for a SubOS with no subos_info is a command that works

### DIFF
--- a/src/platform/runtime_binding.cppm
+++ b/src/platform/runtime_binding.cppm
@@ -284,8 +284,8 @@ resolve_runtime_binding(
             "       Where the C runtime comes from a payload, there is now no "
             "declared runtime to bind to — mcpp declines to guess a version, so "
             "the link falls back to the host and the hermeticity check will say "
-            "so. Only a SubOS created by a current xlings carries the block "
-            "(openxlings/xlings#547).",
+            "so. Run `xlings self doctor --fix` from inside this SubOS to have "
+            "it described (openxlings/xlings#547).",
             selection.subosName,
             info.note.empty() ? "no `subos_info` block" : info.note));
     } else if (info.schema > mcpp::xlings::subos::kSupportedSchema) {

--- a/src/platform/xlings/subos_info.cppm
+++ b/src/platform/xlings/subos_info.cppm
@@ -143,13 +143,28 @@ Info read(const std::filesystem::path& subosDir) {
 
     auto it = doc.find(std::string(kBlock));
     if (it == doc.end() || !it->is_object()) {
+        // The remedy has to be a command that WORKS, and this one has been
+        // wrong twice in opposite directions.
+        //
+        // It first said `xlings self update`, which does not touch a subos
+        // manifest at all. It was then corrected to say nothing backfills and
+        // that recreating the SubOS is the only way -- also wrong: `self
+        // doctor --fix` has always described the ACTIVE subos, and as of
+        // xlings 2026.8.17.1 it describes it truthfully rather than stamping
+        // it with whatever the current default libc happens to be
+        // (openxlings/xlings#547).
+        //
+        // Naming the active subos matters: doctor inspects the one this run is
+        // in and no other, so the user has to be inside the subos that is
+        // missing its block -- which, when mcpp is the one complaining, they
+        // are.
         info.note = std::format(
             "subos '{}' does not describe itself (no `{}` block), so programs "
             "run from here get no environment it declares — a GL application "
-            "will not find its drivers. A SubOS created by a current xlings "
-            "carries it; an existing one is NOT backfilled by `self update` or "
-            "`self doctor --fix` (openxlings/xlings#547), so recreating the "
-            "SubOS is what supplies it today",
+            "will not find its drivers. Run `xlings self doctor --fix` from "
+            "inside this SubOS to have it described (xlings 2026.8.17.1 or "
+            "newer records what the SubOS actually runs; older ones record the "
+            "built-in default, which may not be what is installed here)",
             subosDir.string(), kBlock);
         return info;
     }

--- a/src/toolchain/lifecycle.cppm
+++ b/src/toolchain/lifecycle.cppm
@@ -874,9 +874,8 @@ export int toolchain_install(const mcpp::config::GlobalConfig& cfg,
             mcpp::ui::warning(std::format(
                 "installed, but not bound to a C runtime: {}.\n"
                 "         The install itself succeeded. To complete the wiring, "
-                "use a SubOS created by a current xlings — an existing one is "
-                "not backfilled (openxlings/xlings#547) — then re-run this "
-                "command.",
+                "run `xlings self doctor --fix` from inside this SubOS, then "
+                "re-run this command (openxlings/xlings#547).",
                 fixed->skippedReason));
         }
 


### PR DESCRIPTION
Three messages tell the user how to get an undescribed SubOS described, and **all three name something that does not do it.** The wording has now been wrong in two opposite directions:

1. `xlings self update` — which does not touch a subos manifest at all.
2. *"an existing one is NOT backfilled; recreate the SubOS"* — the correction to (1), and also wrong.

`xlings self doctor --fix` has **always** described the ACTIVE subos. What it got wrong was the *content*: it stamped the block with whatever the built-in default libc happened to be, rather than with what the SubOS actually runs. On a measured 39-subos home that produced two subos declaring `glibc@2.44` over a sysroot serving 2.39.

openxlings/xlings#553 (xlings 2026.8.17.1) fixes the content: the runtime comes from the recorded binding, the workspace record, or the payload behind `lib/libc.so.6` — and when none of those can answer, the `runtime` key is **omitted** rather than filled with a guess.

## No ordering constraint

`self doctor --fix` supplies the block on **today's** xlings too, so this message is true before that release lands; it just writes a runtime that may be wrong. The parenthetical says which version records it truthfully so the user can tell the two apart.

## The omitted-runtime state already has a home here

`runtime_binding.cppm` already handles `info.present && info.runtime.empty()`:

> `SubOS '{}' has no runtime identity in subos_info.runtime; runtime rules cannot be evaluated for artifacts built here`

That was written for a hypothetical. It is now the honest state a described-but-unprovable SubOS reports, so **nothing here needs to change to accept the new format** — which is worth stating explicitly, since the alternative reading is that it was untested and happens to work.

## Why the wording matters more than usual

"from inside this SubOS" is load bearing: doctor inspects the subos the run is in and no other. When mcpp is the one complaining, the user is in it.

And telling someone to delete and recreate a SubOS to recover an environment is a large ask — it was never the smallest thing that works.

Sites changed: `platform/xlings/subos_info.cppm`, `platform/runtime_binding.cppm`, `toolchain/lifecycle.cppm`.
