### PR TITLE
docs: cxx_runtime was inert on MSVC until 2026.8.16, and upgrading is silent

### DIFF
--- a/docs/05-mcpp-toml.md
+++ b/docs/05-mcpp-toml.md
@@ -423,6 +423,14 @@ machine that has only the pinned toolset and no Visual Studio at all.
 The debug CRT (`vcruntime140d.dll` and friends, under `debug_nonredist\`) is
 never staged: it may not be redistributed.
 
+> **Upgrading from 2026.8.15 or earlier?** This key used to be **inert** on the
+> MSVC ABI — it reported `not implemented for the MSVC runtime yet` and every
+> value fell back to `/MD`. Since 2026.8.16 it is honoured, so a manifest that
+> carries `cxx_runtime = "self-contained"` from that era **changes CRT model on
+> upgrade**, from `/MD` to `/MT`. It is not a stricter version of the same
+> model, and the switch is silent because the value was always valid. If your
+> project set it while the key did nothing, decide which one you actually want.
+
 Combining it with `/MT` is a contradiction rather than a missing feature — a
 static CRT leaves no DLL to couple to — so it is reported and resolved to
 `self-contained`. `mcpp pack` enforces the other half: a mode that bundles

--- a/docs/zh/05-mcpp-toml.md
+++ b/docs/zh/05-mcpp-toml.md
@@ -375,6 +375,13 @@ Windows 组件(Win10 起),mcpp 从不分发它;而 `vcruntime140.dll` /
 调试版 CRT(`debug_nonredist\` 下的 `vcruntime140d.dll` 等)永远不会被放进去:
 它不可再分发。
 
+> **从 2026.8.15 或更早版本升上来?** 这条键在 MSVC ABI 上曾经是**空操作** ——
+> 它会报 `not implemented for the MSVC runtime yet`,写什么都退回 `/MD`。
+> 自 2026.8.16 起它真的生效,于是一份从那个年代带着
+> `cxx_runtime = "self-contained"` 的 manifest **会在升级时换掉 CRT 模型**:
+> 从 `/MD` 变成 `/MT`。它不是同一个模型的更严格版本,而且因为这个值一直是合法的,
+> 切换是**静默**的。如果你的工程是在这条键还不起作用时写下它的,请重新决定你真正要哪一个。
+
 把它和 `/MT` 一起用是**矛盾**而不是缺功能 —— 静态 CRT 根本没有 DLL 可以耦合 ——
 所以会被报出来并落到 `self-contained`。另一半由 `mcpp pack` 兜底:什么都不打包的
 模式(`--mode system`、`--mode static`)兑现不了 `toolchain-coupled`,会直接拒绝。


### PR DESCRIPTION
The MSVC section of `05-mcpp-toml` describes today's behaviour correctly and says nothing about the fact that it is **new**.

Through 2026.8.15 the key reported `not implemented for the MSVC runtime yet` and every value fell back to `/MD`; since 2026.8.16 (#422) it selects the CRT model. So a manifest carrying `cxx_runtime = "self-contained"` from that era **switches from /MD to /MT on upgrade** — silently, because the value was always spelled correctly and always accepted, and `/MT` is a *different* CRT model rather than a stricter version of the same one.

**Not hypothetical.** Found while reviewing xrgui's mcpp manifest, which carried exactly that value — set while the key did nothing, with a comment explaining that it was a no-op:

```toml
# mcpp says so itself when asked for anything else:
#   cxx_runtime = "self-contained" is not implemented for the MSVC runtime yet
#   (it would need the /MT runtime); using host-coupled
```

That project wants `/MD` (it matches its xmake build), so the value there is being corrected to `host-coupled` on its side. This adds the note for everyone else in the same position.

Docs only, en + zh.