### PR TITLE
feat(freestanding): bare-metal targets, and a BSP that supplies the whole target world

### DIFF
--- a/.agents/docs/2026-08-18-freestanding-baremetal-analysis.md
+++ b/.agents/docs/2026-08-18-freestanding-baremetal-analysis.md
@@ -1,0 +1,1177 @@
+# C++ 裸机 / freestanding:深度调研与 mcpp 路线分析(2026-08-18)
+
+- Date: 2026-08-18
+- Status: **调研报告 + 路线分析,待 review**(不是实施方案,不含工期)
+- 起因: [issue #403](https://github.com/mcpp-community/mcpp/issues/403) — RFC:mcpp 对裸机/freestanding target 的支持(riscv64-none-elf 类,toy_kernel 用例)。issue 已 CLOSED,维护者标注「不期望近期实现,供后续设计参考」。
+- 关联决策: `.agents/docs/2026-07-24-embedded-platform-support-design.md` **决策 #15**(裸机 / freestanding-modules / ESP32:出范围 / 推迟)。本文重新打开该决策所依据的两条前提,并用实测检验它们。
+- 关联: #276(hosted 嵌入式 Linux SDK,另一条线)
+- 结构:**实测证据(前置)→ 生态对照 → 标准现状 → 问题分解 → 路线 → 设计侧 → 使用侧 → 陷阱 → 待决策点**
+- **⇒ 方案已独立成文:`.agents/docs/2026-08-19-freestanding-baremetal-design.md`**(五层架构、契约层「声明/证据/兜底」、使用侧最小案例、分期与验收判据、D1–D16 回执)。**本文是发现,那份是方案。**
+
+---
+
+## 0. TL;DR
+
+七条结论,每条都有第 1 节的实测编号背书。
+
+1. **mcpp 今天对裸机不是「不支持」,是「静默构建成宿主二进制并报告成功」。**(E1)
+   `mcpp build --target riscv64-none-elf` 配合错误信息自己推荐的逃生舱 `[target.riscv64-none-elf]`,输出 `Finished dev … in 0.04s`,产物是 `target/x86_64-linux-gnu/…/toy_kernel`,一个 **x86-64 glibc 动态 PIE**。生成的 `build.ninja` 里 `--target` 出现 **0 次**。**这条与路线选择无关,任何路线下都必须先修。**
+
+2. **裸机能力在 mcpp 现有载荷里已经物理存在。**(E2)
+   用 mcpp 自带的 `llvm@22.1.8`(clang + `ld.lld` + `llvm-objcopy`),**零新增工具链**,从一个 **C++20 模块接口单元**编出并链成了完整的 RISC-V 64 裸机内核 ELF + 136 字节裸镜像,`llvm-nm -u` 无未定义符号。缺的不是编译器,**缺的全部是 mcpp 的 target / 链接 / 运行模型**。
+
+3. **唯一真实的载荷缺口很小:compiler-rt builtins 只有 x86_64。**(E3)
+   `lib/clang/22/lib/` 下只有 `x86_64-unknown-linux-gnu` 一个目录。⚠️ 而且这个缺口**在 hello-kernel 上看不见**——我们的测试内核 0 个未定义符号,只有做 64 位除法/软浮点的真实内核才会在链接期炸。这是一个天然的假绿点。
+
+4. **`import std` 在裸机上不可用,而且是结构性的,不是配置问题。**(E4)
+   GCC 16.1 的 `bits/std.cc`(4502 行)里 `HOSTED|freestanding` 命中 **0 次**,开头就是 `#include <bits/stdc++.h>` 外加 `<execution>`、`<strstream>`;libc++ 的 `std.cppm`(280 行)只有 **1** 处配置守卫。WG21 侧 SG14 在 2025-05 才在讨论「`std.freestanding` 值不值得做」(P3693R0),没有标准。**结论:mcpp 只能明确关断 + 给诊断,不能「降级」。**
+
+5. **但「有 std 子集可用」不只是近,是已经跑通了。**(E5 / X1–X10)
+   接上真实 picolibc 的头 + 一份 freestanding `__config_site`,libc++ 的 **110 个 `std/*.inc` 对应头里 103 个可编**;⚠️ 做了宿主对照组后确认:**失败的 7 个在 x86_64 宿主上同样失败**(libc++ 尚未实现的 `<generator>`/`<stacktrace>`/`<rcu>` 等)——**freestanding 这一层的编译期损失是 0**。
+   进一步:我据此拼出 `mcpplibs.std.freestanding` 模块并**真的把它链进了裸机内核**——`import` 之后用 `std::array` / `std::ranges::sort`(带投影)/ `std::optional` / `std::atomic` / `std::span` / `std::string_view`,**零未定义符号,text 12435 字节**。`std::thread` / `std::mutex` 在这套配置下**干净地不存在**(编译期报错,不是静默桩)。
+
+6. **子集包不用手写导出表,libc++ 已经把它拆好了。**(X3)
+   `std.cppm` 的实体是 **110 个 `share/libc++/v1/std/<header>.inc`**,每个就是那个头的 `export namespace std { using std::X; }`。子集模块 = **机械挑选 `.inc`**,导出表由上游维护。`mcpplibs.std.freestanding` 的源文件只有 **208 行**,而且是生成的。
+
+7. **正确的架构切分是「目标规格是数据,板级支持是包,std 子集也是包」。**
+   `-march=rv64gc -mabi=lp64d -mcmodel=medany` 是**目标属性**——必须对每个 TU 和每个依赖完全一致,否则 ABI 撕裂。issue #403 里把它们塞进 `[build].cxxflags` 之所以是错的,不只是「宿主解析错」,而是**依赖拿不到它们**。这正是 Rust 用 target-spec JSON 而不是 `Cargo.toml` flags 的原因。而链接脚本 + 启动代码 + 运行命令属于**板子**,应该是索引里的一个普通包(对标 `riscv-rt` / `cortex-m-rt`),不是引擎里的板子数据库。
+
+8. **推荐路线 = B(最小可落地缝),方向留给 C;而 C 里最贵的那块(std 子集)已被 X 系列证明是小的。**
+   A=明确不做、B=开 target/链接/runner 三条缝 + BSP 走包、C=全栈裸机发行版。**无论选哪条,第 1 条的静默失败都必须修**——那是当下唯一的「已发布能力可达的错误行为」。
+
+---
+
+## 1. 本机实测:证据先行
+
+环境:Linux x86_64 / mcpp 二进制 `2026.8.15.3`(仓库 HEAD 为 `f0de3ef`)/ 载荷 `llvm@22.1.8`、`gcc@16.1.0` / 宿主另有 Ubuntu `gcc-riscv64-unknown-elf 13.2.0`。复现命令见附录。
+
+### 1.1 E1 ⚠️ 今天的行为不是拒绝,是静默错构
+
+```console
+$ mcpp build --target riscv64-none-elf
+error: unknown target 'riscv64-none-elf'
+       known targets: `mcpp toolchain list`; a custom triple needs an
+       explicit [target.riscv64-none-elf] section in mcpp.toml
+```
+
+按这条错误信息**自己的指引**加上逃生舱:
+
+```toml
+[target.riscv64-none-elf]
+toolchain = "llvm@22.1.8"
+```
+
+```console
+$ mcpp build --target riscv64-none-elf
+   Resolving toolchain
+    Resolved llvm@22.1.8 → …/xim-x-llvm/22.1.8/bin/clang++
+    Finished dev [unoptimized + debuginfo] in 0.04s
+
+$ file target/x86_64-linux-gnu/*/bin/toy_kernel
+… ELF 64-bit LSB pie executable, x86-64, …, dynamically linked,
+  interpreter …/xim-x-glibc/2.44/lib64/ld-linux-x86-64.so.2 …
+
+$ grep -c -- --target target/x86_64-linux-gnu/*/build.ninja
+0
+```
+
+**机制**(已核到 file:line,不是推断):
+
+| 位置 | 行为 |
+|---|---|
+| `src/toolchain/triple.cppm:299` | `if (k == "unknown" \|\| k == "pc" \|\| k == "w64" \|\| k == "none") continue;` —— **`none` 被当作 vendor 段跳过**,与裸机 OS 段直接撞名 |
+| `src/toolchain/triple.cppm:320` | 剩下的 `elf` 段不认识 → `parse()` 返回 `nullopt`,即「这根本不是一个 triple」 |
+| `src/build/prepare.cppm:1264` | `if (!known && !hasExplicitSection)` 才报错 —— **有 `[target.X]` 段就放行** |
+| `src/build/prepare.cppm:1301` | `host_can_serve` 守卫的条件是 `known && …` —— **不认识的 triple 走不到这条守卫** |
+| `src/build/prepare.cppm:1458-1462` | 代码注释直书:「Escape-hatch triples outside the language don't parse and **leave the spec on the host target**」 |
+
+⚠️ 最值得注意的是:**同一份文件在 1281–1296 行把这个结果称为「最坏的失败模式」**并为此专门加了 `host_can_serve` 守卫(注释里还留了 `--target x86_64-windows-msvc` 产出 ELF 的实测记录)。**守卫加在了已知 target 那条路径上,而逃生舱把同一扇门重新打开了。** 这与 `.agents/docs/2026-08-08` 那批「修补放在控制流到不了的地方」是同一形状。
+
+对使用者而言这比 issue #403 描述的还糟:#403 报的是 flags 被按宿主解析后**硬失败**(至少有红);逃生舱路径是**全绿 + 错产物 + 零诊断**。
+
+### 1.2 E2 现有载荷已经能产出完整裸机内核
+
+只用 `xim-x-llvm/22.1.8` 里的 `clang++` / `clang` / `ld.lld` / `llvm-objcopy`,**不装任何交叉工具链**:
+
+```
+kmain.cppm  (export module kmain;  export extern "C" void kmain())
+start.S     (_start:  la sp, stack_top; call kmain; wfi)
+link.ld     (. = 0x80200000; .text/.rodata/.data/.bss)
+```
+
+```console
+$ clang++ --no-default-config --target=riscv64-none-elf -march=rv64gc -mabi=lp64d \
+      -mcmodel=medany -ffreestanding -fno-exceptions -fno-rtti -nostdinc++ \
+      -std=c++23 --precompile kmain.cppm -o kmain.pcm      # OK
+$ clang++ … -c kmain.pcm -o kmain.o                        # OK
+$ ld.lld -T link.ld start.o kmain.o -o kernel.elf          # LINK OK
+
+$ file kernel.elf
+kernel.elf: ELF 64-bit LSB executable, UCB RISC-V, RVC, double-float ABI,
+            statically linked, not stripped
+$ llvm-objcopy -O binary kernel.elf kernel.bin && ls -l kernel.bin   # 136 bytes
+$ llvm-nm -u kernel.elf                                     # (空:无未定义符号)
+```
+
+三条推论:
+
+- **C++20 模块在 freestanding 下完全可用**——两阶段 `--precompile` → `-c` 对裸机 target 一次通过。模块是语言特性,与 libc 无关。
+- **clang 天然多目标**,不需要「一个 target 一个 payload」。这与 GCC 路线(单目标,每个 triple 一份交叉链)是根本不同的成本结构,值得在决策 #8(「先 GCC」)旁边记一笔:**裸机这条线上 clang 的优势是结构性的**。
+- **`ld.lld` + `llvm-objcopy` 已在载荷里**,链接与镜像生成不需要新工具。
+
+### 1.3 E3 ⚠️ 唯一真实的载荷缺口:builtins 只有 x86_64
+
+```console
+$ ls …/xim-x-llvm/22.1.8/lib/clang/22/lib/
+x86_64-unknown-linux-gnu
+```
+
+`libclang_rt.builtins.a` 只有宿主一份。RISC-V 64 上一旦用到编译器内建运行时(64 位除法、软浮点、`__muldi3` 类),链接期会缺符号。
+
+⚠️ **这个缺口在 hello-kernel 上不可见**:E2 的内核 `llvm-nm -u` 是空的,一路全绿。**若拿 hello-kernel 当 e2e,builtins 这条永远测不到**——与 `.agents/docs/2026-08-12` 记的 bench 假绿、以及 PR#451 「CI 全绿 ≠ 覆盖到了」同族。验收用例必须**故意**含一次 64 位除法或软浮点。
+
+### 1.4 E4 `import std` 是结构性 hosted-only
+
+```console
+$ wc -l …/gcc/16.1.0/include/c++/16.1.0/bits/std.cc
+4502
+$ grep -c "HOSTED\|freestanding\|_GLIBCXX_HOSTED" …/bits/std.cc
+0
+```
+
+`std.cc` 第 26 行起:`#include <bits/stdc++.h>`,随后**无条件**再拉 `<execution>` 和 `<strstream>`。**整份文件没有任何 freestanding 分区**。
+
+libc++ 侧同理:`share/libc++/v1/std.cppm` 共 280 行,配置守卫仅 `_LIBCPP_HAS_ATOMIC_HEADER` **1** 处。
+
+⇒ 两个实现都把 `std` 模块做成了「全都要」的单体。**没有实现侧的开关可以让 `import std` 在裸机上变小。**
+
+标准侧也没有:见第 3 节。**mcpp 的正确姿势是在 `os=none` 上把 `import std` 判为不可用并给诊断**,而不是尝试降级——降级出来的「少一半的 std」会是比硬失败更坏的东西,而且会污染 BMI 缓存身份(参考 `2026-07-31` C++20 档位设计里「跨档位 BMI 硬拒」的先例)。
+
+### 1.5 E5 头文件子集:失败全在 libc,不在 libc++
+
+libc++ 的每目标配置文件是 `include/<triple>/c++/v1/__config_site`,载荷里**只有** `x86_64-unknown-linux-gnu` 一份。直接对 `riscv64-none-elf` 编 `<type_traits>`:
+
+```
+…/__config:646:8: error: "No thread API"
+```
+
+⚠️ `-D_LIBCPP_HAS_THREADS=0` **不管用**(该宏来自 `__config_site`,不是命令行可覆盖的)。合成一份 freestanding `__config_site`(把 `THREADS / FILESYSTEM / LOCALIZATION / MONOTONIC_CLOCK` 四个 `#define` 翻成 0)后,共测 17 个头:
+
+| 结果 | 头 |
+|---|---|
+| **OK(8)** | `<type_traits>` `<concepts>` `<span>` `<expected>` `<bit>` `<utility>` `<tuple>` `<charconv>` |
+| **FAIL(9)** | `<array>` `<optional>` `<algorithm>` `<ranges>` `<variant>` `<atomic>` `<format>` `<string_view>` `<coroutine>` |
+
+失败信息全是两条:`__mbstate_t.h:51: "We don't know how to define mbstate_t"` 和 `string.h:98: unknown type name 'size_t'`。
+
+**全部是 libc 缺失,没有一条是 libc++ 自身的 hosted 依赖。** 换言之:**接上 picolibc / newlib 的头文件,这个子集会立刻变宽**(推断,未实测——本机没装 picolibc,`picolibc-riscv64-unknown-elf` 在 Ubuntu universe 里有 1.8.6-2,但装它属于改用户环境,未执行)。
+
+这条对路线的意义:**「裸机上有可用的 C++ 库」不是遥远目标,是一个载荷构建决策**(给目标编一份 `__config_site` + 一个 freestanding libc),不是引擎特性。
+
+### 1.6 E6 ⚠️ 三个会咬人的环境级事实
+
+1. **`ld.lld` 这个名字在本机解析到 GNU ld。**
+   ```console
+   $ readlink -f $(which ld.lld)
+   /home/speak/.xlings/bin/xlings
+   $ ld.lld --version
+   GNU ld (XPKG: xlings install fromsource:binutils) 2.42
+   ```
+   后果:`ld.lld -T link.ld …` 报 `cannot represent machine 'riscv'`。**裸机链接必须按载荷路径寻址链接器,不能按名字。** 这与 `.agents/docs/2026-08-11` 的 `$ORIGIN` 优先级、以及「链接期用 A、运行期加载 B」是同一类地址-vs-名字问题。
+
+2. **`-mcmodel=medany` 不是可选项,是 link-or-not。**
+   漏掉它,链接直接失败:
+   ```
+   ld.lld: error: relocation R_RISCV_HI20 out of range: 524800 is not in [-524288, 524287]
+   ```
+   载入地址 `0x80200000` 超出 medlow 可寻址范围。**这是「目标规格必须是数据」的最硬证据**:它既不是优化选项也不是用户偏好,它由板子的内存布局决定。
+
+3. **libc++ 的 `__config_site` 是按 target 的文件**,不是宏。「加个 `-isystem` 就能用」是错的。
+
+### 1.7 X1–X10 `mcpplibs.std.freestanding` 子集包:从假设到跑通
+
+E5 只证明了「零 libc 下 8 个头可用」。这一轮把真实 picolibc(Ubuntu `picolibc-riscv64-unknown-elf` 1.8.6-2,`apt-get download` + `dpkg -x` 解到临时目录,**未装进系统**)接上,把整条链走完。
+
+**X1 — libc++ 自己已经把 std 模块拆成可裁剪的零件。**
+`share/libc++/v1/std.cppm` 的结构是:全局模块片段 `#include <header>` × N → `export module std;` → `#include "std/<header>.inc"` × **110**。每个 `.inc` 就是那个头的 `export namespace std { using std::X; }`(例:`std/span.inc` 导出 `dynamic_extent`、`span`、`ranges::enable_borrowed_range`)。
+⇒ **子集模块是机械裁剪,不需要手写也不需要维护导出表。**
+
+**X2/X3 — 接上 picolibc 头之后,编译期损失为零。**
+
+| 配置 | 可编头数 |
+|---|---|
+| 零 libc(E5) | 8 / 17 抽样 |
+| **+ picolibc 头** | **17 / 17 抽样;103 / 110 全量** |
+
+⚠️ **对照组是这条结论的关键**:失败的 7 个(`generator` `hazard_pointer` `rcu` `spanstream` `stacktrace` `stdfloat` `text_encoding`)拿到 **x86_64 宿主 + 完整 libc++/glibc** 上重测,**7 个全部同样失败**——它们是 libc++ 尚未实现的头,与裸机无关。**没有对照组就会把「libc++ 没写」记成「裸机不行」。**
+
+**X4 — include 能过 ≠ 东西真在。** 用真实使用探针(不是 include 探针)复核:
+
+| 设施 | 结果 |
+|---|---|
+| `std::span` / `array` / `ranges::sort` / `optional` / `expected` / `atomic` / `string_view` / `charconv` / coroutine | **可用** |
+| `std::vector` / `std::string`(需堆) | 编译可用(链接期另说,见 X9) |
+| `std::mutex` / `std::thread` | **干净地不存在**(`no type named 'mutex' in namespace 'std'`)—— 不是静默桩,是编译期报错 |
+| `std::cout` | 声明在但不可用 |
+
+`__config_site` 关掉 THREADS/FILESYSTEM/LOCALIZATION 的效果正是我们想要的:**不该有的东西直接消失,而不是留个跑起来才错的壳。**
+
+**X5/X6 — 包装模块本身成立。** 由 `ok.list` 生成的 `stdfs.cppm`(**208 行**,全部是 `#include`)对 `riscv64-none-elf` 编出 reduced BMI 26.5 MB + object 1.3 KB;消费者 `import mcpplibs.std.freestanding;` 后编译通过。
+
+**X7–X10 — 链接期的真实边界(这才是可用性的分界线)。**
+
+第一次链接只缺 **2 个符号**,收敛速度远超预期:
+
+| 缺失符号 | 性质 | 解法 |
+|---|---|---|
+| `std::__libcpp_verbose_abort` | `-fno-exceptions` 下所有 `__throw_*` 的落点 | **用户/BSP 提供 ~3 行**(实测:一个 `for(;;) wfi` 即可) |
+| `std::__sort<__less<int>&, int*>` | libc++ 把标量类型的 `__sort` 做成了 **`extern template`**,实体在编译版 libc++ 里 | 见下 |
+| `memmove`(去掉 `verbose_abort` 后暴露) | 编译器可自行发出的 libc 函数 | picolibc `libc.a` |
+| `std::basic_string::__init/append`(用 `std::format` 时暴露) | `basic_string` 的 out-of-line 成员在编译版 libc++ 里 | 需目标版 `libc++.a` |
+
+⚠️ `__algorithm/sort.h:834-847` 的 `extern template` **无宏可关**(逐条核过,外层无守卫)。但它**只覆盖内建标量类型**——对自定义类型/带投影的 `ranges::sort` 完全走头文件。
+
+**最终边界(X10 实测,零未定义符号):**
+
+```
+kernel4.elf: ELF 64-bit LSB executable, UCB RISC-V, RVC, statically linked
+   text    data     bss     dec
+  12435      16    4096   16547
+```
+
+内核里真正跑的是:`import mcpplibs.std.freestanding;` + `std::array` + `std::ranges::sort(t, {}, &Task::prio)` + `std::optional` + `std::atomic` + `std::span` + `std::string_view`,链接输入 = `start.o` + `kmain.o` + `stdfs.o` + 3 行 runtime + picolibc `libc.a`。
+
+⇒ **分界线是清楚的**:
+
+| 档位 | 需要什么 | 覆盖 |
+|---|---|---|
+| **T1 header-only** | picolibc 头 + `__config_site` + ~3 行 hook | array/span/ranges/algorithm(自定义类型)/optional/expected/atomic/string_view/tuple/bit/utility/concepts/type_traits/charconv/coroutine |
+| **T2 + libc.a** | 上面 + picolibc `libc.a` | 编译器隐式发出的 `memcpy/memmove/memset/memcmp`;堆(需 BSP 给 `sbrk`) |
+| **T3 + 目标版 libc++.a** | 上面 + 为目标编的 libc++ | `std::format`、标量 `std::sort`、`std::string` 全功能 |
+
+**T1+T2 已在本机完全跑通;只有 T3 需要新载荷。**
+
+**X11 ⚠️ picolibc 的发行版包覆盖不到最常见的 RISC-V profile。**
+Ubuntu 包的 rv64 multilib 全集:`rv64i/lp64 rv64ia/lp64 rv64iac/lp64 rv64iaf/lp64f rv64iafd/lp64d rv64if/lp64f rv64ifd/lp64d rv64im/lp64 rv64imac/lp64 rv64imafc/lp64f rv64imf/lp64f`——**没有 `rv64imafdc/lp64d`(即 `rv64gc`)**。本轮实测因此退到 `rv64imac/lp64`。⇒ **载荷不能直接复用发行版包**,要么自建 multilib,要么采纳 LLVM Embedded Toolchain(§2.4)。
+
+**X12 附带发现:qemu 退出码通路是现成的。**
+picolibc 载荷里带 `crt0-semihost.o` 和 `libsemihost.a` ——`mcpp test` 在 qemu 下拿测试退出码不需要自己造 semihosting。
+
+### 1.8 Y1–Y5 实现中立的适配层 + 机械验证(**修正 §1.7 的一条结论**)
+
+§1.7 结尾写了「这条包路线天然绑定 clang/libc++」。**实测证明这条不成立**,原因有两条,都比原判断重要。
+
+**Y1/Y2 — libstdc++ 有真正的 freestanding 模式,而且比 libc++ 更诚实。**
+
+`bits/c++config.h:1638`:`#define _GLIBCXX_HOSTED __STDC_HOSTED__` —— libstdc++ 的 freestanding **由编译期开关驱动**(`-ffreestanding` 会把 `__STDC_HOSTED__` 置 0),44 个头对它敏感。不需要合成任何配置文件。
+
+`g++ -std=c++23 -ffreestanding` 下的真实使用探针:
+
+| 可用 | `<span> <array> <algorithm>/ranges::sort <optional> <expected> <atomic> <string_view> <coroutine>` |
+|---|---|
+| **不可用** | `<charconv> <format> <vector> <thread> <iostream>` —— 全部是 **`#error "This header is not available in freestanding mode."`** |
+
+⚠️ **这条对比是反直觉的,而且方向与 §1.7 相反**:
+
+| | libc++ | libstdc++ |
+|---|---|---|
+| freestanding 开关 | 每目标 `__config_site` **文件**(载荷构建期烙死) | **`-ffreestanding` 编译期开关**,零配置 |
+| 不可用设施的表现 | 头**被守卫成近乎空文件** ⇒ 报错发生在「用它的时候」,信息离现场很远 | **点名 `#error`,当场** |
+| 全量扫 110 头 | 103 "OK" | 53 OK |
+| 但那个数字的含义 | ⚠️ **含约 50 个只是「能 parse」的空壳**(X4 已测 `std::mutex` 根本不存在) | **53 个全部诚实**,其余硬 `#error` |
+
+**libc++ 的 103 不是「更宽」,是「更含糊」。** 把 include 成功率当能力指标会得到完全错误的排序 —— 这正是陷阱 #10。
+
+**Y3 — 一份源码,两个标准库,零 `#if`。**
+
+写一个实现中立的适配层(不 `#include "std/*.inc"`,而是自己写 `export namespace std { using std::span; … }`),同一个 `core.cppm`:
+
+| 编译配置 | 结果 |
+|---|---|
+| GCC 16.1 + libstdc++ + `-ffreestanding`(宿主 x86_64) | `core_gcc.o` ✅ |
+| clang 22 + libc++ + freestanding `__config_site`(`riscv64-none-elf` + picolibc) | `core_clang.pcm` ✅ |
+
+**⇒ 适配层可行,因为导出的名字是标准规定的,不是任何一家的私产。** libc++ 的 `.inc` 只是一份**方便的名字清单**,不是依赖。
+
+**Y4 — 可移植 freestanding 子集 = 52 个头(两家交集)。**
+
+```
+algorithm any array atomic bit cassert cctype cfenv cfloat chrono cinttypes clocale
+compare concepts coroutine csetjmp csignal cstdarg cstddef cstdint cstdio cstdlib
+cstring ctime cuchar cwchar cwctype exception expected functional initializer_list
+iterator limits mdspan memory new numbers numeric optional ranges ratio
+scoped_allocator source_location span string_view tuple typeindex typeinfo
+type_traits utility variant version
+```
+
+⚠️ 但「交集」不是唯一正确答案,因为**两家其实在两个不同档位上**:
+
+| 档 | 环境 | 得到什么 |
+|---|---|---|
+| **T0 `freestanding-core`** | 无 libc / 无堆 | ≈ 上面 52 个头。libstdc++ `-ffreestanding` **零配置**即是;libc++ 需 `__config_site` |
+| **T1 `freestanding+heap`** | + picolibc(含 malloc) | **额外拿到 `vector` / `string` / `format` / `charconv`**(X4/X9 实测,libc++ 侧) |
+| **T2 `hosted`** | 现状 | 全部 |
+
+libc++ + picolibc 之所以「更宽」,不是 libc++ 更强,是 **picolibc 给了堆**。⇒ **档位是环境的函数,不是标准库实现的函数。** 这条直接决定了第 9 节的生态架构。
+
+**Y5 — 「这个库需要什么环境」可以从产物机械判定,零元数据。**
+
+| 源码用了 | `llvm-nm -u` 里出现 | 判定 |
+|---|---|---|
+| `new` / `delete` | `_Znwm` `_ZdlPvm` | 需要 **heap** |
+| `throw` / `catch` | `__cxa_throw` `__cxa_begin_catch` `__cxa_allocate_exception` `__cxa_end_catch` | 需要 **exceptions** |
+| `dynamic_cast` | `__dynamic_cast` `_ZTI1B` | 需要 **RTTI** |
+| 纯计算 | **(空)** | freestanding-clean |
+
+`llvm-nm` 已在载荷里。⇒ **不需要生态先标注,就能判定。** 这是第 9 节的技术地基。
+
+### 1.9 T1–T3b 能力是可插拔的符号契约(**修正 §7.5 里一处分类错误**)
+
+§7.5 曾把 `std::thread` 归到 `hosted` 档。**实测证明这是错的** —— 线程和堆都是**可插拔能力**,不是 hosted 专有设施。
+
+**T1/T2 — 两家标准库都把线程做成了可插拔层。**
+
+| 标准库 | 机制 | 证据 |
+|---|---|---|
+| **libstdc++** | **gthreads**:`gthr.h` / `gthr-default.h` / `gthr-posix.h` / **`gthr-single.h`** 四件齐全;`_GLIBCXX_HAS_GTHREADS` 构建期决定 | 载荷里四个头都在 |
+| **libc++** | **`_LIBCPP_HAS_THREAD_API_EXTERNAL`**:线程原语由外部提供 | `__config:622` / `:662` 明确有这条分支 |
+
+⇒ FreeRTOS / Zephyr 接到任一侧,裸机上就有 `std::thread`。正确的声明是 `tier="core", requires=["threads"]`。
+
+**T3b — `heap` 同理,而且是标准写好的扩展点。**
+
+BSP 侧一个 bump 分配器(替换 `operator new/delete` 重载集),**零 libc、零 malloc**:
+
+```
+$ ld.lld -T link.ld start.o usevec.o bsp_heap.o -e kmain -o heapdemo.elf
+heapdemo.elf: ELF 64-bit LSB executable, UCB RISC-V, statically linked
+   text 5911   data 0   bss 12304        ← llvm-nm -u:空
+```
+
+内核里跑的是 `std::vector<int>` + `push_back` + `std::span` 求和。C++ 标准 [new.delete] **本来就规定 `operator new/delete` 可被用户替换** —— 这不是绕过标准,是标准的扩展点。
+
+⚠️ 中途暴露的一条实用细节:漏掉 `operator new(size_t, align_val_t)` 时,lld 报的是 **`undefined symbol: operator new(unsigned long, std::align_val_t)`** —— 精确点名缺哪个重载。**能力契约是可枚举的符号集,不是模糊概念。**
+
+**⇒ 由此闭环:能力的「契约」和能力的「判据」是同一组符号。**
+
+```
+heap       契约 = operator new/delete 重载集   判据 = 产物有无 _Znwm / _ZdlPvm
+exceptions 契约 = __cxa_throw + _Unwind_*      判据 = 产物有无 __cxa_throw
+rtti       契约 = __dynamic_cast + typeinfo    判据 = 产物有无 __dynamic_cast
+threads    契约 = __gthread_* / __external_*   判据 = 产物有无这些符号
+```
+
+所以 Y5 的符号审计**不是启发式规则**,它检查的就是真正的 ABI 契约;裸机链接之所以是硬门,也是因为契约缺实现在 `-nostdlib` 下必然是未定义符号。
+
+⚠️ **推论**:mcpp **不应该**自己定义一套能力接口 —— 契约由 C++ 标准([new.delete])、Itanium C++ ABI(`__cxa_*`)和各标准库(gthreads / `__external_threading`)**早已定义**,再造一套就是第三套 ABI,与两边都不兼容。唯一需要生态出力的是 `threads`:两家接口不同,一个 RTOS 想服务两边要写两个 shim —— **那是包的工作,不是引擎的**。
+
+### 1.10 H1–H3 生态契约的可组合形态(非标准库能力)
+
+§1.9 覆盖的是**语言运行时**能力。裸机上还有一类**没有任何标准契约**的能力:UART / 定时器 / 存储 / 中断。这一轮量的是它们该长什么形状。
+
+**⚠️ H1 — 形态 A(模块内声明、别的包定义)被语言禁止。**
+
+```
+消费者要:  _ZN3halW8mcpplibsW3halW7console5writeEPKcm
+           → hal::write@mcpplibs.hal.console(char const*, unsigned long)
+提供者给:  _ZN3hal5writeEPKcm
+           → hal::write(char const*, unsigned long)
+ld.lld: error: undefined symbol: hal::write@mcpplibs.hal.console(...)
+```
+
+**模块归属被烙进符号名** ⇒ 附着到模块的函数,定义必须来自同一个模块。**跨包提供实现在物理上不可能。**
+
+⇒ 这给 2026-07-24 决策 #5(C-ABI 是唯一稳定的二进制互操作契约)补了一条**更硬的理由**:在 C++20 模块世界里,跨包提供实现**只有 C ABI 一条路**,这不再只是 ABI 稳定性论证,而是语言层面的物理约束。
+
+**H2 — 形态 B(`extern "C"` 缝)可行**:消费者要 `U mcpp_hal_console_write`,提供者在另一个包定义,链接零未定义符号。代价:单一全局符号 ⇒ **不能有两个提供者**。
+
+**H3 — 形态 C(concept 静态注入)可行,且是唯一可组合的**:
+
+```cpp
+// 契约包:纯接口,零实现
+template <class T> concept Console = requires(T& t, std::span<const char> s) { t.write(s); };
+template <class T> concept Clock   = requires(T& t) { { t.ticks() } -> std::same_as<unsigned long>; };
+
+// 驱动包:只依赖 concept,不知道任何板子
+template <hal::Console C, hal::Clock K> void banner(C& c, K& k);
+
+// BSP 包:Uart 与 Uart2 同时存在
+```
+
+实测:`banner(u, t)` 与 `banner(u2, t)` **两个提供者共存**,同一驱动各实例化一次(零成本静态派发);且同一个 BSP 的 `operator new` 让 `std::vector` 一起工作 —— **生态库与 std 同时点亮**。整体链接零未定义符号,text 9040 字节。
+
+| 形态 | 跨包 | 多提供者共存 | 成本 |
+|---|---|---|---|
+| A 模块内声明 | ❌ 语言禁止 | — | — |
+| B `extern "C"` | ✅ | ❌ | 链接期绑定,不可内联 |
+| C concept 注入 | ✅ | ✅ | **零成本,可内联** |
+
+⇒ **生态 HAL 应以 C 为主**;B 只留给天然单例的运行时能力 —— ⚠️ 而那些恰好已被 §1.9 的标准扩展点(`operator new` / gthreads / `__libcpp_verbose_abort`)覆盖,**生态基本不需要自己发明 `extern "C"` 契约**。
+
+### 1.11 K1–K3 KAL(内核/arch 抽象)的两条硬约束
+
+针对「用 concept 表达 KAL,支持所有 CPU、不管有没有 MMU」这个方向做的探测。**两条结果都是限制性的。**
+
+**K1/K2 — ⚠️ concept 检查语法,不检查语义。**
+
+写一个 `kal::AddressSpace` concept(`map` / `translate`),两个实现:
+
+```
+RiscvSv39::map(0x8000_0000, 0x9000_0000) → true    真重映射
+NoMmu    ::map(0x8000_0000, 0x9000_0000) → false   只能恒等映射
+```
+
+**两者都完全满足同一个 concept,编译期无法区分。** 通用内核代码调用 `map()` 做非恒等重映射,在 NoMmu 上静默失败。
+
+⇒ **MMU 的有无不是一个抽象能藏住的差异**:它上面的代码分成两族(有 demand paging / fork / 地址空间隔离 vs 没有),不是一个统一接口。**这是能力轴(`cfg(mmu)`),不是契约。**
+
+**K3 — ⚠️ 「零成本抽象」在跨模块边界上默认不成立。**
+
+同一段 `setup(arch, va)` 通用代码,三种构建方式:
+
+| 构建 | `RiscvSv39::disable()`(应为一条 `csrci`) | 判据 |
+|---|---|---|
+| **同 TU + `-O2`** | **完全内联**:`csrci` / `csrsi` + 3 条指令 | ✅ 真零成本 |
+| **跨模块 + `-O2`** | **真实 `jal` 调用** `_ZN5archsW5archs9RiscvSv397disableEv` | ❌ 抽象有成本 |
+| **跨模块 + `-flto`** | `kmain` 内 `jal` = **0**,内联进来的 csr 指令 = **4** | ✅ 恢复 |
+
+⇒ **内核热路径(irq 开关、per-cpu 访问、页表项操作)一旦跨包/跨模块,默认会退化成真实函数调用。** 对内核这是不可接受的 —— `local_irq_disable()` 本该是一条指令。
+
+**⇒ KAL 的构建模型必须把 LTO 当作必需项,不是优化项。** 而 LTO 在内核上有自己的代价(链接脚本 section 放置、inline asm 约束、编译期),这条必须提前进设计,不能等发现热路径慢了再补。
+
+### 1.12 KA1–KA3 KAL 作为 kernel ABI 统一层(与 1.11 是两件事)
+
+§1.11 测的是「抽象内核内部」。这一组测的是**另一种读法**:统一 syscall / kernel ABI,转发到不同内核后端。**结果全部是肯定的。**
+
+契约走 C ABI 缝(H1 已证明跨包只有这一条路):
+
+```cpp
+export module openkal.io;
+extern "C" long kal_write(int fd, const char* buf, unsigned long n);
+export namespace kal { inline long write(int, const char*, unsigned long); }
+```
+
+**KA1 —— 同一份 `app.cppm`,零 `#if`,两个内核后端:**
+
+| 后端 | 实现 | 结果 |
+|---|---|---|
+| hosted x86_64-linux | 转发到真 `::write(2)` | ✅ **实际运行输出 `hello from one source`** |
+| riscv64-none-elf 裸机 | 转发到 MMIO UART | ✅ 零未定义符号,**157 字节** |
+
+**KA3 —— 应用对 KAL 的依赖面是可审计的符号集,且两侧完全相同:**
+
+```
+裸机构建的 app.o    外部符号:  kal_write
+hosted 构建的 app.o 外部符号:  kal_write
+```
+
+**KA2 —— 换后端不重编应用**:同一个 `app_b.o` 换掉后端目标文件重链即成。
+
+⇒ 与 K3 合起来给出两层相反的 ABI 结论:
+
+| | AAL | KAL |
+|---|---|---|
+| 典型操作 | `local_irq_disable()` 本该一条 `csrci` | `write()` 本来就要陷入内核 |
+| 一次 call 的相对成本 | **灾难性** | 可忽略 |
+| 正确形态 | **concept + LTO**(K3) | **C ABI**(KA2) |
+
+⚠️ 这正是 Linux 的实际做法(`asm/` 的 `static inline` vs 导出的 syscall 入口)—— 不是巧合。
+
+### 1.13 TH1–TH6 线程契约面 + ⚠️ `thread_local` 的静默失败
+
+**TH1/TH2 —— 契约面有多大(决定这条路是一个下午还是一个季度):**
+
+| | 名字数 |
+|---|---|
+| libc++ `__external_threading` | **36**(~30 函数 + 8 类型):mutex×4 · recursive_mutex×5 · condvar×5 · thread×9 · once×1 · tls×3 |
+| libstdc++ gthreads(`gthr-default.h`) | 71 —— **但其中 17 个是 `__gthread_objc_*` 遗留** ⇒ 真实面 ~30,与 libc++ 高度重合 |
+
+libc++ 已有 `__thread/support/{pthread,windows,c11,external}.h` **四个后端** —— 可插拔线程后端这个形状在标准库里已经存在。
+
+**TH4–TH6 —— ⚠️ `thread_local` 在裸机上是一个完整的静默失败:**
+
+```
+thread_local int counter;   →  编译 ✅  链接 ✅  零未定义符号 ✅  零诊断 ✅
+产生段:.tbss (4 字节)
+
+bump():
+    lw  a0, 0x0(tp)          ← 通过 tp 寄存器寻址
+    addiw a0, a0, 0x1
+    sw  a0, 0x0(tp)
+
+start.S 里设过 tp 吗?  → 没有(只设了 sp)
+```
+
+**⇒ 全绿,运行期静默读写垃圾地址。** 与 §1.1 的 E1 同族:**「没有红」才是问题**。
+
+`thread_local` 不属于线程契约(KAL),属于 **AAL(TLS 寄存器约定)+ BSP(`start.S` 设 `tp` + 链接脚本 `.tdata/.tbss`)**。⚠️ 且 libstdc++/libc++ 内部自己用 `thread_local`,不是「用户不写就没事」。
+
+⇒ **裸机验收用例必须含一个 `thread_local`**,否则这条会活很久。
+
+### 1.14 M1–M5 / ISO 系列:现代 C++ 惯用法可行,⚠️ 以及一次不合格对照的教训
+
+**M1–M3 —— 惯用法在裸机上全部跑通,而且零成本是实测的:**
+
+`concept`(能力契约)+ concept 的 `&&`(world = 接口组合)+ `std::expected`(结构化错误,零 libc 可用)+ **deducing this**(后端只写 `write()`,`write_all()` 免费)+ `if constexpr`(可选能力做增强)。
+
+链接零未定义符号,**text 698 字节**;`kmain` 反汇编 **`jal` 条数 = 0** —— 整条 `log → write_all → write → expected` 链全部内联成直线代码(前提是 **LTO**,见 K3)。
+
+**⚠️ M4/M5 的初始结论是错的,原因是一次不合格的对照。**
+
+初稿断言「clang 22 + 模块 + concept 诊断 = ICE」。但那组对照**同时换了两个变量**(模块 vs 头文件、以及 target/标准库配置)。逐个隔离:
+
+| 隔离 | 结果 |
+|---|---|
+| ISO-1 宿主 + 正常 libc++ + 模块 + 失败 concept | ✅ 诊断完美 |
+| ISO-2 加回 `--target=riscv64-none-elf -ffreestanding` | ✅ |
+| ISO-3 概念里用 `std::` 类型(import std 子集) | ✅ |
+| ISO-4 两个 `import` 同一行 | ✅(clang 接受;GCC 报解析错) |
+| ISO-6 `deducing this` + 跨模块继承 | ✅ |
+| **真因:一个 BMI 建于 `-O2`,另一个建于 `-O2 -flto`,混用** | ❌ **ICE** |
+| **同组 flag 重建全部 BMI** | ✅ **诊断完美** |
+
+flag 一致后的诊断质量远超预期(精确到缺哪个成员):
+
+```
+error: static assertion failed: world 缺 threads 能力
+note: because 'bsp::BareWorld' does not satisfy 'RtosWorld'
+note: because 'w.threads()' would be invalid: no member named 'threads' in 'bsp::BareWorld'
+```
+
+**⇒ 两条结论:**
+
+1. **惯用法完全成立,不存在路线阻塞。**
+2. ⭐ **「BMI flag 一致性」不是优化问题,是「不一致会让编译器崩」** —— 这抬高了「BMI 缓存键必须含 freestanding 轴」的等级(后果从「结果不对」变成「编译器崩溃栈」)。**而 mcpp 的指纹/缓存键系统正是防这个的;我是手敲命令行绕过了它才踩到。**
+
+⚠️ **方法论教训**:这一轮我又犯了「对照组同时换两个变量」的错(与 `gcc-bmi-body-insensitive` 那次同族)。**是用户的质疑逼出了重测。** 不合格的对照会把一个配置错误读成编译器缺陷,并据此得出「路线被阻塞」的结论。
+
+### 1.15 AAL / CABI 系列:最硬原语的裂缝,与 C ABI 编码的代价
+
+**AAL-1/AAL-2 —— 「AAL 会不会碎」的正面测试。**
+
+两个**真实不同**的 arch 实现(riscv Sv39 风格 PTE 位 `V/R/W/X/U` vs x86-64 风格 `P/RW/US/NX`,Context 布局完全不同)+ 一段只依赖 concept 的通用内核代码:
+
+- **AAL-1 通过**:同一段 `setup_task()` 对两个 arch 各实例化一次,**`call` 条数 = 0**。
+- **AAL-2 主动找裂缝,找到三条,而且分成两类:**
+
+| # | 裂缝 | 表现 | 类型 |
+|---|---|---|---|
+| 1 | execute-only(riscv 支持 X 不带 R,x86-64 经典分页做不到) | **两边都编过**,x86 实现静默给了 R+X | **A 类:类型对、语义错、静默** |
+| 2 | 页大小按下标取 `page_sizes[1]` | 编过;riscv/x86 恰好都是 2M,aarch64 16K granule 下是 32M | **A 类** |
+| 3 | 通用代码设 syscall 返回值 `c.a0 = v` | `error: no member named 'a0' in 'RvSv39::Context'` | **B 类:编译期硬错** |
+
+⇒ **规则**:A 类**必须提到能力轴**;B 类**承认它不属于通用层**。与 K2(MMU)、实时性是同一条规则的三次应用。
+
+**CABI —— `result<T,E>` 在 C ABI 上的两种编码,代价实测:**
+
+| 编码 | x86-64 | riscv64 |
+|---|---|---|
+| **2 字结构返回** | **9 条指令** | **10 条指令,2 次内存存取** |
+| 出参 + 错误码 | 12 条指令,3 次栈存取 | 12 条指令,4 次内存存取 |
+
+riscv 反汇编显示 err/value 直接走 `a0`/`a1`,`snez`/`and` 就地做分支消除,**不落栈**。
+
+⇒ **两个 arch 上结构返回都更便宜** ⇒ KAL 的 `result` 用 2 字结构返回。⚠️ 限制:`T` 必须 ≤ 一个机器字,否则退化成隐藏指针。
+
+---
+
+## 2. 生态对照:别人怎么解
+
+### 2.1 Rust / Cargo —— 最完整、也最值得抄的对照
+
+Rust 把裸机拆成**四个互不耦合的层**,这正是 mcpp 缺的分层:
+
+| 层 | Rust 的东西 | 承载什么 |
+|---|---|---|
+| 库分层 | `core` / `alloc` / `std` **在源码层就是三个 crate** | `#![no_std]` 是**减法可证**的:`core` 一定存在 |
+| 目标规格 | 内置 target(如 `riscv64imac-unknown-none-elf`)或 **target-spec JSON** | ISA/ABI/code-model/panic-strategy/linker-flavor 都是**数据** |
+| 板级支持 | `riscv-rt` / `cortex-m-rt` crate + `memory.x` | 启动代码 + 链接脚本 **随包分发** |
+| 运行/调试 | `.cargo/config.toml` 的 `runner = [...]` | `cargo run` → `qemu-system-riscv64 -kernel <artifact>` |
+
+典型 `.cargo/config.toml`:
+
+```toml
+[build]
+target = "riscv64gc-unknown-none-elf"
+rustflags = ["-Clink-arg=-Tsrc/lds/virt.lds"]
+
+[target.riscv64gc-unknown-none-elf]
+runner = ["qemu-system-riscv64", "-nographic", "-machine", "virt", "-kernel"]
+```
+
+对 mcpp 最重要的三点:
+
+- **`core` 的存在是 `no_std` 好用的全部原因。** C++ 侧没有任何实现提供等价物(E4)。这是 C++ 裸机体验落后 Rust 的**根因**,不是工具链问题。
+- **target spec 是文件/数据,不是 flags。** 用户不会在 `Cargo.toml` 里写 `-mcmodel=medany`。
+- **`runner` 只有一行。** 但它把「裸机产物不能直接 exec」这件事整个吸收掉了。
+
+另有 `-Z build-std=core,alloc`(从源码为任意目标现编标准库)——C++ 侧的对应物恰好就是「为目标现编一份 libc++ / `__config_site`」,E5 已经证明其可行性形状。
+
+### 2.2 Zig
+
+target 语法直接是 `arch-os-abi`,`os` 的合法取值里就有 **`freestanding`**(`riscv64-freestanding-none`)。Zig 自带多目标 LLVM 后端 + 自己的 libc/compiler-rt,所以「换 target 就换世界」是零成本的。
+
+**对 mcpp 的启发是 triple 语言本身**:mcpp 的 triple 文档(`triple.cppm:6`)明写「canonical 是 `arch-os[-env]`(三段,无 vendor —— Zig 风格)」,**却把 `os` 的取值锁死在 `{linux, macos, windows}`(同文件第 12 行)**。加一个 `none` 是这套语言的自然延伸,不是异物。
+
+### 2.3 CMake / Conan / PlatformIO / Zephyr
+
+- **CMake**:`CMAKE_SYSTEM_NAME=Generic` 表示「目标没有 OS」,并且必须配 `CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY`,否则 CMake 的工具链探测会去链一个可执行文件而必然失败。⚠️ **这条对 mcpp 直接适用**:mcpp 的 doctor / 工具链探测里任何「编个小程序链一下」的动作,在 `os=none` 下都会假失败。
+- **Conan**:2021 年(1.43)才加 `os=baremetal` 设置,并且官方说明是「这只是一个通用命名约定,预期用户在其下自定义子设置来表达具体硬件/板子/系列」。⇒ **连 Conan 也没有把板子建模进核心**,而是留给 profile。这支持本文第 6 条:板级是数据/包,不是引擎。
+- **PlatformIO / Zephyr(west)**:走到了另一极端——内建**成千上万的板子定义**。这是「发行版构建器」的形态,与 `2026-07-24` 决策 #1(mcpp 不做发行版构建器)明确冲突,**不应作为 mcpp 的方向**。
+
+### 2.4 LLVM Embedded Toolchain(可直接借用的载荷形态)
+
+ARM 维护的 `LLVM-embedded-toolchain-for-Arm` 打包了 **clang + lld + libc++ + libc++abi + compiler-rt + picolibc(可选 newlib / llvm-libc)**,通过 multilib 按 `--target` + FPU 选项自动选库,并提供 `--config` 配置文件。官方说明「C++ 通过 libc++/libc++abi **部分支持**,无多线程,ABI 不稳定」。
+
+⇒ 这就是 E2+E3+E5 三条实测拼出来的那个东西的**成品形态**:mcpp 若走到载荷层,不必从零设计,**这套组合已被验证**(且 RISC-V 也在其目标内)。
+
+### 2.5 OSDev 的既有实践约束
+
+OSDev Wiki 的裸机基线要求几条硬约束,任何 mcpp 方案都绕不开:
+
+- 必须用**交叉编译器**,不能用宿主编译器(mcpp 侧对应 E1:必须真发 `--target`);
+- 链接顺序 **`crti.o` → `crtbegin.o` → 你的 .o → `crtend.o` → `crtn.o`**,顺序错会出「奇怪的 bug」;`crtbegin/crtend` 由编译器提供,`crti/crtn` 要自己写;这两个共同实现 `_init`/`_fini`,**即全局构造函数的调用点**;
+- 编译用 `-ffreestanding`,链接用 `-nostdlib` + `-lgcc`。
+
+⇒ **C++ 的全局构造在裸机上是 BSP 的职责**(`_init` / `.init_array` 遍历)。这条把「BSP 必须能贡献链接输入和链接顺序」这个需求钉死了——不是可选糖。
+
+---
+
+## 3. 标准侧现状:freestanding 与 std 模块
+
+- **freestanding 库子集正在扩大**:P1642(把 `[utilities]`/`[ranges]`/`[iterators]` 的大部分加入 freestanding 子集)、P2338(把「无需 OS 调用、无空间开销」的一切加入 C/C++ 共享 freestanding 库,含 `charconv`、`char_traits`)。C++23 起 `<cstdint>` 等已标为 "all freestanding"。
+- **但模块与 freestanding 的交叉是空白**:P1212R0(*Modules and Freestanding*, 2018)提出四个选项并倾向「扩库 + 裁语言(去异常/RTTI/TLS/默认堆)」,得到 SG14 支持,**但没有进入标准**。P0829 的 freestanding 提案系列同样未落地为 `std.freestanding` 模块。
+- **最新动向**:SG14 在 2025-05 的会议记录(P3693R0)里出现「下次会议是 Embedded,我想知道大家是否认为 `std.freestanding` 模块值得推进」。**这是「还在问值不值得做」的阶段,不是「在做」。**
+
+⇒ **未来 3~5 年内不会有标准化的 freestanding std 模块。** mcpp 若要在裸机上给用户任何 `import`-able 的标准设施,**只能自己做成一个包**(见第 7 节的 `mcpp.core` 设想),不能等标准。
+
+反过来说,这也是 mcpp 唯一可能领先的位置:**mcpp 是 modules-first 的工具,而整个 C++ 生态还没有人发布过「模块化的 freestanding 子集」。**
+
+---
+
+## 4. 问题分解:裸机支持 = 六条正交轴
+
+把 issue #403 的五个痛点重排成正交轴,可以看清哪些是引擎、哪些是生态、哪些根本不是 mcpp 的事。
+
+| # | 轴 | 今天 | 归属 | 规模 |
+|---|---|---|---|---|
+| 1 | **目标身份**:triple 语言容纳 `os=none` | `none` 被当 vendor 跳过(`triple.cppm:299`),整串不可解析 | **引擎** | 小 |
+| 2 | **目标规格**:ISA / ABI / code-model / 载入地址 | 无处安放;塞 `[build].cxxflags` 会漏掉依赖 | **引擎(数据表)** | 中 |
+| 3 | **链接模型**:`-nostdlib -nostartfiles -static -T script`,无 loader / 无 rpath / 用 lld | `CLibMode::None` 存在但语义是「什么都没找到,退回驱动默认」——是**退化态不是正向态** | **引擎** | 中 |
+| 4 | **板级支持**:`start.S` / `link.ld` / `_init` 顺序 / 复位向量 | 无 | **生态(包)** | 小(机制已有) |
+| 5 | **运行/调试**:qemu runner、semihosting 退出码 | 全仓 `runner\|qemu` 有效命中 **1 处**(且无关) | **引擎(一条缝)+ 生态(命令)** | 小 |
+| 6 | **标准库**:`import std` 关断 + freestanding 子集 | 无判定、无诊断 | **引擎(诊断)+ 生态(子集包)** | 小 + 大 |
+
+关键观察:**六条里只有 1/2/3 必须动引擎,而且都不大;4/6 的重头在生态。** 这与 E2(载荷已够用)一致——mcpp 缺的是模型,不是能力。
+
+### ⚠️ 4.1 为什么第 2 轴必须是「数据」而不是「flags」
+
+`-march=rv64gc -mabi=lp64d -mcmodel=medany` 三者有一个共同性质:**链接进同一个镜像的每一个目标文件都必须用完全相同的值编译**,否则要么 lld 在链接期报 ABI 不匹配,要么更糟——过了但运行期行为错。
+
+`[build].cxxflags` 的作用域是**本包**。依赖(未来的 BSP 包、驱动库、第三方 freestanding 库)拿不到它们。所以 issue #403 里那份 `mcpp.toml` 即使 mcpp 修好了「宿主解析」问题,**一旦引入第二个包就会碎**。
+
+Rust 把这些放进 target spec(数据),CMake 放进 toolchain file(数据),Conan 放进 profile(数据)。**三家独立收敛到同一个答案,这不是巧合。**
+
+同时这条与仓库既有原则直接对齐:`.agents/docs/2026-08-18-open-items-analysis-and-axis-discipline.md` 的 flag-axis 纪律、以及 `#233/#240/#242/#344` 那批「同一决策两处推导 = 架构债」。**目标规格必须是一张表,被编译 flags、链接 flags、产物命名、runner、`cfg()` 求值共同消费。**
+
+---
+
+## 5. 三条路线
+
+### Route A — 明确不做(维持决策 #15)
+
+- **做什么**:把 `os=none` 加入 triple 语言**仅用于识别并拒绝**,给一条清楚的「mcpp 不支持裸机目标,建议使用 Makefile/CMake」诊断;修掉 E1 的静默失败。
+- **代价**:issue #403 的 toy_kernel 继续用 Makefile;C++ 裸机生态与 mcpp 无关。
+- **何时选它**:如果判断裸机用户与 mcpp 的核心价值(modules + 包管理 + 现代 C++23)重叠太少。⚠️ 但注意:**决策 #15 的两条理由已被 E2/E4 部分推翻**——「需要 freestanding modules 核心特性」是错的(模块在裸机上直接可用,E2),真正缺的只是 `import std`(E4);「512KB MCU 上 modules 优势无关」对 MCU 成立,**对 RISC-V 内核/SoC 不成立**(toy_kernel 正是后者)。
+
+### Route B — 最小可落地缝(**推荐**)
+
+开三条缝,板级走包:
+
+1. **triple 语言收下 `os=none`**(`env` 取 `elf`,canonical `riscv64-none-elf` —— 与 Rust/LLVM 拼写一致),`family()` 返回空(⇒ `cfg(unix)` / `cfg(windows)` 自动为假,已是现有行为),新增 `cfg(freestanding)` 或 `cfg(os = "none")` 谓词。
+2. **`kKnownTargets` 增加目标规格列**(ISA / ABI / code-model / 默认链接器),并让 `[target.<triple>]` 能覆写这些键 —— 闭词表 + 逃生舱,与仓库既有风格一致。
+3. **`CLibMode` 增加正向的 `Freestanding` 态**:发 `-ffreestanding -nostdlib -nostartfiles -static -T <script>`,**不发** loader / rpath / crt 前缀;链接器强制走载荷内的 `ld.lld` 绝对路径(E6-1)。hermetic 检查在此模式下**从「报告泄漏」升级为「任何宿主路径即致命」**。
+4. **`[target.<triple>].runner`**:`mcpp run` 把产物路径追加到 runner 命令尾部执行(Cargo 同款语义)。
+5. **`import std` 在 `os=none` 上关断 + 诊断**。
+6. **BSP 走包**:链接脚本、`start.S`、`crti/crtn`、runner 命令由索引里的一个普通包提供(`riscv-virt-rt` 之类)。**需要新增的只有「链接脚本 + 链接顺序」这一类 provision**;工具、host module、依赖目录等 provision 机制(`src/build/provisions.cppm` 的 `kTable`)已经就位,新增一行即可。
+
+- **不做**:不建板子数据库、不打包 GCC 裸机交叉链、不做 freestanding std 子集。
+- **产出**:issue #403 的 toy_kernel 能用 `mcpp build/run --target riscv64-none-elf` 全流程跑通,`mcpp.toml` 里没有一条 hack。
+
+### Route C — 全栈裸机(方向,不是下一步)
+
+在 B 之上加:per-target compiler-rt builtins(E3)、freestanding `__config_site` + picolibc 载荷(E5)、**`mcpp.core` 模块化 freestanding 子集**(第 3 节论证的差异化位置)、`mcpp test` 的 qemu + semihosting 退出码、`mcpp debug` 的 gdb stub 接线、BSP 模板与 `mcpp new --template`。
+
+- **这是「C++ 世界的 embedded Rust 生态」**,也是唯一真正做到 issue 里那句「简单容易」的形态。
+- **规模与 `2026-07-24` 嵌入式方案相当或更大**,不应与 B 捆绑决策。
+
+**推荐:B。** 理由:E2 证明能力已在,B 的引擎改动被六条轴框得很死;而 A 与 C 都需要先回答「mcpp 要不要这个用户群」这个战略问题,B 不需要——**B 的每一条缝在非裸机场景也都有独立价值**(目标规格表、正向链接模型、runner 都是通用能力)。
+
+---
+
+## 6. 设计侧:引擎要动什么
+
+按「一个决策一处推导」的要求列。以下是**分析结论,不是实施计划**。
+
+### 6.1 一张目标规格表(第 2 轴)
+
+`triple.cppm` 的 `TargetInfo` 今天有 5 列(canonical / tier / note / pin / defaultStatic)。裸机需要它长出规格列:
+
+```
+{ "riscv64-none-elf", "planned", "bare", "llvm@22.1.8", true,
+  .isa = "rv64gc", .abi = "lp64d", .codeModel = "medany",
+  .linker = Linker::Lld, .clib = CLibMode::Freestanding }
+```
+
+**消费方必须收敛到这一处**:编译 flags、链接 flags、`cfg()` 上下文、产物命名(`.elf`)、runner 选择。⚠️ 这里最容易犯的错是「编译侧读表、链接侧再推一遍」——那正是 `linkmodel.cppm` 头注释里记载的 #195 原始病灶(四份发散的副本)。
+
+### 6.2 `CLibMode::Freestanding`(第 3 轴)
+
+现有 `CLibMode::None` 的语义是**否定式**的:「什么都没找到 —— 驱动默认(宿主)生效;hermeticity 检查报告漏进来了什么」(`linkmodel.cppm:27-29`)。裸机需要的是**肯定式**的第四态:
+
+| | `None`(今天) | `Freestanding`(新) |
+|---|---|---|
+| 语义 | 没找到 C 库 | **明确不要** C 库 |
+| CRT | 驱动默认 | `-nostartfiles`,CRT 由 BSP 提供 |
+| loader / rpath | 驱动默认 | **禁止**(PT_INTERP 必须不存在) |
+| 宿主路径泄漏 | 报告 | **致命** |
+| 链接脚本 | — | 必需,`-T <path>` |
+
+⚠️ **不要复用 `None`。** `None` 今天的行为(退回宿主驱动默认)恰恰是 E1 的静默失败,把裸机接到它上面等于把新功能建在已知缺陷上。
+
+### 6.3 runner 缝(第 5 轴)
+
+`mcpp run` 今天假定产物可直接 exec(`cmd_build.cppm:153` → `build_run_target`)。最小改动:目标规格/`[target.<triple>]` 提供 runner argv,`run` 在其尾部追加产物路径。`mcpp test` 同理,但**需要一个退出码约定**(qemu semihosting / `sifive_test` 设备)—— 这条属于 C,B 阶段可只做 `run`。
+
+### 6.4 `import std` 的关断(第 6 轴)
+
+现有 `hasImportStd` 门 + import-std 诊断(`prepare.cppm` 附近)已经是正确的挂点。需要的是:`os=none` ⇒ `hasImportStd = false`,且诊断文案要说清**为什么**(「`import std` 需要 hosted 实现;`riscv64-none-elf` 是 freestanding 目标」),并指向替代路径。
+
+⚠️ **不要做部分 std。** 见第 1.4 节。
+
+### 6.5 BSP 的 provision 形状(第 4 轴)
+
+BSP 包需要向消费者贡献:链接脚本路径、启动目标文件、**链接顺序约束**(OSDev 的 `crti → crtbegin → user → crtend → crtn`)、runner 命令。
+
+`src/build/provisions.cppm` 的 `kTable` 设计意图正好是这个:「一个 provision KIND 是 kTable 的一行,每行声明它是否可按裸名寻址、是否只在显式 re-export 的边上传播」。**新增 `LinkerScript` / `StartupObjects` 两行,复用同一套 fixpoint 传播**,不新增传播逻辑。⚠️ 顺序约束是这里唯一的新语义(现有 provision 都是集合,没有序),需要单独想清楚。
+
+---
+
+## 7. 使用侧:「简单容易」长什么样
+
+### 7.1 今天(issue #403 实录)
+
+`mcpp.toml` 里 8 行 hack flags + 一份 Makefile 手写 link/run/debug + `find target -name "*.a" | head -1` 靠运气取产物。**而且按第 1 节,那份 `mcpp.toml` 今天会静默产出宿主二进制。**
+
+### 7.2 Route B 之后
+
+```toml
+[package]
+name = "toy_kernel"
+version = "0.1.0"
+
+[dependencies]
+riscv-virt-rt = "1.0"          # BSP:start.S + link.ld + runner,来自索引
+
+[target.riscv64-none-elf]
+toolchain = "llvm@22.1.8"
+```
+
+```console
+$ mcpp build --target riscv64-none-elf
+$ mcpp run   --target riscv64-none-elf     # BSP 的 runner → qemu-system-riscv64 -kernel …
+```
+
+**用户手写的裸机知识 = 0 行。** ISA/ABI/code-model 来自目标规格表(数据),链接脚本与启动代码来自 BSP 包,运行命令来自 BSP 包。这与 Rust 的 `riscv-rt` + `runner` 组合是同构的。
+
+再加一层糖(仍属 B):
+
+```console
+$ mcpp new toy_kernel --template riscv64-virt-kernel
+```
+
+### 7.3 `mcpplibs.std.freestanding`:一个开发者可选用的子集包
+
+§1.7 已经把它跑通了,所以这里写的是**实测形态**而不是设想:
+
+```cpp
+export module kmain;
+import mcpplibs.std.freestanding;          // ← 可选;不 import 就是纯裸机 C++
+
+struct Task { int prio; char id; };
+
+export extern "C" void kmain() {
+    std::array<Task, 4> t{{{3,'c'},{1,'a'},{4,'d'},{2,'b'}}};
+    std::ranges::sort(t, {}, &Task::prio);
+    std::optional<Task> top = t.empty() ? std::optional<Task>{} : std::optional{t.back()};
+    std::atomic<int> seen{0};
+    std::span<Task> sp{t};
+    for (auto const& x : sp) { seen.fetch_add(1); /* MMIO */ }
+    // std::thread / std::mutex 在这里根本不存在 —— 编译期就报错,不是运行期惊喜
+}
+```
+
+关键性质(全部实测):
+
+- **名字就是 `std::`,不是影子命名空间。** `.inc` 用的是 `export namespace std { using std::span; }` —— 再导出的是**同一个实体**,不是副本。所以它与任何 `#include <span>` 的代码 ODR 兼容,也不会造成「两套 span」。这也意味着**用户代码从裸机移回 hosted 时一行不用改**。
+- **可选。** 不 import 它,项目就是纯裸机 C++(E2 那个内核就没用它)。
+- **源文件是生成的**(208 行,全是 `#include`),导出表由 libc++ 上游维护。
+- **`.inc` 清单 = 这个包的全部策略。** 「哪些设施在裸机上算数」这个领域判断落在**包**里,与 `2026-07-24` 决策 #6(绑定质量是封装作者的领域知识,不是 mcpp 机制)一致。
+
+⚠️ 三条诚实的代价:
+
+1. **libc++ 侧要跟随版本**(`__config_site` 每 target 一份,随版本走)。libstdc++ 侧没有这个负担(`-ffreestanding` 即可,Y1)。
+2. **T3 档需要为目标编 libc++.a**(`std::format`、标量 `std::sort`)。T1/T2 不需要。
+3. ~~绑定 clang/libc++~~ —— **这条已被 Y3 推翻**:同一份实现中立的 `core.cppm`(自己写 `export namespace std { using std::span; … }`,不用 `.inc`)在 **libstdc++ + `-ffreestanding`** 和 **libc++ + `__config_site`** 两边都编过。导出的名字是标准规定的,`.inc` 只是一份方便的清单。**代价变成:适配层要自己维护那张名字表**(约 52 个头的公共子集),换来实现中立。这是划算的交易,也是这个包存在的真正理由 —— **它提供的是「两家都保证的可移植 freestanding 子集」,而不是「libc++ 的转发」。**
+
+---
+
+## 7.5 生态侧:一个库「在裸机上能不能用」怎么表示
+
+这是比引擎改动更长期的一条,必须整体设计,否则会变成一堆各自为政的布尔键。
+
+### 7.5.1 先把问题问对:它不是一个布尔
+
+`freestanding = true` 表达不了任何真实情况。真实的轴是**环境能力集**:
+
+```
+heap | exceptions | rtti | threads | hosted-std | float | lockfree-atomics
+```
+
+一个库可能要堆但不要异常;可能纯头无所谓;可能只有某个 feature 要堆。**布尔会立刻不够用,然后长出第二个布尔。**
+
+⚠️ **并且这些轴里没有一条是「hosted 专有」的**(§1.9 T1–T3b 实测):`heap` 由 BSP 的 `operator new` 替换即可(零 libc 跑通 `std::vector`),`threads` 由 RTOS 接进 gthreads / `__external_threading` 即可。**能力是可插拔的符号契约,不是「有没有操作系统」的同义词。** 本节初稿把 `std::thread` 归为 `hosted`,那是错的。
+
+而 §1.8-Y4 已经证明**档位是环境的函数,不是标准库的函数**:libc++「更宽」只是因为 picolibc 给了堆。所以正确的建模是「能力集」,`T0/T1/T2` 只是它上面的**命名预设**。
+
+### 7.5.2 三层,各司其职
+
+| 层 | 谁声明 | 内容 | 何时求值 |
+|---|---|---|---|
+| **目标提供** | 目标规格表(§6.1)+ BSP 包 | `os=none` ⇒ 默认全关;BSP 提供 `sbrk` ⇒ 打开 `heap` | 解析期 |
+| **库需要** | 包(可选) | 需要的能力集;可 per-feature | 解析期 |
+| **产物验证** | mcpp | 符号审计(Y5) | 编译/链接期 |
+
+### 7.5.3 ⚠️ 关键洞察:验证是免费的,因为裸机链接本身就是验证
+
+X7–X10 实测:裸机链接会**逐条点名**缺什么(`memmove`、`__libcpp_verbose_abort`、`basic_string::__init`)。因为 `-nostdlib` 下**没有 libc/libstdc++ 来静默满足这些符号** —— 而 hosted 链接恰恰会。
+
+⇒ **只要 §6.2 的 `CLibMode::Freestanding` 是真的 `-nostdlib`,「这个库用了它不该用的东西」就是一个硬错误,不需要任何新机制。** Y5 的符号表只是把同一件事**提前**到单个目标文件层面并翻译成人话。
+
+### 7.5.4 ⇒ 因此元数据的职责不是正确性,是把错误提前
+
+这一步决定了整个设计的取舍:
+
+| | 有元数据 | 无元数据 |
+|---|---|---|
+| 正确性 | ✅ | ✅(链接期硬错) |
+| 错误发生在 | **解析期,报「包 foo 需要 heap,目标 riscv64-none-elf 未提供」** | 链接期,报 `undefined symbol: _Znwm` |
+| 用户能否行动 | 能(换包/开 BSP heap) | 难(要自己把 mangled 符号翻译回包) |
+
+**元数据是诊断质量,不是正确性依赖。** 这条直接解掉最难的兼容问题(下一节)。
+
+### 7.5.5 ⚠️ 不能要求生态先标注
+
+mcpp-index 里已发布的包不会为了裸机去改 manifest。而且按索引地板那次的教训(`index-floor-must-degrade`):**不认识的键会让旧客户端整份 manifest 加载失败 ⇒ 已发布包永远无法采用新键。**
+
+因为 7.5.4 成立,这个问题消失:
+
+- **未标注 = 未知,不是不支持。** 不可证伪就放行(与 `mcpp add` 存在性门同一判据),让链接期兜底。
+- **hosted 目标上完全不引入门**(零行为变化)。
+- **验证结果由 `mcpp publish` 计算并写进索引描述符**,不是写进用户的 manifest —— **索引是数据,manifest 是声明**。这与 PR#451 的 `[[runtime.artifacts]] 承载证据` 同形。
+
+### 7.5.6 落到 mcpp 现有词表,新增键尽量为 0
+
+| 需要表达的 | 用现有的什么 | 是否要新键 |
+|---|---|---|
+| 「这段代码只在有堆时编」 | `[target.'cfg(...)'.build]` 条件通道 + 新增 `cfg(freestanding)` 谓词 | **0**(谓词是词表扩展,不是新段) |
+| 「这个 feature 需要堆」 | 已有 feature 系统 | **0** |
+| 「这个库需要哪些能力」 | `[runtime] capabilities/provides` 已是 requires/provides 语法;但 `[runtime]` 语义是**运行期宿主能力**,环境契约是**编译/链接期目标属性**,塞进去会是第二次「一个名字量两件事」 | 需要时再开,**且要先证明诊断确实不够** |
+| 「验证结果」 | 索引描述符 | **0**(索引侧字段,非 manifest) |
+
+**建议分期**:先做 `cfg(freestanding)` 谓词 + 链接期兜底 + 符号审计诊断(**manifest 零新增键**);**只有当诊断被证明不够好时**,再考虑声明键。这与本仓「先证明需要,再加键」的做法一致 —— 反例是 `cxxRuntimeTests`(#418):一个解析在 nowhere、应用在 nowhere 的键,看起来可用,什么都不做。
+
+### 7.5.7 ⚠️ 符号审计抓不到什么(必须写进文档,否则会被当成完备保证)
+
+1. **inline asm / 裸 syscall / MMIO** —— 不产生任何可疑符号。
+2. **纯头库在自己这一侧没有产物**,需求只在**消费者**的目标文件里显形。⇒ 审计必须能在消费者侧跑(这恰好是裸机链接天然发生的地方),不能只在库发布时跑一次。
+3. **能力够 ≠ 能用**:一个 T0-clean 的库可能仍然要 `<format>`(T1)。审计答的是「用了什么」,不是「够不够」。
+4. **弱符号/COMDAT** 不能与 `U` 混算(与 `origin-precedence` 那次「判据必须是 GLOBAL 计数」同一类错误)。
+
+---
+
+## 8. ⚠️ 陷阱清单
+
+按「会让人误判成功」的危险程度排序。
+
+1. **E1 的静默失败会在任何路线下继续存在,除非专门修。** 它不在 issue #403 的五个痛点里(#403 报的是硬失败),是本次调研新发现的。守卫已存在于相邻路径(`prepare.cppm:1301`),逃生舱绕开了它。
+2. **裸机 e2e 会因为缺 qemu 而全体静默跳过。** 本仓 261 个 e2e 用 `# requires:` 门控,现有 token 里 `gcc` 96 次、`elf` 40 次。⚠️ 按 PR#451 的教训(十个新 e2e 因 `# requires: gcc` 在 macOS/Windows **全跳过**,放开后才暴露 Windows/macOS 真实失败),**一个 `# requires: qemu` 就足以让整条裸机线在 CI 上永远绿而从未运行**。裸机验收必须**先**回答「CI 上谁真的跑了它」。
+3. **hello-kernel 是 builtins 缺口的假绿**(E3)。验收用例必须含 64 位除法/软浮点。
+4. **`ld.lld` 按名字寻址会拿到 GNU ld**(E6-1),而 GNU ld 对 riscv 的报错是 `cannot represent machine 'riscv'` —— 一条**不像是「找错链接器」**的错误信息,极易误判成目标不支持。
+5. **`-mcmodel` 漏了会在链接期才炸,且报错是 relocation 越界**(E6-2),同样不像配置缺失。
+6. **`[build].cxxflags` 路线在单包工程上能跑通**,引入第二个包才碎(§4.1)。⚠️ 也就是说:**用 toy_kernel 单包验证「flags 方案够用了」会得到错误结论**。
+7. **CMake 的 `CMAKE_TRY_COMPILE_TARGET_TYPE` 教训适用于 mcpp**:任何「编个小程序链一下」的探测(doctor / 工具链能力探测 / `hasImportStd` 探测)在 `os=none` 下都会假失败。这条需要在实施前普查。
+8. **`import std` 若做成「部分可用」,会污染 BMI 缓存身份。** 参考 C++20 档位设计里「跨档位 BMI 硬拒 ⇒ 零缓存改动」的先例——freestanding 必须是**缓存键的一个轴**,或者干脆硬拒。
+9. **决策 #15 的两条理由需要更新**(不是推翻整个决策,是更新它的依据):模块本身在裸机可用(E2),真正缺的只有 `import std`(E4);MCU 论证对 RISC-V SoC/内核不成立。
+10. **⚠️「N 个头能 include」是一个几乎无意义的数字,除非配真实使用探针**(X4)。`__config_site` 把 LOCALIZATION/THREADS 关掉后,`<iostream>` 仍然「能 include」——因为它被守卫成了近乎空文件。**统计 include 成功率 = 统计空文件数量。**
+11. **⚠️ 没有宿主对照组,会把「libc++ 还没实现」记成「裸机不支持」**(X3)。7 个失败头在 x86_64 + 完整 libc++ 上同样失败。**对照组把「freestanding 的编译期损失」从「7 个头」修正为「0」。**
+12. **⚠️ picolibc 的发行版包没有 rv64gc/lp64d 变体**(X11)。用 `rv64imac/lp64` 验证通过**不能**推广到最常见的 RISC-V profile —— 这是一个「换个 `-march` 就没有库」的隐形边界。
+13. **⚠️「libc++ 比 libstdc++ 的 freestanding 子集更宽」是错的排序**(Y1/Y2)。103 vs 53 里,libc++ 的一半是**能 parse 的空壳**(`std::mutex` 根本不存在),libstdc++ 是硬 `#error`。**更宽的那个数字来自更含糊的失败方式。** 我自己在 §1.7 就是靠这个数字得出了「绑定 clang/libc++」的错判,Y3 推翻了它。
+14. **⚠️ 符号审计不是完备保证**(§7.5.7):inline asm / 裸 syscall 不留痕;纯头库在自己这侧没有产物;弱符号不能与 `U` 混算。**把它当成完备门会比没有门更危险。**
+
+---
+
+## 9. 待 review 的决策点
+
+请逐条给方向,后续才好出实施方案。
+
+| # | 决策点 | 选项 | 本文倾向 |
+|---|---|---|---|
+| D1 | **E1 的静默失败何时修** | (a) 立即,独立于路线 (b) 随路线一起 | **(a)** —— 这是已发布能力可达的错误行为,与 RFC 结论无关 |
+| D2 | **裸机的战略定位** | A 明确不做 / **B 最小缝** / C 全栈 | **B**,C 作为方向留白 |
+| D3 | **triple 语言收不收 `os=none`** | 收(canonical `riscv64-none-elf`)/ 不收 | **收**;即使选 A 也需要它来做「识别并拒绝」 |
+| D4 | **目标规格放哪** | (a) `kKnownTargets` 加列 (b) 独立 target-spec 文件 (c) 只 `[target.<triple>]` 键 | **(a)+(c)**:闭词表 + 逃生舱,与仓库风格一致;(b) 留给 C |
+| D5 | **`CLibMode` 加正向 `Freestanding` 态,还是复用 `None`** | 加 / 复用 | **加**;复用等于把新功能建在 E1 的缺陷上 |
+| D6 | **BSP 走包还是走引擎** | 包(provision 加行)/ 引擎板子表 | **包**;与决策 #1(不做发行版构建器)一致,也与 Conan 的收敛一致 |
+| D7 | **`import std` 在 `os=none`** | 硬关断 + 诊断 / 尝试子集 | **硬关断**;子集是 `mcpp.core` 包的事(C) |
+| D8 | **首个验证目标** | `riscv64-none-elf` @ qemu virt(toy_kernel 现成)/ `armv7m-none-eabi` @ MCU | **riscv64 virt**:有现成用例、有 E2 的实测通路、qemu 可在 CI 装 |
+| D9 | **CI 怎么真跑** | qemu 进 CI / 只做编译+链接断言 / 不做 | 需要明确答案,否则触发陷阱 #2 |
+| D10 | **compiler-rt builtins 的来源** | 自建 / 采纳 LLVM Embedded Toolchain / 不做(B 阶段) | B 阶段可**不做但要诊断**;C 阶段倾向采纳既有成品(§2.4) |
+| D11 | **`mcpplibs.std.freestanding` 做不做、什么时候做** | (a) B 阶段就做(它是纯包,不依赖引擎改动)(b) 归到 C (c) 不做 | **(a) 可行且诱人**:§1.7 已跑通,且它**不需要任何引擎改动**——但它会把裸机线绑到 clang/libc++(见 D12) |
+| D12 | **裸机线的编译器**(§1.8 后**已改判**) | clang 优先 / GCC 优先 / **两家都支持,适配层中立** | **两家都支持**。Y3 证明中立适配层可行;Y1 证明 libstdc++ 的 freestanding 是零配置的 `-ffreestanding` 且诊断更好。⚠️ 但 **clang 天然多目标**(E2)在裸机这条线上仍是结构性优势 —— 结论是「载荷优先 clang、库中立」,**不是分叉** |
+| D13 | **freestanding libc 的来源** | picolibc(自建 multilib)/ 采纳 LLVM Embedded Toolchain / newlib | **picolibc**;⚠️ 但发行版包**没有 rv64gc 变体**(X11),必须自建或采纳成品 |
+| D14 | **`mcpplibs.std.freestanding` 的形态** | 转发 libc++ `.inc` / **自写实现中立的名字表** | **自写中立表**(§7.3 修正条 3):代价是维护约 52 个头的公共子集清单,换来两家标准库通用 + 可移植性成为包的卖点 |
+| D15 | **生态如何表示 freestanding 可用性** | 加 manifest 声明键 / **cfg 谓词 + 链接期兜底 + 索引侧验证结果** | **后者**(§7.5):manifest **零新增键**;元数据只负责把错误提前,不负责正确性;⚠️ 不能要求已发布包先标注 |
+| D16 | **档位命名** | `T0/T1/T2` / `freestanding-core` + `freestanding+heap` + `hosted` / 直接用能力集 | 倾向**能力集为准、档位只做命名预设**(§7.5.1)—— 布尔和固定档位都会很快不够用 |
+
+---
+
+## 10. 四个视角:同一批证据,谁该做什么
+
+前九节按「证据 → 路线 → 设计」组织。这一节把同一批结论按**角色**重投影 —— 因为四个角色的义务、失败模式和「对我意味着什么」完全不同。
+
+### 10.1 mcpp 引擎/架构侧
+
+**拥有(四件,每件必须「一处推导」):**
+
+| # | 拥有什么 | 落点 | 规模 |
+|---|---|---|---|
+| 1 | **目标身份 + 目标规格表** | `triple.cppm`:`os` 词表加 `none`;`TargetInfo` 长出 isa/abi/code-model/linker/clib-mode/env-capabilities 列 | 中 |
+| 2 | **正向的 `CLibMode::Freestanding`** | `linkmodel.cppm`:`-nostdlib -nostartfiles -static -T`,不发 loader/rpath/crt 前缀 | 中 |
+| 3 | **runner 缝** | `mcpp run/test` 不再假定产物可 exec | 小 |
+| 4 | **诊断与门** | E1 的静默失败、`import std` 关断、符号审计翻人话 | 小 |
+
+**明确不拥有:**板子数据库(与决策 #1 冲突)、std 子集的内容策略(决策 #6:领域知识归包)、libc 实现、「哪些设施算 freestanding」的判断。
+
+**⚠️ 引擎侧四个架构风险(全部有本仓先例):**
+
+1. **同一决策两处推导** —— 规格表若被编译侧读一遍、链接侧再推一遍,就是 #195 的原始病灶复发(`linkmodel.cppm` 头注释记着那四份发散副本)。
+2. **修补放在控制流到不了的地方** —— E1 就是活例:`host_can_serve` 守卫挂在 `known` 分支,逃生舱走 `!known`。**新加的门必须自己回答「逃生舱走不走这里」。**
+3. **BMI 缓存键漏掉 freestanding 轴** —— 同一份源码在 hosted / freestanding 下的 BMI 不可互换(cpp20 档位「跨档位 BMI 硬拒」的先例)。
+4. **⚠️ 探测类代码在 `os=none` 下假失败** —— CMake 因此才有 `CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY`。mcpp 里任何「编个小程序链一下」的探测(doctor、工具链能力探测、`hasImportStd` 探测)都要**在实施前普查一遍**,否则裸机目标会在探测阶段就假失败。
+
+**规模判断**:B 路线的引擎改动集中在 `triple.cppm` / `linkmodel.cppm` / `prepare.cppm` 三个**已有结构**里,不是新子系统。
+
+### 10.2 生态侧(载荷 / 索引 / 包)
+
+**要交付四类东西,其中只有第一类是真的新工程量:**
+
+| 类 | 内容 | 状态 |
+|---|---|---|
+| **载荷** | per-target compiler-rt builtins(E3);picolibc(⚠️ 发行版包无 rv64gc,X11);T3 档的目标版 libc++.a;libc++ 的每目标 `__config_site` | **唯一真缺口**;可采纳 LLVM Embedded Toolchain(§2.4) |
+| **BSP 包** | `start.S` + `link.ld` + `crti/crtn` + 默认 `__libcpp_verbose_abort`(3 行)+ runner 命令 | 机制近乎已有;⚠️ 缺「链接**顺序**」这一种 provision |
+| **`mcpplibs.std.freestanding`** | 实现中立名字表(约 52 头交集,D14) | §1.7/1.8 已跑通;**长期维护品,不是写一次** |
+| **索引侧验证结果** | `mcpp publish` 算能力集写进描述符 | 零 manifest 改动 |
+
+**⚠️ 生态侧头号风险:CI 上没人真跑。** 一个 `# requires: qemu` 就让整条裸机线永远绿(陷阱 #2,PR#451 同款)。**这条要在动手前回答,不是收尾时。**
+
+**⚠️ 第二风险:载荷的 multilib 覆盖是隐形边界。** X11 实测:换个 `-march` 就没有库。载荷的「支持哪些 ISA 组合」必须是**可查询的数据**,不能是「试了才知道」。
+
+### 10.3 应用开发者(写内核/固件的人)
+
+**今天** → issue #403 实录:8 行 hack flags + Makefile 手写 link/run/debug + `find target -name "*.a" | head -1` 靠运气。⚠️ 而且那份 `mcpp.toml` 今天会**静默产出宿主二进制**(E1)。
+
+**B 路线后** → 手写的裸机知识 **0 行**(§7.2)。
+
+**他必须知道的三件事(「简单容易」的真实边界):**
+
+1. **`import std` 没有**;但 `import mcpplibs.std.freestanding` 有,**而且名字就是 `std::`** —— 导出的是同一个实体,不是影子命名空间 ⇒ **代码搬回 hosted 一行不用改**。这是对开发者最重要的承诺:*你写的是 C++,不是裸机 C++ 方言。*
+2. **`std::thread` / `std::mutex` 不存在是编译期报错**,不是运行期惊喜(X4/Y2 实测)。libstdc++ 甚至会点名 `#error "This header is not available in freestanding mode."`
+3. **堆由 BSP 提供**;没有堆就没有 `vector`/`string`/`format`(T0 vs T1,§1.7)。
+
+**⚠️ 他会踩的两个坑:**
+- `-mcmodel` 漏了**在链接期才炸**,报错是 relocation 越界(E6-2),完全不像「配置缺失」。
+- **单包跑通不代表加了依赖还能跑** —— ISA/ABI/code-model 若走 `[build].cxxflags`,依赖拿不到(§4.1)。⚠️ 用 toy_kernel 单包验证「flags 够用了」会得到错误结论。
+
+### 10.4 库作者(发包的人)
+
+这个视角最有意思,因为它决定生态能不能长起来 —— 而 C++ 在这里与 Rust 有**结构性差异**。
+
+**⚠️ Z1 实测:纯头库的裸机可用性不是库的属性,是消费者的属性。**
+
+同一个纯头模板库 `tinylib`,两个消费者:
+
+```
+useA.cpp (用 Ring<int>) → (空)          ⇒ freestanding-clean
+useB.cpp (用 Vec<int>)  → _Znam _ZdaPv  ⇒ 需要 heap
+库自身编出的目标文件     → 无实例化,无任何符号可审
+```
+
+⇒ **「库 X 支不支持 freestanding」在 C++ 里普遍无法在库级回答。** Rust 的 `#![no_std]` 是 crate 级 + 编译器强制,C++ 侧**做不到等价的静态保证**。这不是 mcpp 的缺陷,是语言的形状,必须诚实写进文档。
+
+**架构后果(强化 D15):**
+
+- 库级标注只能是**发现/诊断层**(「这个库大概率能用」),**不能是门**。
+- 真正的判据必须在**消费者的链接**上 —— 而那恰好是免费的(§7.5.3:`-nostdlib` 下没有 libc 来静默满足符号)。
+- ⇒ **更不该建 manifest 声明键当门。**
+
+**库作者的四级投入,L0 必须永远可用:**
+
+| 级 | 做什么 | 成本 | 得到什么 |
+|---|---|---|---|
+| **L0 什么都不做** | — | 0 | 未标注 = **未知,不是不支持**;hosted 用户零影响;裸机用户靠链接期兜底 |
+| **L1 跑一次审计** | 让 mcpp 报告用了什么 | 极低 | 常见结果:**发现自己其实已经 clean** |
+| **L2 条件化** | `cfg(freestanding)` gate 掉要堆的路径 | 中 | 同一个包同时服务两端 |
+| **L3 声明 + CI** | 在裸机目标上跑 CI | 高 | 可信承诺 |
+
+⚠️ **L0 永远可用是硬承诺。** 一旦「不标注就被排除」,生态会立刻分裂成两半 —— 而 mcpp-index 里已发布的包不会为裸机回头改 manifest(索引地板那次的教训)。
+
+**⚠️ 库作者的三个陷阱:**
+1. **「我本地审计过了」不等于消费者那边干净** —— 纯头库自身没有产物(Z1)。
+2. **能力够 ≠ 能用**:T0-clean 的库仍可能需要 `<format>`(T1)。审计答的是「用了什么」,不是「够不够」。
+3. **feature 会改变答案** —— 一个 feature 开了就要堆 ⇒ 能力集必须能 per-feature,否则又是一个「一个名字量两件事」。
+
+### 10.5 一句话对齐
+
+| 角色 | 一句话 |
+|---|---|
+| 引擎 | **加三条缝(target/link/runner),不加板子数据库;新门必须自己回答「逃生舱走不走这里」。** |
+| 生态 | **唯一真缺口是载荷(builtins + libc + T3 libc++);其余是包。⚠️ 先回答 CI 上谁真跑。** |
+| 开发者 | **裸机知识手写 0 行;`std::` 还是 `std::`,搬回 hosted 一行不用改。** |
+| 库作者 | **什么都不做也不会被排除;C++ 里 freestanding 是消费者属性,库级标注只能是诊断不能是门。** |
+
+---
+
+## 附录 A:复现命令
+
+```bash
+# E1 —— 静默错构(在任意空目录)
+cat > mcpp.toml <<'EOF'
+[package]
+name = "toy_kernel"
+version = "0.1.0"
+[target.riscv64-none-elf]
+toolchain = "llvm@22.1.8"
+EOF
+mkdir -p src && echo 'int main(){return 0;}' > src/main.cpp
+mcpp build --target riscv64-none-elf          # → Finished dev … 成功
+file target/x86_64-linux-gnu/*/bin/toy_kernel # → x86-64 dynamic PIE
+grep -c -- --target target/x86_64-linux-gnu/*/build.ninja   # → 0
+
+# E2 —— 用 mcpp 现有载荷造裸机内核
+L=~/.xlings/data/xpkgs/xim-x-llvm/22.1.8
+CXX="$L/bin/clang++ --no-default-config --target=riscv64-none-elf -march=rv64gc \
+     -mabi=lp64d -mcmodel=medany -ffreestanding -fno-exceptions -fno-rtti \
+     -nostdinc++ -std=c++23"
+$CXX --precompile kmain.cppm -o kmain.pcm && $CXX -c kmain.pcm -o kmain.o
+$L/bin/clang --no-default-config --target=riscv64-none-elf -march=rv64gc \
+     -mabi=lp64d -mcmodel=medany -c start.S -o start.o
+$L/bin/ld.lld -T link.ld start.o kmain.o -o kernel.elf   # 必须用绝对路径
+$L/bin/llvm-objcopy -O binary kernel.elf kernel.bin
+$L/bin/llvm-nm -u kernel.elf
+
+# E3 —— builtins 只有宿主
+ls $L/lib/clang/22/lib/
+
+# E4 —— std 模块无 freestanding 分区
+grep -c "HOSTED\|freestanding" ~/.xlings/data/xpkgs/xim-x-gcc/16.1.0/include/c++/16.1.0/bits/std.cc
+grep -c "_LIBCPP_HAS_" $L/share/libc++/v1/std.cppm
+
+# E5 —— 合成 freestanding __config_site 后的头子集
+sed -e 's/#define _LIBCPP_HAS_THREADS 1/#define _LIBCPP_HAS_THREADS 0/' \
+    -e 's/#define _LIBCPP_HAS_LOCALIZATION 1/#define _LIBCPP_HAS_LOCALIZATION 0/' \
+    -e 's/#define _LIBCPP_HAS_FILESYSTEM 1/#define _LIBCPP_HAS_FILESYSTEM 0/' \
+    -e 's/#define _LIBCPP_HAS_MONOTONIC_CLOCK 1/#define _LIBCPP_HAS_MONOTONIC_CLOCK 0/' \
+    $L/include/x86_64-unknown-linux-gnu/c++/v1/__config_site > fs/c++/v1/__config_site
+$CXX -isystem fs/c++/v1 -isystem $L/include/c++/v1 -c <(echo '#include <span>') -o /dev/null
+
+# E6 —— ld.lld 名字陷阱
+readlink -f $(which ld.lld); ld.lld --version | head -1
+
+# ── X 系列:std.freestanding 子集包 ────────────────────────────────────────
+# picolibc:只下载 + 本地解包,不装进系统
+apt-get download picolibc-riscv64-unknown-elf
+dpkg -x picolibc-riscv64-unknown-elf_*.deb root
+P=$PWD/root/usr/lib/picolibc/riscv64-unknown-elf
+
+CXX="$L/bin/clang++ --no-default-config --target=riscv64-none-elf \
+     -march=rv64imac -mabi=lp64 -mcmodel=medany -ffreestanding \
+     -fno-exceptions -fno-rtti -std=c++23 -nostdinc++ \
+     -isystem fs/c++/v1 -isystem $L/include/c++/v1 -isystem $P/include \
+     -I $L/share/libc++/v1"
+
+# X3 —— 110 个 std/*.inc 对应头的可编性 + ⚠️ 宿主对照组
+for inc in $L/share/libc++/v1/std/*.inc; do h=$(basename $inc .inc)
+  printf '#include <%s>\nint f(){return 0;}\n' "$h" > h.cpp
+  $CXX -c h.cpp -o /dev/null 2>/dev/null && echo "$h" >> ok.list || echo "$h" >> fail.list
+done                                          # → OK=103 FAIL=7
+for h in $(cat fail.list); do                 # ⚠️ 对照组:这 7 个在宿主也全败
+  printf '#include <%s>\nint f(){return 0;}\n' "$h" > h.cpp
+  $L/bin/clang++ -std=c++23 -stdlib=libc++ -c h.cpp -o /dev/null 2>/dev/null \
+    && echo "HOST-OK $h(真·裸机损失)" || echo "HOST-FAIL $h(libc++ 未实现)"
+done
+
+# X5 —— 生成子集模块(208 行,全是 #include)
+{ echo "module;"; sed 's|.*|#include <&>|' ok.list
+  echo "export module mcpplibs.std.freestanding;"
+  sed 's|.*|#include "std/&.inc"|' ok.list; } > stdfs.cppm
+$CXX -Xclang -emit-reduced-module-interface --precompile stdfs.cppm -o stdfs.pcm
+$CXX -c stdfs.cppm -o stdfs.o
+
+# X10 —— 消费 + 链接,零未定义符号(rt.cpp 仅 3 行 __libcpp_verbose_abort)
+$CXX -fmodule-file=mcpplibs.std.freestanding=stdfs.pcm -c kmain4.cppm -o kmain4.o
+$L/bin/ld.lld -T link.ld start.o kmain4.o stdfs.o rt.o \
+    -L $P/lib/rv64imac/lp64 -lc -o kernel4.elf
+$L/bin/llvm-nm -u kernel4.elf     # → 空
+$L/bin/llvm-size kernel4.elf      # → text 12435
+
+# X11 —— picolibc multilib 覆盖(⚠️ 无 rv64imafdc/lp64d)
+(cd $P/lib && for d in rv64*; do for a in $d/*/; do printf "%s " "${a%/}"; done; done)
+
+# ── Y 系列:实现中立适配层 + 机械验证 ──────────────────────────────────────
+# Y1 —— libstdc++ 的 freestanding 是编译期开关,不是配置文件
+grep -n "_GLIBCXX_HOSTED" $G/include/c++/16.1.0/x86_64-linux-gnu/bits/c++config.h
+#   → #define _GLIBCXX_HOSTED __STDC_HOSTED__
+
+# Y2 —— 不可用设施的表现:libstdc++ 点名 #error
+echo '#include <vector>' > u.cpp
+g++ -std=c++23 -ffreestanding -c u.cpp -o /dev/null
+#   → #error "This header is not available in freestanding mode."
+
+# Y3 —— 同一份中立 core.cppm,两个标准库都过
+g++      -std=c++23 -fmodules -ffreestanding -fno-exceptions -fno-rtti -c core.cppm -o core_gcc.o
+$CXX     --precompile core.cppm -o core_clang.pcm         # riscv64-none-elf + libc++
+
+# Y4 —— 可移植子集 = 两家交集(52)
+comm -12 <(sort ok.list) <(sort gcc_ok.list) | wc -l
+
+# Y5 —— 从产物机械判定环境需求(零元数据)
+g++ -std=c++23 -c libprobe.cpp -o libprobe.o && $L/bin/llvm-nm -u libprobe.o
+#   new/delete → _Znwm _ZdlPvm | throw → __cxa_throw | dynamic_cast → __dynamic_cast
+#   纯计算     → (空)
+
+# Z1 —— ⚠️ 纯头库:可用性是消费者的属性,不是库的属性
+g++ -std=c++23 -c useA.cpp -o useA.o && $L/bin/llvm-nm -u useA.o | grep -E "_Zn|_Zd"
+#   → (空)            useA 只用了 Ring<int>
+g++ -std=c++23 -c useB.cpp -o useB.o && $L/bin/llvm-nm -u useB.o | grep -E "_Zn|_Zd"
+#   → _Znam _ZdaPv    useB 用了 Vec<int>
+#   而库自身:无实例化 ⇒ 无任何符号可审
+```
+
+## 附录 B:参考来源
+
+- OSDev Wiki:[Bare Bones](https://wiki.osdev.org/Bare_Bones)、[C++](https://wiki.osdev.org/C%2B%2B)、[Calling Global Constructors](https://wiki.osdev.org/Calling_Global_Constructors)、[Meaty Skeleton](https://wiki.osdev.org/Meaty_Skeleton)、[Expanded Main Page](https://wiki.osdev.org/Expanded_Main_Page)
+- Rust:[The Embedonomicon — Creating a custom target](https://docs.rust-embedded.org/embedonomicon/custom-target.html)、[rustc platform support: riscv64im-unknown-none-elf](https://doc.rust-lang.org/nightly/rustc/platform-support/riscv64im-unknown-none-elf.html)
+- WG21:[P1642R11 Freestanding Library](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1642r11.html)、[P2338R4 Freestanding Library: Character primitives and the C library](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2338r4.html)、[P1212R0 Modules and Freestanding](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1212r0.html)、[P0829R3 Freestanding Proposal](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0829r3.html)、[P2465 std / std.compat modules](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2465r3.pdf)、[P3693R0 SG14 minutes (2025-05)](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3693r0.pdf)
+- 工具链:[LLVM Embedded Toolchain for Arm](https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm)、[picolibc](https://github.com/picolibc/picolibc)、[Trying to build libc++ for bare-metal ARM targets (LLVM Discourse)](https://discourse.llvm.org/t/trying-to-build-libc-for-bare-metal-arm-targets/90501)
+- 其他构建系统:[cmake-toolchains(7)](https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html)、[Conan 1.43 baremetal setting](https://blog.conan.io/2021/12/21/New-conan-release-1-43.html)、[Zig Build Targets](https://ziglang-zig.mintlify.app/build/targets)

--- a/.agents/docs/2026-08-19-baremetal-ecosystem-closure-plan.md
+++ b/.agents/docs/2026-08-19-baremetal-ecosystem-closure-plan.md
@@ -1,0 +1,295 @@
+# 裸机 / freestanding — 全生态打通实施计划(第二阶段)
+
+- Date: 2026-08-19
+- Status: **实施计划,待 review**
+- 上游:`2026-08-19-freestanding-baremetal-implementation-plan.md`(第一阶段;**基础依赖侧已完成**)
+- 方案:`2026-08-19-freestanding-baremetal-design.md` · 证据:`2026-08-18-freestanding-baremetal-analysis.md`
+- 范围:**把链路从「包装好了」推到「用户能用」** —— 跨 `xim-pkgindex` / `mcpp` / `mcpplibs` 三仓
+
+---
+
+## 0. 现在在哪(实测基线,不是推测)
+
+第一阶段交付的**基础依赖侧**已在已发布索引里,并本地真跑通:
+
+| 已有 | 状态 |
+|---|---|
+| `xim:qemu-riscv@9.2.4-1` | ✅ 五宿主目标,镜像双端 |
+| `xim:picolibc-riscv@1.8.12` | ✅ 两档位 `rv64gc/lp64d` + `rv32imac/ilp32`,含 builtins |
+| 裸机内核(C++20 模块 → `ld.lld` → qemu) | ✅ 零未定义符号、无 PT_INTERP、真启动 |
+| picolibc 程序(`printf` 浮点 + `malloc`) | ✅ semihosting 真跑 |
+
+**但这一切今天都要手写十几个 flag。** 用户侧一行都还没打通 —— 这就是本计划要消灭的距离。
+
+### 0.1 ⭐ 三条决定本计划形状的实测
+
+1. **接缝已经可表达,不需要新轴。** `build.mcpp` 拿得到 `MCPP_TARGET` / `MCPP_TARGET_OS` /
+   `MCPP_TARGET_ARCH` / `MCPP_TARGET_ENV`(`hostprogram.cppm:155-158`),并能发
+   `include_dir()` / `link_search()` / `link_lib()` / `cflag()` / `cxxflag()`。
+   ⇒ **BSP 包零引擎改动就能把 xlings 的 sysroot 接进编译链接。**
+
+2. **它表达不了的恰好只有两件事** —— 而这两件正是引擎必须补的:
+   - **链接线的顺序**:`crt0.o` 必须排在用户对象**之前**,`link_search`/`link_lib` 表达不了序;
+   - **运行**:`build.mcpp` 是构建期程序,`mcpp run` 需要的 argv 模板它够不到。
+
+3. **现有 provision 只有三种**(`build/provisions.cppm:79`):`tool` · `host-module` · `dep-dir`。
+   ⇒ W8 要加的 `linker-script` / `startup-objects` / `runner` 是**真新语义**,不是重复造轮子。
+
+---
+
+## 1. 「打通」的定义:一条可执行的验收链
+
+⭐ **本计划的唯一总判据 —— 用户写这些,然后跑这三条命令:**
+
+```toml
+# mcpp.toml
+[package]
+name = "hello-mcu"
+version = "0.1.0"
+
+[build]
+target = "riscv64-none-elf"
+
+[dependencies]
+riscv-virt-rt              = "0.1"   # BSP:链接脚本 + 启动 + runner
+mcpplibs.std.freestanding  = "0.1"   # std 子集
+```
+
+```bash
+mcpp build --target riscv64-none-elf
+mcpp run   --target riscv64-none-elf     # qemu 里打印出模块的输出
+mcpp test  --target riscv64-none-elf     # 3 个用例,一次 qemu 全过
+```
+
+⚠️ **判据的严格形式**:上面这份工程里,**用户看不到也不需要知道**下列任何一个词 ——
+`picolibc`、`compiler-rt`、`libclang_rt.builtins`、`crt0-semihost.o`、`picolibcpp.ld`、
+`-nostdlib`、`-mcmodel=medany`、`-machine virt`、`-bios none`、`-semihosting`。
+
+**它们全部由 BSP 包 + 引擎承担。** 只要用户还得自己写其中任何一个,这条线就没打通。
+
+### 1.1 三个否定判据(防假绿)
+
+| # | 不算打通 |
+|---|---|
+| N1 | 「能构建」但 `mcpp run` 要用户自己拼 qemu 命令 |
+| N2 | 「能跑」但依赖用户在 `mcpp.toml` 里手写 `link-search` / `cflag` |
+| N3 | 「都能跑」但换一块板(`rv32imac/ilp32`)要改引擎而不是换 BSP 依赖 |
+
+---
+
+## 2. 三仓责任划分与接缝
+
+| 仓库 | 负责 | **绝不负责** |
+|---|---|---|
+| `openxlings/xim-pkgindex` | 工具链载荷、模拟器、**目标 sysroot**(已完成) | 不认识 target triple、不认识 BSP |
+| `mcpp-community/mcpp` | target 模型 · 链接模式 · provision · runner · test harness | ⚠️ **永不认识 picolibc / 某块板 / 某个 qemu 参数** |
+| `mcpplibs/*` + `mcpplibs/mcpp-index` | BSP(板级)· std 子集 · 未来的 HAL | 不改引擎 |
+
+### 2.1 ⭐ 接缝的形状(已实测可行)
+
+```
+xim:picolibc-riscv          (xlings 包,目标 sysroot)
+        ▲
+        │ [xlings] deps  +  build.mcpp 读 MCPP_TARGET_* 后
+        │ 发 include_dir / link_search / link_lib / cflag
+        │
+riscv-virt-rt               (mcpp 包:BSP)
+        │
+        │ 依赖边 + provision(linker-script / startup-objects / runner)
+        ▼
+   用户工程                  (只写 [dependencies])
+```
+
+⚠️ **BSP 是唯一知道「板」的地方**:内存布局、UART 地址、qemu 机器型号、
+`<march>/<mabi>` 档位选择,全部在这一层。换板 = 换一个依赖。
+
+### 2.2 ⚠️ 接缝上必须先验证的三件事(Phase 0)
+
+读代码得出的结论这一轮被实测推翻过多次,所以每条都先做探针:
+
+| 探针 | 问题 | 为什么必须先做 |
+|---|---|---|
+| **Z1** | BSP 的 `build.mcpp` 真能把 sysroot 的 include/lib 接进消费者的编译链接吗? | 若不能,Phase C 整个形状要改 |
+| **Z2** | `build.mcpp` 在**交叉 target** 下真跑得起来吗(它是**宿主**程序) | 宿主程序 + 交叉工程是两套 flag,可能撞车 |
+| **Z3** | provision 从 BSP 传到用户工程,经过几条边?re-export 需要吗? | 决定 W8 的传播语义 |
+
+⭐ **Z1 与 Z2 在 hosted target 上就能验**(拿一个假 sysroot 目录),不依赖任何引擎改动
+⇒ **今天就能开工,且失败代价只有一个探针。**
+
+---
+
+## 3. 工作单元
+
+### 3.1 Phase 0 — 探针先行(3 个,零依赖,最先做)
+
+| ID | 内容 | ⚠️ 验收判据(可执行) | 规模 |
+|---|---|---|---|
+| **Z1** | BSP-seam 探针:一个 mcpp 包,`build.mcpp` 读 `MCPP_TARGET_ARCH` 后发 `include_dir`/`link_search`/`link_lib`,消费者在 **hosted** 目标上构建 | 消费者的 `compile_commands.json` 里出现该 include dir,且 `build.ninja` 的链接线含该 `-L`/`-l`;⚠️ **换一个 `MCPP_TARGET_ARCH` 值 ⇒ 发出的目录随之改变**(否则是常量不是接缝) | S |
+| **Z2** | build.mcpp 在交叉 target 下的行为普查:它用哪套 flag 编译、`MCPP_TARGET_*` 在 `--target riscv64-none-elf` 下取到什么值 | 逐项列出;⚠️ **若 build.mcpp 自身被交叉编译则是硬缺陷**,必须记为 W3 的一条 | S |
+| **Z3** | provision 传播探针:`dep-dir` 从间接依赖到用户工程走不走得通 | 三层依赖链上取到 provision;⚠️ 若需 re-export,W8 的三种新 kind 各自的 `reexportOnly` 列就此定死 | S |
+
+### 3.2 Phase A — 引擎:能表达、能构建(承接第一阶段的 W0–W6/W13)
+
+| ID | 内容 | 依赖 | ⚠️ 验收判据 | 规模 |
+|---|---|---|---|---|
+| **W0** | 修 E1 静默失败:门的判据改为「这次构建为哪个 target 发了 `--target`」 | — | 无裸机配置时**指名道姓报错**;**不存在「成功且产物是 x86-64」的路径** | S |
+| **W1** | `triple` 收 `os=none` | W0 | `riscv64-none-elf` 解析成功;⚠️ `x86_64-none-linux-gnu` **仍解析为 linux** | S |
+| **W2** | `TargetSpec` 表 + **单一取值口** | W1 | 消费方逐个核对**无第二处推导**;`kKnownTargets` 含 `riscv64-none-elf` / `riscv32-none-elf` | M |
+| **W3** | 探测代码普查(doctor / 工具链能力 / `hasImportStd`)在 `os=none` 下的行为 | Z2 | 逐点列清单并修掉会假失败的 | S–M |
+| **W4** | `CLibMode::Freestanding`:`-nostdlib -nostartfiles -static -T`;⚠️ **链接器按载荷绝对路径寻址 + 校验 `--version` 含 `LLD`** | W2,W3 | 产物 `file` 含 `UCB RISC-V`;`readelf -l` **无 PT_INTERP**;`llvm-nm -u` **空**;⚠️ **验收工程必须用 picolibc `printf` 打一个浮点数**(见 §6-R2) | M |
+| **W5** | BMI 缓存键 + 指纹纳入 `TargetSpec` 全字段 | W2 | 同源码 hosted / freestanding 下 BMI **互不复用** | S |
+| **W6** | `import std` 关断 + 指向 `mcpplibs.std.freestanding` 的诊断 | W1 | `os=none` 下给出 mcpp 自己的诊断,**不是 libstdc++ 内部报错** | S |
+| **W7a** | `cfg(freestanding)` / `cfg(os="none")` 谓词 | W1 | `[target.'cfg(freestanding)'.build]` 在裸机下生效、hosted 下不生效 | S |
+| **W13** | 产物形态:`.elf` + `.bin` + `.map` + **size 摘要**默认 | W4 | 四件齐备,构建后打印 text/data/bss | S |
+
+### 3.3 Phase B — 引擎:能跑、能测
+
+| ID | 内容 | 依赖 | ⚠️ 验收判据 | 规模 |
+|---|---|---|---|---|
+| **W12** | e2e harness `# requires-hard:`:能力缺失 **FAIL 而非 SKIP**;CI 汇总**实际执行条数** | — | 故意不装 qemu ⇒ 裸机 e2e **job 红,不是绿着跳过** | S |
+| **W8** | provision 三种新 kind:`linker-script`(单值,冲突报错)· `startup-objects`(**两个具名槽 `prologue`/`epilogue`,槽内数组序**)· `runner` | W4,Z3 | BSP 提供的 `crt0` 按 `prologue → 用户对象 → epilogue` 进链接线;⚠️ **两个 BSP 同时提供 = 硬错误** | M |
+| **W9** | `mcpp run` runner:`[target].runner` argv 模板 + 产物路径追加;**BSP 亦可经 provision 提供** | W2,W8 | `mcpp run --target riscv64-none-elf` 在 qemu 里打印出预期串;⚠️ **两种机器形态都要过**(`-bios default -kernel`(OpenSBI)与 `-bios none -semihosting`(picolibc)) | S–M |
+| **W11** | `mcpp test` 裸机:默认 `batch`(一镜像一次 qemu,semihosting 打用例名)· `isolated` 可选 · **超时后自动重跑一次 isolated 定位** | W9,W12 | 3 用例 batch 一次全过;人为让第 2 个跑飞 ⇒ **超时后指出是第 2 个** | M |
+| **W16** | `--target` + `--workspace` 冲突即报错 | — | 混合 workspace 上**报错说明冲突**,不静默覆盖 | S |
+| **W15** | CDB 合并到 workspace 根 | — | 根上一份 CDB,每个文件带所属成员 target 的 flags | S |
+
+### 3.4 Phase C — 生态库(mcpplibs)
+
+| ID | 内容 | 依赖 | ⚠️ 验收判据 | 规模 |
+|---|---|---|---|---|
+| **E-BSP** | `mcpplibs/riscv-virt-rt` — qemu `virt` 的 BSP:`[xlings] deps = ["xim:picolibc-riscv"]`,`build.mcpp` 按 `MCPP_TARGET_ARCH` 选档位并接 sysroot;提供 `linker-script` / `startup-objects` / `runner` | Z1,W8,W9 | §1 的三条命令在**只声明这一个依赖**时跑通;⚠️ **换成 rv32 档只改 BSP 的一个值,引擎零改动**(N3) | M |
+| **E-STD-1** | `mcpplibs/std-freestanding` **S-1 零 libc 档**:8 个头 + 基础类型 | — | `import mcpplibs.std.freestanding;` + `std::to_chars` + `std::span` 在裸机链接**零未定义符号** | M |
+| **E-STD-2** | **S-2**:52 头可移植子集(接 picolibc 头) | E-STD-1,E-BSP | 方案 §7.1 的三文件工程跑通(`array`/`ranges::sort`/`optional`/`atomic`/`string_view`) | M |
+| **E-IDX** | 三个包进 `mcpplibs/mcpp-index`(`pkgs/<字母>/<name>.lua`) | E-BSP,E-STD-1 | `mcpp add riscv-virt-rt` 从**已发布索引**解析成功 | S |
+
+⚠️ **E-STD-1 的依赖关系已被第一阶段改变**:原计划说它需要「BSP 提供 `memcpy/memmove/memset/memcmp`」——
+**有了 picolibc 之后这四个来自 `libc.a`**。零 libc 档只在**不依赖 BSP**时才需要自带,
+⇒ S-1 的定位从「最小可发布」变成「**不想要 libc 的人的选项**」,而主线是 S-2。
+
+### 3.5 Phase D — 使用侧闭环
+
+| ID | 内容 | 依赖 | ⚠️ 验收判据 | 规模 |
+|---|---|---|---|---|
+| **T1** | `mcpp new --template baremetal-riscv` | E-IDX,W9 | 生成的工程**开箱即过** §1 三条命令,manifest 不超过 §1 那五行依赖 | S |
+| **D1** | 文档:裸机上手页 + BSP 作者指南(怎么写一个新板) | E-BSP | 照文档能从零写出第二块板的 BSP(⚠️ 判据是**别人写得出来**,不是文档存在) | M |
+| **D2** | 诊断文案:缺 BSP / 缺 runner / 缺能力时**指名道姓**并给出下一步命令 | W6,W8 | 三种缺失各有一条测试钉住文案含**具体包名** | S |
+
+### 3.6 Phase E — 三仓联防(⭐ 本计划最容易被跳过、也最要命的一档)
+
+⚠️ **链路跨三仓,而三个仓库的 CI 今天互相看不见。** 任何一侧改动都能悄悄打断它。
+
+| ID | 内容 | ⚠️ 验收判据 | 规模 |
+|---|---|---|---|
+| **X1** | **唯一权威夹具**:`baremetal-closure` —— §1 的工程 + 三条命令 + 断言,放在一个所有仓都能取的地方 | 夹具本身是一个仓库/目录,**没有第二份拷贝** | S |
+| **X2** | 三仓 CI 各自跑 X1:`xim-pkgindex`(改包时)· `mcpp`(改引擎时)· `mcpplibs`(改库时) | 三条流水线都**真跑过一次并红过一次**(人为破坏各自那一侧) | M |
+| **X3** | 版本兼容探针:mcpp × sysroot × BSP 的矩阵 | ⚠️ 至少验证 **llvm 大版本跨越**(22 编的 builtins 给 23 用)与 **picolibc 头 × libc++ 子集**两条 | S–M |
+
+⭐ **X2 的判据是「红过一次」而不是「绿了」** —— 这一轮已经三次遇到「CI 全绿但那条路径从没执行」。
+
+---
+
+## 4. 依赖拓扑
+
+```
+Phase 0(今天可开,零依赖)
+   Z1 seam探针 ── Z2 build.mcpp交叉行为 ── Z3 provision传播
+      │              │                        │
+      │              ▼                        │
+      │           W3 探测普查                 │
+      │              │                        │
+引擎  ▼              ▼                        ▼
+   W0 ─► W1 ─► W2 ─► W4 ─► W8 ─► W9 ─► W11
+              │      │      ▲             ▲
+              │      │      │             │
+              ├─► W5 │      │             W12(必须早于 W11 的验收)
+              ├─► W6 │      │
+              ├─► W7a│      │
+              └──────┴─► W13│
+                            │
+生态                        │
+   E-STD-1 ────────────────┐│
+   E-BSP ◄──── Z1 ─────────┴┴──► E-STD-2 ──► E-IDX
+      │                                        │
+使用侧                                         ▼
+                                            T1 ─► D1 ─► D2
+联防
+   X1 夹具 ──► X2 三仓 CI ──► X3 兼容矩阵
+```
+
+**关键路径 = `Z1 → W0 → W1 → W2 → W4 → W8 → W9 → E-BSP → T1`(9 个)。**
+其余 **15 个可并行**,其中 **7 个(Z1/Z2/Z3/W0/W12/W15/W16/E-STD-1)零依赖,今天就能开**。
+
+---
+
+## 5. 里程碑与验收
+
+| 里程碑 | 含 | ⚠️ 验收判据(必须是这句) |
+|---|---|---|
+| **M-0 接缝可信** | Z1 · Z2 · Z3 · W0 · W12 | ① Z1 里**改 target 值 ⇒ 发出的目录随之改变**;② 故意不装 qemu ⇒ 裸机 e2e **job 红** |
+| **M-1 能表达** | W1 · W2 · W3 | `--target riscv64-none-elf` 解析成功;无配置时**指名道姓报错**;探测点清单已产出 |
+| **M-2 能构建** | W4 · W5 · W6 · W7a · W13 | `file` 含 `UCB RISC-V` · 无 PT_INTERP · `llvm-nm -u` 空;⚠️ **验收工程用 picolibc `printf` 打浮点**且**至少一个依赖** |
+| **M-3 能跑** | W8 · W9 · E-BSP | `mcpp run --target riscv64-none-elf` 打印出预期串;⚠️ 判据是**裸机 e2e 实际执行条数 > 0** |
+| **M-4 能测** | W11 | 3 用例 batch 一次全过;第 2 个跑飞 ⇒ **超时后指出是第 2 个** |
+| **M-5 生态可取** | E-STD-2 · E-IDX | `mcpp add riscv-virt-rt` 从**已发布索引**解析;三文件工程跑通 |
+| **M-6 ⭐ 打通** | T1 · D1 · D2 | ⭐ **§1 那五行依赖 + 三条命令,在一台干净机器上从零跑通,用户没见过 §1 列出的任何一个词** |
+| **M-7 不再退化** | X1 · X2 · X3 | 三仓 CI 各自**红过一次**;兼容矩阵两条已验 |
+
+---
+
+## 6. ⚠️ 风险(每条都有实测出处)
+
+| # | 风险 | 出处 | 防线 |
+|---|---|---|---|
+| **R1** | **CI 绿着但那条路径从没执行** | 本轮三次 | W12 前置;判据是**执行条数 > 0**;X2 判据是**红过一次** |
+| **R2** | **builtins 缺口的假绿**:`rv64gc` 有硬件 `divu`,64 位除法**碰不到** builtins | 第一阶段实测 | M-2 验收工程**必须 `printf` 一个浮点数**(那是唯一会引 `__ashlti3`/`__lshrti3` 的日常操作) |
+| **R3** | **`ld.lld` 按名字解析到宿主 GNU ld** | 第一阶段独立复现(`unrecognised emulation mode: elf64lriscv`) | W4 强制**绝对路径** + `--version` 校验 |
+| **R4** | **默认 cfg 毒化交叉编译**:llvm 载荷的 `clang.cfg` 无条件注入宿主 glibc 头 + 写死 x86-64 动态链接器 | 第一阶段实测 | ✅ **mcpp 已经躲开**(`flags.cppm:495`)—— 但 **W3 必须逐点确认探测路径也躲开了** |
+| **R5** | **单包验证会得出错误结论**(flags 作用域,加第二个包才碎) | 方案 §4.1 | M-2 验收工程**至少一个依赖** |
+| **R6** | **BMI flag 不一致 ⇒ 编译器崩**(不只是结果不对) | ISO 系列 | W5 与 W4 同期 |
+| **R7** | **`thread_local` 静默写坏内存**(编过链过零诊断) | TH6 | 裸机验收用例**必须含一个 `thread_local`** |
+| **R8** | **带序 provision 被顺手做成集合** | — | W8 判据显式检查链接线**顺序** |
+| **R9** | **新门被逃生舱绕开**(E1 的原始形状) | E1 | 每个新门自问「**逃生舱走不走这里**」并写测试 |
+| **R10** | **读代码下结论**(本轮又被实测推翻多次) | 全程 | 每个单元判据是**命令 + 期望输出** |
+| **R11** | ⚠️ **三仓改动互不可见** —— 任一侧都能悄悄打断链路 | 结构性 | Phase E 是**必需配套**,不是可选项 |
+| **R12** | **`build.mcpp` 是宿主程序,工程是交叉的** —— 两套 flag 可能撞车 | 未验证 | **Z2 先探**;若 build.mcpp 被交叉编译则是硬缺陷 |
+| **R13** | ⚠️ **文档写了但别人写不出第二块板** | — | D1 的判据是**别人真写出来**,不是文档存在 |
+
+---
+
+## 7. 版本兼容与无感升级(X3 展开)
+
+| 轴 | 问题 | 现状 | 探针 |
+|---|---|---|---|
+| **llvm 大版本** | sysroot 的 builtins 用 22.1.8 编,给 23 的 clang 用行不行? | builtins 是 ABI 稳定的运行时函数,**理论上行** | ⚠️ 理论不算 —— X3 必须真用 23 链一次 |
+| **picolibc 头 × libc++ 子集** | libc++ 的 freestanding 头依赖 libc 头的哪些部分? | S-2 已验 52 头交集 | 换 picolibc 小版本后重跑 |
+| **BSP × 引擎** | 新增 provision kind 后旧 BSP 还能用吗? | 未发生 | ⚠️ **provision 表加行必须向后兼容**:旧包不声明新 kind ⇒ 沿用默认,不是失败 |
+| **sysroot 升级** | picolibc 1.9 出来后怎么升? | 需**重新构建**(包刻意不设 `ci.update`) | 脚本已在 `.agents/tools/`,判据是同输入同字节 |
+
+⚠️ **一条硬约束**:`xim:picolibc-riscv` 的版本号是 picolibc 的,但内含 builtins 的 llvm 版本
+**只写在 `BUILDINFO` 里**。⇒ X3 必须能回答「这台机器上的 sysroot 是哪个 llvm 编的」,
+否则 llvm 升级后的问题无法定位。
+
+---
+
+## 8. 不在本计划内
+
+| 项 | 去向 |
+|---|---|
+| **P4** libc++ 每目标 freestanding `__config_site` | E-STD-2 内部按需;不单独立项 |
+| **E-STD S-3**(`format` / `sort` / `string` 全功能) | 需为目标编 libc++;M-6 之后再评估 |
+| **ARM / 其它 arch** | ⚠️ 判据是 **N3**:换 arch 应当只是加一个 BSP + 一个 sysroot 包;**若需改引擎,说明 W2 的 TargetSpec 抽象错了** |
+| **D 档**(openkal / openhal / openarch) | 路线图在第一阶段计划 §7,**不并入本计划里程碑** |
+| **烧录 / OTA** | 设备侧的事,mcpp 不碰 |
+
+---
+
+## 9. 为什么这样排
+
+1. **Phase 0 先行**,是因为这一轮「读代码下结论」被实测推翻了不止一次,而接缝是本计划里
+   **唯一还没有任何实测支撑**的部分。三个探针加起来不到一天,买的是整个 Phase C 的形状。
+2. **E-STD-1 从「最小证明」降级为「可选档」**:第一阶段把 picolibc 做出来之后,
+   `memcpy` 那四个函数来自 `libc.a`,S-1 不再是通往 S-2 的必经之路。**主线是 S-2。**
+3. **Phase E 与 Phase A/B/C 并行而不是排在最后**:X1 的夹具就是 M-2/M-3/M-4 的验收载体,
+   先有夹具,后面每个里程碑都直接用它,而不是各写一份。
+4. ⭐ **M-6 的判据是「用户没见过那些词」** —— 这是唯一能把「能跑」和「打通」区分开的判据。
+   任何以「我们能构建裸机产物了」结束的版本,都还停在 M-2。

--- a/.agents/docs/2026-08-19-baremetal-ecosystem-closure-plan.md
+++ b/.agents/docs/2026-08-19-baremetal-ecosystem-closure-plan.md
@@ -293,3 +293,55 @@ Phase 0(今天可开,零依赖)
    先有夹具,后面每个里程碑都直接用它,而不是各写一份。
 4. ⭐ **M-6 的判据是「用户没见过那些词」** —— 这是唯一能把「能跑」和「打通」区分开的判据。
    任何以「我们能构建裸机产物了」结束的版本,都还停在 M-2。
+
+---
+
+## 10. 已落地(2026-08-19,mcpp#455)与实测修正
+
+### 10.1 落地了什么
+
+| 单元 | 状态 | 判据(实跑) |
+|---|---|---|
+| **Z1/Z2/Z3** 探针 | ✅ | 见 §10.2 —— **改变了 Phase C 的形状** |
+| **W1** triple 收 `os=none` | ✅ | `riscv64-none-elf` / `riscv32-none-elf` 解析;`x86_64-none-linux-gnu` **仍是 linux**(两侧单测) |
+| **W2** TargetSpec 表 + 单一取值口 | ✅ | 新目录 `src/freestanding/`,`resolve()` 是唯一读点 |
+| **W4** freestanding 链接 | ✅ | `file` 含 `UCB RISC-V` · 无 PT_INTERP · `llvm-nm -u` 空 · 入口 0x80200000 |
+| **W6** `import std` 关断 + 诊断 | ✅ | 诊断**点名** `mcpplibs.std.freestanding` 与要加的那行 manifest |
+| **W9** runner | ✅ | `mcpp run --target-triple` 在 qemu 里跑出模块输出;缺 runner 时指名道姓 |
+| **W12** `# requires-hard:` | ✅ | 机制两侧已验;⚠️ 但两条裸机 e2e **刻意不用它**(见 §10.3) |
+| **W8** 的**链接脚本**部分 | ✅ | 以 `link-script` **一行 directive** 落地,而非新 provision 子系统(见 §10.2) |
+| **W8** 的 `startup-objects` 带序槽 | ⛔ **不需要** | 实测 `-lcrt0-semihost` 从**归档**里拉得进来,顺序由链接脚本的 section 序决定 |
+| **E-BSP** 的形状 | ✅ 已验证(本地) | 消费者只写一条依赖 + `import board;`,跑出 `float 3.1416` / `MALLOC-OK` |
+| W3 · W5 · W7a · W11 · W13 · W15 · W16 | ❌ 未做 | |
+
+### 10.2 ⚠️ 探针改变了设计的三处
+
+1. ⭐ **接缝的两半是不对称的,而且是刻意的**(`directives.cppm:143-151`):
+
+   ```
+   link-search / link-lib / link-script   LinkGlobal      → 到达消费者
+   include-dir / cflag / cfg              PackagePrivate  → 不到达
+   ```
+
+   ⇒ **计划里担心的"引擎要不要认识 sysroot"整块消失了**:目标头由 libc 包装包**私有** include、对外 **export 一个 C++ 模块**(即 mcpp-index 里 `compat.*` 的既有形状),引擎不需要任何 sysroot 概念。
+
+2. ⭐ **W8 缩到一行。** 唯一真正缺的是 `-T`(没有任何 directive 能发它);启动对象走 `-l<归档>` 即可。原计划的「两个具名槽 + 槽内数组序」是为解决一个实测上不存在的问题。
+
+3. ⚠️ **`build.mcpp` 拿不到 `[xlings] deps` 的安装路径** —— 计划里完全没提到的缺口。补成 **`xpkg_dir(ns, name)` 接口**(不是路径约定):否则 BSP 要把 store 内部结构写进代码。
+
+### 10.3 ⚠️ `requires-hard` 用错了地方(自我修正)
+
+第一版给两条裸机 e2e 打了 `# requires-hard:`。**这是错的**:qemu-riscv 在 macOS/Windows 的 runner 上本来就没有,硬 token 会让那些 job **结构性首红** —— 比它防的问题更糟。
+
+⇒ **token 只能表达"平台适用性",表达不了"这台 runner 本该有它"。** 后者的守卫必须放在**知道自己是谁**的地方:`ci-linux-e2e.yml` 的 `baremetal` job 装好 qemu + sysroot,然后**断言两条 PASS 行真的出现了**(`run_all.sh` 跳过时退出码是 0,回答不了这个问题)。
+
+### 10.4 还差什么才算 §1 的「打通」
+
+| 缺口 | 影响 |
+|---|---|
+| `runner` 仍在**消费者**的 manifest 里 | 违反 §1.1 的 **N1**:BSP 应当能供它 |
+| BSP/std 子集尚未发布到 `mcpplibs/mcpp-index` | 只验证了 path 依赖,没验证 `mcpp add` |
+| `mcpp new --template baremetal-riscv`(T1) | 用户仍要手写 `[targets.firmware]` 与 `main = "src/start.S"` |
+| 裸机 `mcpp test`(W11) | M-4 未开始 |
+
+⇒ **当前位置:M-2 完成,M-3 的引擎半边完成,生态半边形状已验证但未发布。**

--- a/.agents/docs/2026-08-19-baremetal-ecosystem-closure-plan.md
+++ b/.agents/docs/2026-08-19-baremetal-ecosystem-closure-plan.md
@@ -308,7 +308,7 @@ Phase 0(今天可开,零依赖)
 | **W4** freestanding 链接 | ✅ | `file` 含 `UCB RISC-V` · 无 PT_INTERP · `llvm-nm -u` 空 · 入口 0x80200000 |
 | **W6** `import std` 关断 + 诊断 | ✅ | 诊断**点名** `mcpplibs.std.freestanding` 与要加的那行 manifest |
 | **W9** runner | ✅ | `mcpp run --target-triple` 在 qemu 里跑出模块输出;缺 runner 时指名道姓 |
-| **W12** `# requires-hard:` | ✅ | 机制两侧已验;⚠️ 但两条裸机 e2e **刻意不用它**(见 §10.3) |
+| **W12** `# requires-hard:` | ⛔ **撤销** | 实现了、用了一次、CI 一小时内证伪(见 §10.3);守卫改在 job 里 |
 | **W8** 的**链接脚本**部分 | ✅ | 以 `link-script` **一行 directive** 落地,而非新 provision 子系统(见 §10.2) |
 | **W8** 的 `startup-objects` 带序槽 | ⛔ **不需要** | 实测 `-lcrt0-semihost` 从**归档**里拉得进来,顺序由链接脚本的 section 序决定 |
 | **E-BSP** 的形状 | ✅ 已验证(本地) | 消费者只写一条依赖 + `import board;`,跑出 `float 3.1416` / `MALLOC-OK` |
@@ -329,11 +329,22 @@ Phase 0(今天可开,零依赖)
 
 3. ⚠️ **`build.mcpp` 拿不到 `[xlings] deps` 的安装路径** —— 计划里完全没提到的缺口。补成 **`xpkg_dir(ns, name)` 接口**(不是路径约定):否则 BSP 要把 store 内部结构写进代码。
 
-### 10.3 ⚠️ `requires-hard` 用错了地方(自我修正)
+### 10.3 ⚠️ W12(`requires-hard`)被实测撤销 —— 计划里的一条错误主张
 
-第一版给两条裸机 e2e 打了 `# requires-hard:`。**这是错的**:qemu-riscv 在 macOS/Windows 的 runner 上本来就没有,硬 token 会让那些 job **结构性首红** —— 比它防的问题更糟。
+计划把 `# requires-hard:`(能力缺失 FAIL 而非 SKIP)列为**前置必做**,理由是"CI 绿着但从没跑过"。机制实现了,给两条裸机 e2e 用了一次,**CI 在一小时内证伪**:
 
-⇒ **token 只能表达"平台适用性",表达不了"这台 runner 本该有它"。** 后者的守卫必须放在**知道自己是谁**的地方:`ci-linux-e2e.yml` 的 `baremetal` job 装好 qemu + sysroot,然后**断言两条 PASS 行真的出现了**(`run_all.sh` 跳过时退出码是 0,回答不了这个问题)。
+```
+FAIL: 130_freestanding_riscv_build_and_run.sh
+      (REQUIRED capability missing: llvm)      ← macOS 的 e2e suite
+```
+
+`llvm` 与 `qemu-riscv` 在 macOS/Windows runner 上**本来就没有**,硬 token 让那些 job **结构性首红** —— 比它要防的静默跳过更糟。
+
+⭐ **真正的结论比"用错地方"更强:同一个 token 要同时表达"这个平台本来就没有"和"这台 runner 配错了",而 token 里没有任何东西能区分这两者。** ⇒ 机制**整个撤掉**,因为一个没有正确用法的机制,下一个人会用错同一次。
+
+守卫必须放在**知道自己是谁**的地方:`ci-linux-e2e.yml` 的 `baremetal` job 装好 qemu + sysroot(装进 **MCPP 用的那个 home**,否则 131 会跳过),**直接跑**这两个脚本(它们是独立的;`run_all.sh` 不接过滤参数,会为两条测试跑完 250 条),然后**断言各自的 PASS 行真的出现了** —— 两个脚本都可能 exit 0 而没跑,所以退出码回答不了这个问题。
+
+⚠️ 这条也是本轮第二次「我预警了、然后自己踩了」:提交信息里写着硬 token 会让 macOS 首红,却因为从一个**改动前的备份**还原文件,把修复覆盖掉了。
 
 ### 10.4 还差什么才算 §1 的「打通」
 

--- a/.agents/docs/2026-08-19-freestanding-baremetal-design.md
+++ b/.agents/docs/2026-08-19-freestanding-baremetal-design.md
@@ -1,0 +1,2576 @@
+# mcpp 裸机 / freestanding 支持 — 架构设计方案(2026-08-19)
+
+- Date: 2026-08-19
+- Status: **方案,待 review**(第 10 节是决策回执)
+- 关联 issue: [#403](https://github.com/mcpp-community/mcpp/issues/403)(RFC,已 CLOSED)、#276(hosted 嵌入式,另一条线)
+- 关联决策: `.agents/docs/2026-07-24-embedded-platform-support-design.md` 决策 #15(裸机推迟)—— 本方案更新其依据,见 §10
+- **⇒ 发现与证据独立成文:`.agents/docs/2026-08-18-freestanding-baremetal-analysis.md`(E1–E6 / X1–X12 / Y1–Y5 / Z1 / C1–C4 全部实测与复现命令)。本文是方案,那份是发现。** 本文每条设计都标注支撑它的实测编号。
+
+---
+
+## 0. 一句话方案
+
+**引擎只加三条缝(目标规格 / 链接模型 / runner),裸机知识全部下沉为包;库的 freestanding 能力用「声明 + 证据 + 兜底」三元组表达,其中只有兜底是门。**
+
+```
+┌─ L5 生态层 ── BSP 包 · mcpplibs.std.freestanding · 载荷(builtins/picolibc/libc++)
+│                     ↑ 全部是普通包/载荷,引擎不认识任何一块板子
+├─ L4 契约层 ── 声明(作者,给人看) · 证据(mcpp 算,给人看) · 兜底(裸机链接,唯一的门)
+├─ L3 运行层 ── runner argv 模板 + 产物路径追加;test 走 semihosting 退出码
+├─ L2 链接层 ── CLibMode::Freestanding(正向态):-nostdlib -nostartfiles -static -T
+└─ L1 目标层 ── triple 收 os=none + TargetSpec 一张表(isa/abi/code-model/linker/env-caps)
+```
+
+**为什么这么切**:E2 实测证明 mcpp 现有 LLVM 载荷**已经能**从 C++20 模块接口单元编出并链成完整 RISC-V 裸机内核。缺的不是能力,是模型。所以引擎的活是「把已有能力接上」,不是「造新能力」。
+
+---
+
+## 1. 范围
+
+### 做
+
+| | 内容 | 支撑 |
+|---|---|---|
+| P0 | **修 E1 的静默失败**(与路线无关的义务) | E1 |
+| P0 | L1 目标层:`os=none` + TargetSpec 表 | E1/E6-2/§4.1 |
+| P0 | L2 链接层:`CLibMode::Freestanding` | E2/E6-1 |
+| P0 | `import std` 在 `os=none` 上关断 + 诊断 | E4 |
+| P1 | L3 runner(`mcpp run`) | 全仓 runner 概念命中 1 处 |
+| P1 | L4 契约层(声明/证据/兜底) | Y5/Z1/C1–C4 |
+| P2 | L5:BSP 包 + `mcpplibs.std.freestanding` | X1–X10/Y3 |
+| P2 | `mcpp test` semihosting 退出码 | X12 |
+| P3 | 载荷:per-target builtins + picolibc + T3 libc++ | E3/X11 |
+
+### 不做(明确)
+
+- **板子数据库**(PlatformIO/Zephyr 形态)—— 与 2026-07-24 决策 #1 冲突。板子是包。
+- **「哪些设施算 freestanding」的引擎判断** —— 决策 #6:领域知识归包。
+- **libc 实现** —— 采纳 picolibc/newlib,不自造。
+- **把声明做成门** —— §5.3 论证。
+- **ESP32 / Xtensa / MCU 级(<1MB)** —— 决策 #15 的这半仍然成立。
+
+---
+
+## 2. L1 目标层:目标规格是数据
+
+### 2.1 triple 收下 `os=none`
+
+canonical 拼写 `riscv64-none-elf`(arch=riscv64, os=none, env=elf),与 Rust/LLVM 一致。
+
+⚠️ **实施第一坑**:`src/toolchain/triple.cppm:299` 今天把 `none` 当 vendor 段跳过:
+
+```cpp
+if (k == "unknown" || k == "pc" || k == "w64" || k == "none") continue;
+```
+
+规则改为:**`none` 只在「整串没有其它 OS token」时才是 OS**;否则维持 vendor 语义(`x86_64-none-linux-gnu` 仍解析为 linux)。这条必须有单测正反两侧钉住。
+
+派生:
+- `family()` 对 `os=none` 返回空 ⇒ `cfg(unix)` / `cfg(windows)` 自动为假(**现状即正确**,无需改)
+- 新增 `cfg(freestanding)` 谓词(词表扩展,不是新段)
+
+### 2.2 TargetSpec:一张表,一处推导
+
+```cpp
+struct TargetSpec {
+    std::string_view isa;        // "rv64gc"   → -march=
+    std::string_view abi;        // "lp64d"    → -mabi=
+    std::string_view codeModel;  // "medany"   → -mcmodel=
+    Linker           linker;     // Lld | DriverDefault
+    CLibMode         clib;       // Freestanding | Sysroot | PayloadFirst
+    EnvCaps          provides;   // heap/exceptions/rtti/threads/hosted-std 的默认值
+};
+```
+
+`TargetInfo` 增一列 `spec`。裸机行:
+
+```cpp
+{ "riscv64-none-elf", "planned", "bare", "llvm@22.1.8", /*defaultStatic=*/true,
+  .spec = { "rv64gc", "lp64d", "medany", Linker::Lld, CLibMode::Freestanding,
+            EnvCaps::none() } },
+```
+
+hosted 行的 `spec` 留空 = 驱动默认(零行为变化)。
+
+**⚠️ 为什么必须是数据而不是 flags**(§4.1 of 分析文):`-march/-mabi/-mcmodel` 必须对链接进同一镜像的**每个 TU 和每个依赖**完全一致。`[build].cxxflags` 的作用域是本包,依赖拿不到 —— issue #403 那份 manifest 即使修好宿主解析,**一引入第二个包就碎**。Rust(target-spec JSON)、CMake(toolchain file)、Conan(profile)三家独立收敛到同一答案。
+
+**⚠️ 一处推导的执行判据**:所有消费方从**同一个** `resolve_target_spec()` 取值,不各自推。消费方清单(实施时逐个核对):
+
+```
+compile flags · link flags · cfg 求值上下文 · 产物命名 · runner 选择
+· BMI 缓存键 · hermetic 白名单
+```
+
+`linkmodel.cppm` 头注释记着 #195 的原始病灶就是「四份发散的副本」——**这条不是风格建议**。
+
+### 2.3 逃生舱
+
+`[target.<triple>]` 可覆写 spec 的每个键(开放词表):
+
+```toml
+[target.riscv64-none-elf]
+toolchain    = "llvm@22.1.8"
+isa          = "rv64imac"
+abi          = "lp64"
+code-model   = "medany"
+linker-script = "boards/virt.ld"
+```
+
+⚠️ **但逃生舱必须走门**(见 §2.4),这是 E1 的教训。
+
+### 2.4 ⚠️ P0:堵掉 E1 的静默失败
+
+**今天的行为**(实测,mcpp 2026.8.15.3):`--target riscv64-none-elf` + 逃生舱段 → `Finished dev … 0.04s`,产物是 `target/x86_64-linux-gnu/…` 下的 **x86-64 glibc 动态 PIE**,`build.ninja` 里 `--target` 出现 **0 次**。
+
+机制:`prepare.cppm:1264` 的门条件是 `!known && !hasExplicitSection`,`prepare.cppm:1301` 的 `host_can_serve` 门条件是 `known && …` ⇒ **不可解析的 triple 两道门都不经过**;`prepare.cppm:1458-1462` 的注释直书「leave the spec on the host target」。
+
+**修法**:门的判据从「triple 认不认识」改成「**这次构建到底为哪个 target 发了 `--target`**」。具体:
+
+1. 逃生舱 triple 若 `parse()` 失败 → **不再静默落回宿主**,而是要求 `[target.X]` 显式给出 `isa/abi` 或 `llvm-target`,否则硬失败;
+2. 任何 `--target` 非空的构建,若最终 spec 的 target 等于宿主 target,**必须是用户显式要求的**,否则报错;
+3. 产物目录用**解析后的 target**,与 `--target` 不一致时报错而不是改名。
+
+**验收判据**(必须是这句,不能是「构建失败」):`mcpp build --target riscv64-none-elf` 在**没有**裸机配置时给出指名道姓的错误;在有配置时产物 `file` 输出含 `UCB RISC-V`。
+
+---
+
+## 3. L2 链接层:`CLibMode::Freestanding`
+
+### 3.1 为什么是新态而不是复用 `None`
+
+`linkmodel.cppm:27-29` 的 `CLibMode::None` 语义是**否定式**的:「什么都没找到 —— 驱动默认(宿主)生效」。**那正是 E1 的静默失败本身。** 把裸机接到它上面 = 把新功能建在已知缺陷上。
+
+| | `None`(今天) | `Freestanding`(新) |
+|---|---|---|
+| 语义 | 没找到 C 库 | **明确不要** C 库 |
+| CRT | 驱动默认 | `-nostartfiles`,CRT 由 BSP 提供 |
+| loader / rpath | 驱动默认 | **禁止**(产物不得有 PT_INTERP) |
+| 宿主路径泄漏 | 报告 | **致命** |
+| 链接脚本 | — | 必需 `-T <path>` |
+| 链接器 | 驱动默认 | **载荷内 `ld.lld` 的绝对路径** |
+
+### 3.2 发什么
+
+**编译侧**:`-ffreestanding` + spec 的 `-march/-mabi/-mcmodel` + 由 EnvCaps 决定的 `-fno-exceptions` / `-fno-rtti`(**不是硬编码** —— 一个提供异常的 BSP 应当能打开它)。
+
+**链接侧**:`-nostdlib -nostartfiles -static -T <script>`;**不发** `--dynamic-linker`、`-rpath`、`-B` crt 前缀。
+
+### 3.3 ⚠️ 链接器必须按路径寻址,不能按名字
+
+实测(E6-1):本机 `ld.lld` 经 xlings shim 解析到 **GNU ld 2.42**,对 riscv 报 `cannot represent machine 'riscv'` —— 一条完全不像「找错链接器」的错误。
+
+⇒ `Linker::Lld` 解析为**载荷内的绝对路径**,并在使用前校验 `--version` 含 `LLD`。
+
+### 3.4 hermetic 检查语义反转
+
+`hermetic.cppm` 今天的模型是「dry-run `-###`,断言 CRT + loader 落在允许前缀内,泄漏则报告」。裸机下:
+
+- 没有 CRT / loader 可断言(它们不存在)
+- 断言改为:**产物无 PT_INTERP、无 DT_NEEDED、无未定义符号、链接输入不含任何宿主路径**
+- 泄漏从「报告」升级为「致命」;`allow_host_libs` 逃生舱在 `os=none` 下**不生效**(裸机链宿主库没有正当用例)
+
+### 3.5 链接顺序:唯一的新 provision 语义
+
+OSDev 的硬约束:`crti.o → crtbegin.o → 用户 .o → crtend.o → crtn.o`,顺序错会出「奇怪的 bug」;这两组共同实现 `_init`/`_fini`,**即 C++ 全局构造的调用点**。
+
+`src/build/provisions.cppm` 的 `kTable` 设计意图正好是「一个 provision KIND 一行,复用同一套 fixpoint 传播」。新增两行:
+
+| Kind | 内容 | ⚠️ 新语义 |
+|---|---|---|
+| `LinkerScript` | 链接脚本路径 | 单值,冲突即报错(两个 BSP 不能都给) |
+| `StartupObjects` | 启动目标文件 + **序号** | **现有 provision 全是无序集合,这是第一个带序的** |
+
+⚠️ 带序是这一层唯一真正的新概念,实施时不要顺手把它做成集合。
+
+---
+
+## 4. L3 运行层:runner
+
+### 4.1 `mcpp run`
+
+全仓 `runner|qemu` 的有效命中今天是 **1 处**(且无关)—— 这是纯新增,无兼容负担。
+
+```toml
+[target.riscv64-none-elf]
+runner = ["qemu-system-riscv64", "-machine", "virt", "-nographic",
+          "-bios", "default", "-kernel"]
+```
+
+语义与 Cargo 一致:**产物路径追加到 argv 尾部**。BSP 包也可提供 runner(作为 provision),`[target]` 覆写它。
+
+### 4.2 `mcpp test`
+
+需要退出码约定。实测(X12):picolibc 载荷自带 `crt0-semihost.o` + `libsemihost.a` ⇒ **semihosting 退出码通路是现成的**,不需要自造。
+
+`mcpp test --target riscv64-none-elf` = 为每个测试目标链一个 semihost crt0 的镜像,qemu 跑,读退出码。
+
+⚠️ 见 §9:这条能否算数完全取决于 CI 上有没有 qemu。
+
+---
+
+## 5. L4 契约层:声明 / 证据 / 兜底
+
+**这一层回答的问题**:mcpp-index 上,开发者怎么看出「这个库在裸机上能不能用」。
+
+### 5.1 先承认语言的形状
+
+⚠️ **Z1 实测**:同一个纯头模板库,消费者 A 用 `Ring<int>` → 符号表空(freestanding-clean);消费者 B 用 `Vec<int>` → `_Znam _ZdaPv`(要堆);**库自身编出的目标文件无实例化,无任何符号可审**。
+
+⇒ **C++ 里「库 X 支不支持 freestanding」普遍不是一个库级事实。** Rust 的 `#![no_std]` 是 crate 级 + 编译器强制,C++ 侧**做不到等价的静态保证**。
+
+**但这不意味着不要声明。** 它意味着声明的语义必须写对:
+
+| | Rust `#![no_std]` | mcpp `[freestanding]` |
+|---|---|---|
+| 是什么 | **证明**(编译器强制) | **契约**(作者承诺:在文档化的 API 范围内成立) |
+| 可信度来自 | 语言 | **证据**(§5.4) |
+| 违反时 | 编译失败 | 消费者链接期硬错(§5.5) |
+
+### 5.2 三元组
+
+| | 谁产生 | 存哪 | 服务谁 | 是门吗 |
+|---|---|---|---|---|
+| **声明** | 库作者 | `mcpp.toml` `[freestanding]` → 发布进 xpkg 描述符 | **人**:索引浏览、选型 | ❌ |
+| **证据** | mcpp(publish / CI 算) | xpkg 描述符 `[freestanding.verified]` | **人 + 索引展示** | ❌ |
+| **兜底** | 消费者的裸机链接 | — | **机器** | ✅ **唯一的门** |
+
+### 5.3 声明:字段与语义
+
+```toml
+[freestanding]
+tier     = "core"                          # core | heap | hosted(缺省)
+requires = ["float"]                       # 预设之外的额外能力(可选)
+example  = "examples/freestanding.cpp"     # ⭐ 一致性示例
+```
+
+#### 5.3.1 它解决的是谁的问题
+
+一个开发者在 mcpp-index 上看到 `mcpplibs.tinyfsm`,他正在写 RISC-V 内核。他要回答一个问题:**「这个库我能用吗?」** 今天没有任何办法知道,只能拉下来试。
+
+`[freestanding]` 段就是这个问题的答案栏。**它不参与构建决策**(§5.7 规则 2),它是**索引页上的一行字**,以及支撑那行字的证据。
+
+#### 5.3.2 `tier`:我这个库对环境的最低要求
+
+不是「我用哪个标准库」,也不是「我支不支持裸机」,而是「**跑我需要环境提供什么**」:
+
+| tier | 意思(库作者视角) | 环境要满足 | 库能用的标准设施 |
+|---|---|---|---|
+| `core` | 我只要编译器和一点栈 | 无 libc / 无堆 / 无异常 / 无 RTTI / 无线程 | Y4 实测的 **52 头两家交集**(`span array algorithm ranges optional expected atomic string_view tuple bit concepts type_traits memory numeric mdspan coroutine …`) |
+| `heap` | 我内部要 `new` / `vector` | + libc(picolibc)+ malloc | 额外 `vector string format charconv`(X4/X9 实测) |
+| `hosted` | 我要完整 OS | 现状 | 全部 |
+
+**缺省是 `hosted`** —— 不写 `[freestanding]` 段 = 没声明 = 按 hosted 处理(§5.7 规则 1:这不等于「不支持裸机」,只是「没说」)。
+
+举例说明它怎么用:
+
+| 库 | tier | 为什么 |
+|---|---|---|
+| `tinyfsm`(状态机) | `core` | 纯计算,状态存在成员里 |
+| 定长缓冲区格式化 | `core` | 输出写进调用方给的 `char[]` |
+| `tinyjson`(解析) | `heap` | 节点数量运行期才知道,要动态数组 |
+| 用 `std::thread` 的 | `core` + `requires=["threads"]` | ⚠️ **不是 `hosted`** —— 见 §5.3.4,线程是可插拔能力,RTOS BSP 能提供 |
+| 用 `<filesystem>` / `import std` 的 | `hosted` | 真的需要 OS |
+
+⚠️ **档位是环境的函数,不是标准库实现的函数**(Y4 实测):libc++ 在裸机上能给 `vector` 不是因为 libc++ 比 libstdc++ 强,**是因为 picolibc 给了 malloc**。所以 `heap` 描述的是环境提供了什么,不是库选了谁。
+
+#### 5.3.3 `requires`:为什么不能只有三个档位
+
+三个档位是**能力集上的命名预设**,不是枚举的全部:
+
+```
+core   = {}
+heap   = {heap}
+hosted = {heap, exceptions, rtti, threads, hosted-std}
+```
+
+完整的能力轴 —— **每一条的本质都是「一组符号契约」**,见 §5.3.4:
+
+| 能力 | 含义 | 契约(符号)由谁定义 | 谁能实现 |
+|---|---|---|---|
+| `heap` | `new` / `delete` 可用 | **C++ 标准** [new.delete]:可替换的 `operator new/delete` 重载集 | **BSP / 任何库 / picolibc**(T3b 实测) |
+| `exceptions` | `throw` / `catch` | **Itanium C++ ABI**:`__cxa_throw` + `_Unwind_*` | unwinder 载荷 + 链接脚本保 `.eh_frame` |
+| `rtti` | `dynamic_cast` / `typeid` | **Itanium C++ ABI**:`__dynamic_cast` + typeinfo 布局 | 基本自足(typeinfo 是编译器生成的数据) |
+| `threads` | `std::thread` / `std::mutex` | ⚠️ **两家不同**:libstdc++ = gthreads(`__gthread_*`);libc++ = `_LIBCPP_HAS_THREAD_API_EXTERNAL` | **RTOS / BSP**(T1/T2 实测) |
+| `hosted-std` | `import std` / `<iostream>` / `<filesystem>` | POSIX / OS | 只有真 OS |
+| `float` | 硬件浮点 | 目标 ISA | 目标 ISA 含 `f`/`d`(有些 MCU 没 FPU) |
+| `lockfree-atomics` | 原生 CAS | 目标 ISA | 目标 ISA 含 `a`(X11 的 `rv64i` 变体就没有) |
+
+**布尔为什么立刻不够用**:一个库可能要堆但不要异常;可能只有开了某个 feature 才要堆(⚠️ §5.9-5:声明必须能 per-feature);可能在没有 FPU 的目标上就是不能用。`freestanding = true` 一条都表达不了,而且加第二个布尔会立刻长出第三个。
+
+所以:**常见情况写 `tier`(一个词),预设之外的用 `requires` 补**。
+
+```toml
+[freestanding]
+tier     = "core"        # 不要堆/异常/RTTI/线程
+requires = ["float"]     # 但我要硬件浮点
+```
+
+**resolver 怎么用它**(§5.5:这不是门,是诊断):目标提供的能力集 = 目标规格表的 `EnvCaps` ∪ BSP 提供的;库需要的 = `tier` 预设 ∪ `requires`。差集非空 ⇒ **解析期给一条指名道姓的诊断**,而不是等到链接期看 mangled 符号。
+
+#### 5.3.4 ⚠️ 能力的接口由谁定义 —— mcpp 一个都不发明
+
+这是整个契约层最容易做错的一步。先回答一个具体质疑:**`std::thread` 为什么不是 `hosted`?**
+
+**因为线程在两个标准库里都是可插拔层,不是 hosted 专有设施**(实测):
+
+| 标准库 | 机制 | 证据 |
+|---|---|---|
+| **libstdc++** | **gthreads** —— `gthr.h` / `gthr-default.h` / `gthr-posix.h` / **`gthr-single.h`**;`_GLIBCXX_HAS_GTHREADS` 在构建期决定 | T2:四个 gthr 头齐全,含单线程变体 |
+| **libc++** | **`_LIBCPP_HAS_THREAD_API_EXTERNAL`** —— 「线程原语由外部提供」模式,用户给 `__external_threading` | T1:`__config:622/662` 明确有这条分支 |
+
+FreeRTOS / Zephyr 接上任一侧,裸机上就有 `std::thread`。**所以正确的声明是 `tier="core", requires=["threads"]`,不是 `hosted`。** 原表那行是错的,已改。
+
+**同样的道理适用于 heap —— T3b 实测**:BSP 侧一个 **bump 分配器**(替换 `operator new/delete` 重载集,约 12 个符号),**零 libc、零 malloc**,`std::vector<int>` 在 `riscv64-none-elf` 上直接可用:
+
+```
+heapdemo.elf: ELF 64-bit LSB executable, UCB RISC-V, statically linked
+   text 5911   bss 12304     ← 未定义符号:空
+```
+
+C++ 标准 [new.delete] **本来就规定 `operator new/delete` 可被用户替换** —— 这不是绕过标准,这是标准写好的扩展点。
+
+##### 结论:能力 = 符号契约,契约早已存在
+
+| 问法 | 答案 |
+|---|---|
+| 是 C++ 语言模型里的吗? | **heap 是**(标准 [new.delete] 可替换函数);**exceptions / rtti 是 Itanium C++ ABI**;**threads 不是标准的**,是两家标准库各自的可插拔层 |
+| 只要某种实现提供支持即可吗? | ✅ **是,这就是答案。而且接口早就存在,不用发明。** |
+| mcpp 出一个库定义标准能力接口? | ❌ **不应该。** 那会变成**第三套 ABI**,与 libstdc++ 和 libc++ 都不兼容,谁都不会用 |
+| mcpp 本身做成模块? | ❌ **不。** mcpp 不实现能力,也不定义能力接口 |
+
+**mcpp 只做三件事**,一件都不多:
+
+1. **记账** —— 目标提供哪些能力(TargetSpec ∪ BSP),库需要哪些(`tier` ∪ `requires`)
+2. **验证** —— 符号审计(Y5)
+3. **诊断** —— 差集非空时在解析期说清楚,而不是让用户在链接期读 mangled 符号
+
+这与 2026-07-24 决策 #6(mcpp 定机制、领域专家定语义)和决策 #5(C-ABI 是唯一稳定的二进制互操作契约)是同一条线。
+
+##### ⭐ 由此闭环:审计不是启发式
+
+**能力的「契约」和能力的「判据」是同一组符号。**
+
+```
+heap       契约 = operator new/delete 重载集   判据 = 产物里有没有 _Znwm / _ZdlPvm
+exceptions 契约 = __cxa_throw + _Unwind_*      判据 = 产物里有没有 __cxa_throw
+rtti       契约 = __dynamic_cast + typeinfo    判据 = 产物里有没有 __dynamic_cast
+threads    契约 = __gthread_* / __external_*   判据 = 产物里有没有这些符号
+```
+
+所以 §5.4 的符号审计**不是一个近似规则**,它检查的就是真正的 ABI 契约;§5.5 的链接期兜底之所以是硬门,也是因为契约缺实现在 `-nostdlib` 下必然是未定义符号。**整套设计的三层(声明 / 证据 / 兜底)咬在同一组符号上。**
+
+##### ⚠️ 唯一需要生态出力的一处
+
+`threads` 的接口 **libstdc++ 与 libc++ 不同**(gthreads vs `__external_threading`)。一个 RTOS 想同时服务两边,得写两个 shim。
+
+**这是包的工作,不是引擎的工作** —— 生态可以出 `mcpplibs.rtos-threads-shim` 之类的适配包,把 FreeRTOS/Zephyr 接到两个标准库各自的扩展点上。⚠️ 但**接口仍然是标准库定义的那两个**,mcpp 不在中间再插一层。
+
+#### 5.3.5 ⭐ `example`:把「作者说」变成「机器能验」
+
+这是整段的支点,也是最容易被略过的一条。
+
+**为什么需要它**:⚠️ Z1 实测 —— 同一个纯头模板库,消费者用 `Ring<int>` 符号表是空的(clean),用 `Vec<int>` 就出现 `_Znam`(要堆)。**库自身编出的目标文件没有实例化,没有任何符号可审。** 所以 `tier = "core"` 光写在那里,**没有任何东西能检验它**。
+
+**`example` 做的事**:作者提供一个**只使用他声明为该档位的 API** 的示例程序。然后 CI 在**真实的裸机目标**上编它,并审计产物:
+
+```console
+$ mcpp build --target riscv64-none-elf        # 编 examples/freestanding.cpp
+$ llvm-nm -u <产物>                            # 审计符号
+```
+
+三种结果,全部自动判定,**不需要人工 review**:
+
+| 结果 | 判定 | 索引显示 |
+|---|---|---|
+| 编不过 | 声明是假的 | ⚠️ 已声明,验证失败 |
+| 编过了,但符号含 `_Znwm` | 声明 `core` 实际要堆 | ⚠️ 已声明,实测 tier=heap |
+| 编过了,符号干净 | 声明得到证据支持 | ✅ 已验证 |
+
+**类比**:`tier` 之于「这个库能在裸机上用」,就像一句注释之于「这个函数没 bug」;`example` 就是那个单元测试 —— **声明本身不可信,是可执行的检验让它可信。**
+
+**顺带的两个好处**:
+
+- 它同时**就是文档** —— 用户点开这个库,第一眼看到的是「怎么在裸机上用它」的可编译代码,而不是一段散文。
+- **复用现有机制**:`examples/` 目录 + e2e 已经存在,不是新子系统。
+
+**⚠️ 它仍然不是完备保证**(必须写进文档,见 §5.9):示例只覆盖示例用到的 API。一个消费者用了示例没碰过的模板,可能仍然要堆。这就是为什么门是链接期兜底(§5.5),而不是这个示例。
+
+### 5.4 证据:机器算,人不能写
+
+`mcpp publish`(以及库自己的 CI)产出,写进 xpkg 描述符:
+
+```toml
+[freestanding.verified]
+targets = ["riscv64-none-elf"]     # 实际编/链过的目标
+tier    = "core"                   # 实测达到的档位
+symbols = []                       # 符号审计结果;空 = clean
+example = "examples/freestanding.cpp"
+at      = "2026-08-19"
+by      = "mcpp 2026.8.19"
+```
+
+**符号审计**(Y5 实测,零元数据、零生态配合):
+
+| 产物里出现 | 判定 |
+|---|---|
+| `_Znwm` `_Znam` `_ZdlPvm` `_ZdaPv` / `malloc` | 需要 **heap** |
+| `__cxa_throw` `__cxa_begin_catch` `__cxa_allocate_exception` | 需要 **exceptions** |
+| `__dynamic_cast` `_ZTI*` | 需要 **RTTI** |
+| `pthread_*` `__cxa_thread_atexit` | 需要 **threads** |
+| (空) | freestanding-clean |
+
+`llvm-nm` 已在载荷里。审计对象 = **一致性示例编出的产物**(Z1:库自身没有产物可审)。
+
+**⚠️ 手写的 `[freestanding.verified]` 在发布时被覆盖。** 证据字段是机器的输出,不是人的输入 —— 否则它会立刻退化成第二个声明。
+
+### 5.5 兜底:唯一的门,而且是免费的
+
+⚠️ **关键洞察**:X7–X10 实测,裸机链接会**逐条点名**缺什么(`memmove`、`__libcpp_verbose_abort`、`basic_string::__init`)。因为 `-nostdlib` 下**没有 libc/libstdc++ 来静默满足这些符号**,而 hosted 链接恰恰会。
+
+⇒ **只要 §3 的 `CLibMode::Freestanding` 是真的 `-nostdlib`,「这个库用了它不该用的东西」就已经是硬错误,不需要任何新机制。**
+
+声明和证据的职责因此**不是正确性,是把错误提前并翻译成人话**:
+
+| | 有声明/证据 | 无 |
+|---|---|---|
+| 正确性 | ✅ | ✅(链接期硬错) |
+| 错误在哪发生 | 解析期,「包 `foo` 声明 tier=heap,目标 `riscv64-none-elf` 未提供 heap」 | 链接期,`undefined symbol: _Znwm` |
+| 用户能否行动 | 能 | 难 |
+
+### 5.6 索引展示:三态,永不合并
+
+```
+mcpplibs.tinyfsm 1.2.0   freestanding: core   ✅ 已验证  riscv64-none-elf · 2026-08-19
+mcpplibs.foo     0.3.0   freestanding: core   ⚠️ 已声明,未验证
+mcpplibs.bar     2.0.0   freestanding: —      未声明(≠ 不支持)
+```
+
+### 5.7 四条硬规则(实施时不得违反)
+
+1. **未声明 ≠ 不支持。** 解析期永不因缺声明而拒绝依赖。(库作者 L0 永远可用)
+2. **声明不做门。** 唯一的门是消费者的裸机链接。
+3. **声明与证据分两栏,永不合并。** 合并 = 把「作者说」冒充「已验证」。
+4. **证据由机器算,人不能写。**
+
+⚠️ 规则 1 是硬承诺:一旦「不标注就被排除」,生态立刻分裂成两半,而 mcpp-index 里已发布的包不会为裸机回头改 manifest。
+
+### 5.8 ⚠️ 兼容性(实测支撑,C1–C4)
+
+| 侧 | 实测 | 结论 |
+|---|---|---|
+| manifest 未知顶层段 `[freestanding]` | C1:静默容忍,构建成功 | ✅ 安全 |
+| manifest 未知 `[package]` 键 | C2:静默容忍 | ✅ 安全 |
+| `--strict` | C3:**也不报** | ✅ 安全 |
+| xpkg 描述符未知键 | C4:键是**闭词表** `kKnownXpkgKeys`(26 个),未知键收进 `xpkgUnknownKeys` **静默跳过** | ✅ 安全 |
+
+⚠️ **但有一条必须写进 checklist**:`closest_known_xpkg_key` 会对「像是拼错」的未知键喷 did-you-mean 警告。**新键名必须与那 26 个现有键的编辑距离足够远**,否则老客户端会在整个生态上刷噪音。`freestanding` / `freestanding.verified` 距离足够,安全 —— 但换名字时要重新验。
+
+### 5.9 ⚠️ 符号审计抓不到什么(必须写进文档)
+
+否则它会被当成完备保证,那比没有保证更危险:
+
+1. **inline asm / 裸 syscall / MMIO** —— 不留任何可疑符号。
+2. **纯头库在自己这侧没有产物**(Z1)—— 所以审计对象必须是**一致性示例**,而且「我本地审计过了」≠ 消费者那边干净。
+3. **能力够 ≠ 能用** —— T0-clean 的库仍可能需要 `<format>`(T1)。审计答的是「用了什么」,不是「够不够」。
+4. **弱符号 / COMDAT 不能与 `U` 混算** —— 与 `origin-precedence` 那次「判据必须是 GLOBAL 计数」同类错误。
+5. **feature 会改变答案** —— 一个 feature 开了就要堆 ⇒ 声明与证据都必须能 per-feature,否则又是一个「一个名字量两件事」。
+
+---
+
+## 6. L5 生态层
+
+### 6.0 BSP 包是什么,和普通库有什么区别
+
+#### 6.0.1 它解决什么问题
+
+裸机程序开机时,CPU 从复位地址开始执行。此刻:
+
+- **没有栈** —— `sp` 是垃圾值,任何函数调用都会炸
+- **`.bss` 没清零** —— 全局变量的初值不可信
+- **全局对象的构造函数没跑** —— `.init_array` 没人遍历
+- **没有人调用你的 `kmain`**
+- **链接器不知道代码该放在哪个地址** —— qemu `virt` 是 `0x80200000`,别的板子不是
+
+hosted 世界里这些活是 libc 的 `crt0.o` + 动态加载器干的。裸机上那些东西都不存在,**所以必须有人提供**。BSP(Board Support Package)包就是提供这些的包。
+
+#### 6.0.2 `riscv-virt-rt` 里到底有什么
+
+名字沿用 Rust embedded 的惯例(`cortex-m-rt` / `riscv-rt`,`-rt` = runtime):
+
+```
+riscv-virt-rt/
+├── src/start.S        _start:设 sp、清 .bss、遍历 .init_array、跳 kmain
+├── src/rt.cpp         __libcpp_verbose_abort 默认实现(3 行:for(;;) wfi)
+│                      可选 sbrk —— 实现了它,这个目标就有 heap 能力
+├── boards/virt.ld     链接脚本:qemu virt 的内存布局(.text 从 0x80200000)
+└── mcpp.toml          声明它提供:linker-script / startup-objects / runner
+```
+
+`mcpp.toml` 里那段 runner 就是 `mcpp run` 能工作的原因:
+
+```toml
+[provides]
+linker-script   = "boards/virt.ld"
+startup-objects = ["src/start.S"]          # ⚠️ 带序,见 §3.5
+runner = ["qemu-system-riscv64", "-machine", "virt", "-nographic",
+          "-bios", "default", "-kernel"]
+env-caps = ["heap"]                        # 因为实现了 sbrk
+```
+
+换一块板子 = 换一个 BSP 包(`hifive-rt`、`k210-rt`、`stm32f4-rt`)。**你的 `kmain` 一行不用改** —— 变的是内存布局和启动方式,不是业务逻辑。这正是用户不用手写 `link.ld` 的原因。
+
+#### 6.0.3 与普通库的区别
+
+| | 普通库 | BSP 包 |
+|---|---|---|
+| 回答的问题 | 「给我一个**功能**」 | 「让程序能在**这块板子**上启动起来」 |
+| 贡献什么 | 模块接口 + 目标文件/静态库 | 链接脚本、启动目标文件、runner、内存布局 |
+| **数量** | 一个工程可以有很多个 | **恰好一个** —— 两个链接脚本 = 硬冲突 |
+| **顺序** | 无序集合(链接器自己解析) | **有序** —— `crti→crtbegin→user→crtend→crtn` 错了会出「奇怪的 bug」 |
+| 按什么选 | 按功能 | **按硬件**,与业务代码无关 |
+| 在能力模型里的角色 | **消费**能力(§5.3.3 的 `requires`) | **提供**能力(实现 `sbrk` ⇒ 目标获得 `heap`) |
+
+**三条区别里最深的是第三条**:BSP 是 §5 契约层里「目标提供什么」的**实际提供者**。目标规格表(§2.2)给出裸机目标的能力**默认值**(全关),BSP 再往上加。所以:
+
+```
+目标能力集 = TargetSpec.provides ∪ BSP.env-caps
+库可用性   = 库的 requires ⊆ 目标能力集     ← §5.3.3 的诊断判据
+```
+
+一个不实现 `sbrk` 的 BSP,配上一个 `tier = "heap"` 的库,mcpp 就能在**解析期**说清楚:「`tinyjson` 需要 heap,目标 `riscv64-none-elf` + `riscv-virt-rt` 未提供 —— 换一个提供 heap 的 BSP,或改用 `tier=core` 的库」。这比链接期的 `undefined symbol: _Znwm` 好得多。
+
+**前两条区别是引擎必须支持的新语义**:唯一性(冲突即报错)和有序性(§3.5),这也是 BSP 无法用现有 provision 机制直接表达的全部原因。
+
+### 6.1 三类组件
+
+| 组件 | 内容 | 状态 |
+|---|---|---|
+| **BSP 包**(如 `riscv-virt-rt`) | 见 §6.0 | 机制近乎已有;缺 §3.5 的带序 provision |
+| **`mcpplibs.std.freestanding`** | **实现中立**的名字表(Y3:同一份 `core.cppm` 在 libstdc++`-ffreestanding` 与 libc++`__config_site` 两边都编过) | X5–X10 已跑通;**长期维护品** |
+| **载荷** | per-target compiler-rt builtins(E3)· picolibc(⚠️ 发行版包无 rv64gc,X11)· T3 档的目标版 libc++.a · libc++ 每目标 `__config_site` | **唯一真工程量**;可采纳 LLVM Embedded Toolchain |
+
+### 6.2 生态契约层(HAL):非标准库能力怎么办,以及「实现一次两边都亮」
+
+§5.3.4 讲的是**语言运行时**能力(heap/exceptions/rtti/threads)——它们的契约由标准和 Itanium ABI 定义,mcpp 不发明。但裸机上还有一大类能力**根本没有标准契约**:UART / 定时器 / 随机源 / 存储 / 中断注册 / 电源。
+
+这类能力怎么办?**Rust 的答案是 `embedded-hal`** —— 一组 trait,HAL 实现提供、驱动 crate 消费,一个驱动写一次就能跑在所有实现了该 trait 的芯片上。⚠️ 关键:**`embedded-hal` 不属于 cargo**,它是社区 crate,cargo 对它一无所知。
+
+#### 6.2.1 分两层,不是一层
+
+```
+Layer A  生态契约层(embedded-hal 形状)     ← 接口包,内容由生态定义,mcpp 不定义
+             ↕  BSP / 适配包同时实现两侧
+Layer B  标准 / ABI 扩展点                   ← operator new · gthreads · picolibc hooks(早已存在)
+```
+
+**「实现一次,生态库和 std 都亮」是成立的,但机制是 Layer B 而不是新 ABI**(实测):
+
+| BSP 实现了 | 自动点亮 | 实测 |
+|---|---|---|
+| `operator new/delete` 重载集 | `std::vector` / `std::string` / 所有 std 容器 | T3b(零 libc) |
+| gthreads / `__external_threading` | `std::thread` / `std::mutex` | T1/T2(机制确认) |
+| `hal::Console` concept | 所有依赖该 concept 的生态驱动库 | H3 |
+
+⇒ **一个 BSP 包同时实现 Layer A 的 concept 和 Layer B 的扩展点,两侧一起亮 —— 不需要 mcpp 发明任何契约。** H3 实测:同一个 `bsp.virt` 让生态驱动 `mcpplibs.shell` 和 `std::vector` 同时工作,链接零未定义符号。
+
+#### 6.2.2 ⚠️ 契约的三种形态,只有两种可行
+
+| 形态 | 跨包提供实现 | 多提供者共存 | 成本 | 结论 |
+|---|---|---|---|---|
+| **A** 模块内声明,别的包定义 | ❌ **语言禁止** | — | — | **不可用** |
+| **B** `extern "C"` 缝 | ✅ | ❌ 单一全局符号 | 链接期绑定,不可内联 | 单例型能力 |
+| **C** concept 静态注入 | ✅ | ✅ | **零成本**,可内联 | **生态 HAL 主形态** |
+
+**⚠️ H1 实测 —— 形态 A 为什么被语言禁止**:模块归属被烙进符号名。
+
+```
+消费者要:  _ZN3halW8mcpplibsW3halW7console5writeEPKcm
+           → hal::write@mcpplibs.hal.console(char const*, unsigned long)
+提供者给:  _ZN3hal5writeEPKcm
+           → hal::write(char const*, unsigned long)
+ld.lld: error: undefined symbol: hal::write@mcpplibs.hal.console(...)
+```
+
+附着到模块的函数,**定义必须来自同一个模块**(接口单元或模块实现单元)。**另一个包在物理上给不了它。**
+
+⇒ 这为 2026-07-24 决策 #5(「C-ABI 是唯一稳定的二进制互操作契约」)补上了一条**新的、更硬的理由**:在 C++20 模块世界里,跨包提供实现**只有 C ABI 一条路** —— 这不再只是 ABI 稳定性论证,而是**语言层面的物理约束**。
+
+**形态 C 实测(H3)—— 可组合性的完整形态:**
+
+```cpp
+// 契约包 mcpplibs.hal —— 纯接口,零实现
+export namespace hal {
+    template <class T> concept Console = requires(T& t, std::span<const char> s) { t.write(s); };
+    template <class T> concept Clock   = requires(T& t) { { t.ticks() } -> std::same_as<unsigned long>; };
+}
+
+// 驱动包 mcpplibs.shell —— 只依赖 concept,不知道任何板子
+export template <hal::Console C, hal::Clock K>       // ← 两个能力组合
+void banner(C& c, K& k);
+
+// BSP 包 bsp.virt —— 提供实现;⚠️ Uart 与 Uart2 可同时存在
+struct Uart  { void write(std::span<const char>); };
+struct Uart2 { void write(std::span<const char>); };
+struct Timer { unsigned long ticks(); };
+```
+
+实测结果:`shell::banner(u, t)` 与 `shell::banner(u2, t)` 同时存在,**同一个驱动被两个提供者各实例化一次,零成本静态派发**;整体链接零未定义符号,9040 字节 text。
+
+#### 6.2.3 ⇒ 生态 HAL 该长什么样
+
+- **以形态 C(concept)为主** —— 设备/驱动类能力:可组合、多实例、零成本、跨包无障碍。
+- **形态 B(`extern "C"`)只留给天然单例的运行时能力** —— 堆、panic 落点、系统时钟。
+- ⚠️ **而这些单例能力恰好已经被 Layer B 覆盖了**(`operator new`、`__libcpp_verbose_abort`、gthreads)⇒ **生态基本不需要自己发明 `extern "C"` 契约**。
+
+#### 6.2.4 mcpp 在这一层做什么(仍然只有三件)
+
+**契约的内容由生态定义,mcpp 一条都不定义。** mcpp 提供的是让「契约—实现—消费」三角能被表达和验证的机制,而这套机制**已经存在**:`2026-06-29-feature-capability-model-design.md` 的 `provides` / `requires` / `--cap` 提供者选择 —— 「依赖声明一个 capability 而非具体包,resolver 绑定恰好一个提供者」,**正是 embedded-hal 的形状**。
+
+需要做的只是让它在**构建/链接层**可用(今天 `RuntimeConfig.capabilities` 的语义是运行期宿主能力),而不是新造一套。
+
+⚠️ 这与 Rust 的分工一致:`embedded-hal` 不属于 cargo。**HAL 属于生态,不属于构建工具。**
+
+### 6.3 `mcpplibs.std.freestanding` 的形态
+
+**不**转发 libc++ 的 `std/*.inc`(那会绑定实现),而是自己写标准规定的名字表:
+
+```cpp
+module;
+#include <span>
+#include <optional>
+// … 约 52 个头(Y4 交集)
+export module mcpplibs.std.freestanding;
+
+export namespace std {
+    using std::span; using std::dynamic_extent;
+    using std::optional; using std::nullopt;
+    // …
+    namespace ranges { using std::ranges::sort; /* … */ }
+}
+```
+
+⚠️ **导出的是同一个实体,不是影子命名空间** —— 所以它与任何 `#include <span>` 的代码 ODR 兼容,且**用户代码从裸机搬回 hosted 一行不用改**。这是对开发者最重要的承诺。
+
+代价:要维护那张约 52 项的清单。换来:两家标准库通用,且「可移植的 freestanding 子集」本身成为这个包的卖点。
+
+---
+
+## 7. 使用侧:最小案例
+
+### 7.1 工程(三个文件,零裸机知识手写)
+
+```
+toy_kernel/
+├── mcpp.toml
+└── src/
+    └── main.cppm
+```
+
+**`mcpp.toml`**
+
+```toml
+[package]
+name    = "toy_kernel"
+version = "0.1.0"
+
+[dependencies]
+riscv-virt-rt = "1.0"            # BSP:启动代码 + 链接脚本 + runner
+
+[target.riscv64-none-elf]
+toolchain = "llvm@22.1.8"
+```
+
+**`src/main.cppm`**
+
+```cpp
+export module toy_kernel;
+import mcpplibs.std.freestanding;      // 可选;不 import 就是纯裸机 C++
+
+namespace { volatile char* const kUart = reinterpret_cast<volatile char*>(0x10000000); }
+struct Task { int prio; char id; };
+
+export extern "C" void kmain() {
+    std::array<Task, 4> t{{{3,'c'}, {1,'a'}, {4,'d'}, {2,'b'}}};
+    std::ranges::sort(t, {}, &Task::prio);
+    std::span<Task> sp{t};
+    std::atomic<int> seen{0};
+    for (auto const& x : sp) { seen.fetch_add(1); *kUart = x.id; }
+    std::optional<Task> top = t.empty() ? std::optional<Task>{} : std::optional{t.back()};
+    *kUart = top->id;
+}
+```
+
+**命令**
+
+```console
+$ mcpp build --target riscv64-none-elf
+$ mcpp run   --target riscv64-none-elf     # → qemu-system-riscv64 … -kernel <artifact>
+$ mcpp test  --target riscv64-none-elf     # → qemu + semihosting 退出码
+```
+
+### 7.2 谁提供了什么
+
+| 谁 | 提供 |
+|---|---|
+| **你写的** | `kmain` 的业务逻辑。**裸机知识 0 行。** |
+| **BSP 包** | `_start` / 栈 / `.bss` 清零 / `link.ld` / 链接顺序 / `__libcpp_verbose_abort` / runner argv |
+| **`mcpplibs.std.freestanding`** | `std::array` `std::ranges::sort` `std::span` `std::atomic` `std::optional` —— **真 `std::` 实体** |
+| **目标规格表(引擎)** | `-march=rv64gc -mabi=lp64d -mcmodel=medany` —— ⚠️ 不在你的 manifest 里,因为它必须对每个依赖一致 |
+| **链接模型(引擎)** | `-nostdlib -nostartfiles -static -T`、载荷内 `ld.lld` 绝对路径、无 PT_INTERP |
+| **载荷** | clang / lld / llvm-objcopy(**E2 实测已够用**)+ builtins + picolibc |
+
+### 7.3 不用 std 子集的版本(零依赖)
+
+```toml
+[package]
+name = "toy_kernel"
+version = "0.1.0"
+
+[target.riscv64-none-elf]
+toolchain     = "llvm@22.1.8"
+linker-script = "link.ld"
+runner = ["qemu-system-riscv64", "-machine", "virt", "-nographic", "-bios", "default", "-kernel"]
+```
+
+```cpp
+export module toy_kernel;
+namespace { volatile char* const kUart = reinterpret_cast<volatile char*>(0x10000000); }
+export extern "C" void kmain() {
+    for (const char* s = "mcpp bare metal\n"; *s; ++s) *kUart = *s;
+}
+```
+
+**这个版本 E2 已经在本机真实跑通过**(clang + ld.lld + llvm-objcopy,136 字节裸镜像,零未定义符号)——只是今天得手敲命令行,方案做的就是把这几行命令收进引擎。
+
+### 7.4 库作者侧的最小案例
+
+```toml
+[package]
+name    = "mcpplibs.tinyfsm"
+version = "1.0.0"
+
+[freestanding]
+tier    = "core"
+example = "examples/freestanding.cpp"
+```
+
+```cpp
+// examples/freestanding.cpp —— CI 在 riscv64-none-elf 上编它;编不过则证据栏变红
+import mcpplibs.tinyfsm;
+extern "C" void kmain() { /* 只用文档化的 core 档 API */ }
+```
+
+**L0 的库作者什么都不用做** —— 未声明 ≠ 不支持,hosted 用户零影响,裸机用户靠链接期兜底。
+
+---
+
+## 8. 分期与验收判据
+
+每期的判据都写成**可执行的断言**,不是「跑通了」。
+
+| 期 | 内容 | 验收判据(必须是这个,不是「构建成功」) |
+|---|---|---|
+| **S0** | 堵 E1 静默失败 | `mcpp build --target riscv64-none-elf` 无裸机配置时**指名道姓报错**;不存在「成功且产物是 x86-64」的路径。回归测试直接断言 `file` 输出 |
+| **S1** | L1 目标层 + L2 链接层 | 产物 `file` 含 `UCB RISC-V`;`readelf -l` **无 PT_INTERP**;`llvm-nm -u` 为空;`build.ninja` 里 `--target` 出现次数 > 0 |
+| **S2** | `import std` 关断 | `os=none` 下 `import std;` 给出说明「为什么」的诊断,而不是 libstdc++ 内部报错 |
+| **S3** | L3 runner(前置:qemu 进 xim + harness 硬需求语义) | `mcpp run --target riscv64-none-elf` 在 qemu 里打印出预期串;⚠️ 判据是**「裸机 e2e 实际执行条数 > 0」**,不是「全绿」(§9.1) |
+| **S4** | L4 契约层 | 声明缺失不影响解析;声明存在但证据缺失时索引显示「已声明,未验证」;手写证据字段被覆盖 |
+| **S5** | L5 包 | BSP + std 子集包进索引;§7.1 的三文件工程端到端通过 |
+| **S6** | 载荷 | ⚠️ 验收用例**必须含一次 64 位除法或软浮点**(E3:hello-kernel 是 builtins 缺口的假绿) |
+
+---
+
+## 9. ⚠️ 必须先回答的问题与已知假绿点
+
+按危险程度排序。**前两条要在动手前回答,不是收尾时。**
+
+1. **⚠️ CI 上谁真的跑裸机?** 这条分成两半,**而且只有前一半已经有答案**。
+
+   **(a) 装得上 —— 已解决:qemu 进 xim-pkgindex。** qemu 走 xlings 生态的包索引,与工具链同一套安装机制,mcpp 侧零新增基建,且 xlings/mcpp 两个生态复用同一份包。这与 2026-07-24 决策 #16(「qemu 交叉 test-run = xlings provisioning 免费 + 薄接线」)一致。工程量:一个 xim 包 + `[xlings] deps` 一行。
+
+   **(b) ⚠️ 真的跑了 —— 未解决,而且机制上天然会静默跳过。** 实测 `tests/e2e/run_all.sh`:
+
+   ```
+   check_requires():  # requires: 的 token 不在 CAPS 里 → 返回 "should skip"
+   CAPS 由 command -v 探测填充
+   ```
+
+   **harness 里没有「硬需求」语义** —— 没有任何办法说「这条必须跑,缺能力就让 job 失败」。所以即使 qemu 可安装,只要 CI 没装它,`# requires: qemu` 的裸机 e2e 会**全部静默跳过、整条线永远绿**。这正是 PR#451 的形状(十个新 e2e 因 `# requires: gcc` 在 macOS/Windows 全跳过,放开后才暴露 Windows/macOS 真实失败)。
+
+   **⇒ 需要的改动**(小,但必须在 S3 之前):
+
+   - e2e harness 增加**硬需求**语义(如 `# requires-hard: qemu`):能力缺失时 **FAIL 而不是 SKIP**;
+   - 或/并且:CI 矩阵里显式断言 `qemu ∈ CAPS`,把「这个 job 到底跑了几条」变成可见数字。
+
+   ⚠️ **判据不能是「裸机 e2e 全绿」,必须是「裸机 e2e 实际执行条数 > 0」。** 前者在零执行时也成立。
+2. **⚠️ hello-kernel 是 builtins 缺口的假绿。** E2 的内核 `llvm-nm -u` 为空、一路全绿,而载荷里 compiler-rt builtins 只有 x86_64(E3)。验收用例必须**故意**触发编译器内建运行时。
+3. **⚠️ 探测类代码在 `os=none` 下会假失败。** CMake 因此才有 `CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY`。mcpp 里所有「编个小程序链一下」的探测(doctor、工具链能力探测、`hasImportStd` 探测)**要在 S1 之前普查一遍**。
+4. **⚠️ 单包验证会得出错误结论。** ISA/ABI/code-model 若走 `[build].cxxflags`,toy_kernel 单包能跑通,**加第二个包才碎**(§2.2)。验收工程必须至少有一个依赖。
+5. **⚠️ BMI 缓存键必须含 freestanding 轴。** 同一份源码在 hosted / freestanding 下的 BMI 不可互换(cpp20 档位「跨档位 BMI 硬拒」先例)。
+6. **⚠️ 新门必须自己回答「逃生舱走不走这里」。** E1 就是活例:守卫挂在 `known` 分支,逃生舱走 `!known`。
+7. **⚠️ picolibc 发行版包无 rv64gc**(X11)。用 `rv64imac/lp64` 验证通过不能推广到最常见的 RISC-V profile。载荷的 ISA 覆盖必须是**可查询的数据**,不能是「试了才知道」。
+8. **⚠️ 符号审计不是完备保证**(§5.9)。当成完备门比没有门更危险。
+9. **⚠️ 「libc++ 子集更宽」是错的排序**(Y1/Y2)。103 vs 53 里 libc++ 的一半是能 parse 的空壳(`std::mutex` 根本不存在),libstdc++ 是硬 `#error`。**别用 include 成功率当能力指标。**
+
+---
+
+## 10. 决策回执(D1–D16 在本方案里怎么落的)
+
+| # | 决策 | 本方案 |
+|---|---|---|
+| D1 | E1 何时修 | **S0,独立于路线** —— 已发布能力可达的错误行为 |
+| D2 | 战略定位 | **Route B**(三条缝 + 包);C 留作方向 |
+| D3 | triple 收 `os=none` | **收**,§2.1(即使选 A 也需要它来「识别并拒绝」) |
+| D4 | 目标规格放哪 | `kKnownTargets` 加列 + `[target.<triple>]` 逃生舱,§2.2/2.3 |
+| D5 | `CLibMode` 新态 | **加 `Freestanding`**,不复用 `None`,§3.1 |
+| D6 | BSP 走包还是引擎 | **包**,§6 |
+| D7 | `import std` | **硬关断 + 诊断**,S2 |
+| D8 | 首个目标 | `riscv64-none-elf` @ qemu virt |
+| D9 | CI 怎么真跑 | **(a) 装得上 = qemu 进 xim-pkgindex(已定,xlings/mcpp 双生态复用)**;⚠️ **(b) 真的跑了 = 未决** —— e2e harness 缺硬需求语义,缺能力时是 SKIP 不是 FAIL(实测)。§9.1,S3 的前置 |
+| D10 | builtins 来源 | S6;倾向采纳 LLVM Embedded Toolchain |
+| D11 | std 子集包时机 | **可与 B 并行**(纯包,不依赖引擎改动) |
+| D12 | 裸机线编译器 | **两家都支持,库中立**(Y3);载荷优先 clang(E2 多目标优势) |
+| D13 | libc 来源 | **picolibc**;⚠️ 需自建 multilib 或采纳成品(X11) |
+| D14 | 子集包形态 | **自写实现中立名字表**,不转发 `.inc`,§6.1 |
+| D15 | 生态如何表示 | **声明 + 证据 + 兜底三元组**;声明有(给人看),门只有兜底,§5 |
+| D16 | 档位命名 | `core` / `heap` / `hosted`,由 Y4 实测定义;能力集为底,档位是预设 |
+
+### 10.1 对 2026-07-24 决策 #15 的更新
+
+原文:「裸机 / freestanding-modules / ESP32:出范围 / 推迟 —— 需 freestanding modules(无 hosted import std)核心特性;ESP32 三难合一;512KB RAM MCU 上 C++23-modules 优势无关。」
+
+**更新(不是推翻整条,是更新依据):**
+
+| 原理由 | 实测后 |
+|---|---|
+| 「需要 freestanding modules 核心特性」 | ❌ **模块在裸机上直接可用**(E2:模块接口单元编出 RISC-V 裸机 object)。真正缺的只有 `import std`(E4),而它可以硬关断 |
+| 「512KB MCU 上 modules 优势无关」 | ✅ 对 MCU 成立;❌ 对 RISC-V SoC / 内核不成立(toy_kernel 正是后者) |
+| 「ESP32 三难合一」 | ✅ 仍然成立 —— **本方案不含 ESP32/Xtensa** |
+
+---
+
+## 11. 更大的方向:openhal / openkal 与「可组合内核」
+
+> ⚠️ **本节不属于本方案范围,也不应捆绑决策。** 记在这里是因为它与 §6.2 的契约形态直接相连,而且本轮为它做了三组探测(K1–K3)。本方案的 L1–L3(引擎三条缝)**无论这个方向做不做都需要,且不依赖它** —— 所以这个方向可以推迟,不阻塞任何东西。
+
+### 11.1 愿景
+
+mcpp-community 官方维护 **openhal**(硬件)+ **openkal**(kernel ABI)+ **AAL**(arch 机制),以此为标准实现一套**可组合的内核/OS**,不限嵌入式,涵盖现代 x86 到无 MMU 的 MCU;freestanding 默认支持一切,KAL 覆盖几乎所有 CPU/kernel,HAL 覆盖所有硬件。
+
+### 11.2 三层在三个不同的位置,KAL 是其中门槛最低的一层
+
+**⚠️ 先纠正一个措辞歧义**:「KAL」有两种可能含义,可行性天差地别。
+
+| 读法 | 含义 | 可行性 |
+|---|---|---|
+| **KAL-A:抽象内核内部** | 把调度器/内存管理/IPC 做成可替换接口 | ❌ 见 §11.3 —— 横切且策略耦合,无成功先例 |
+| **KAL-B:统一 syscall / kernel ABI,转发到不同内核后端** | 应用面对一套 ABI,后端是 Linux / 自研内核 / WASI / 无内核 | ✅ **三层里先例最多的一层** |
+
+本节以下讲的是 **KAL-B**。它与 AAL/HAL 处在**三个不同的位置**:
+
+```
+应用 / 生态库 / mcpplibs.std.freestanding
+     ↕  KAL   syscall / kernel ABI     后端:Linux · 自研内核 · WASI · 无内核(裸机)
+内核实现(任选,不被抽象)
+     ↕  AAL   arch 机制                后端:x86_64 · riscv64 · aarch64
+硬件
+     ↕  HAL   设备                     后端:各种外设
+```
+
+**⇒ 做 KAL 完全不需要写内核。第一个后端就是 Linux。** 这是三层里门槛最低、收益最直接的一层。
+
+#### 11.2.1 为什么 KAL-B 可行而 KAL-A 不可行
+
+| | KAL-A(抽象内核内部) | **KAL-B(统一 kernel ABI)** |
+|---|---|---|
+| 消费者 | 内核自己的子系统 | **应用 / 生态库** |
+| 耦合 | 横切 —— 内存模型约束调度器 | **叶子** —— `write()` 不约束调度器 |
+| 缝是新造的吗 | 是,要在紧耦合处切一刀 | **否 —— syscall 早就是每个 OS 的稳定 ABI 边界**,只是把已有的缝标准化 |
+| 缺能力时 | 内核跑不起来 | **优雅降级** —— 后端不提供 `fork` 就是不提供,落回能力集(§5.3.3) |
+
+#### 11.2.2 先例(这是三层里最厚的)
+
+**KAL-B 不是新想法,是被反复验证的形状:**
+
+- **WASI** —— 字面意义上就是这个:syscall 级 ABI + 多后端实现
+- **Rust `std`** —— `sys/unix` / `sys/windows` / `sys/wasi` 三套后端撑同一套 `std` API。**这就是 KAL-B**
+- **POSIX** —— 最早的 kernel ABI 统一层
+- **libc(musl/glibc)** —— 事实上的 kernel ABI 统一层
+- **NT subsystems**(Win32 / POSIX / OS2 跑在同一个 NT executive 上)
+- Zircon vDSO · wasi-libc · Go runtime
+
+#### 11.2.3 KA1–KA3 实测:同一份源码,两个内核后端
+
+契约走 C ABI 缝(H1 已证明跨包只有这一条路):
+
+```cpp
+export module openkal.io;
+extern "C" long kal_write(int fd, const char* buf, unsigned long n);   // 契约
+export namespace kal { inline long write(int, const char*, unsigned long); }
+```
+
+**同一份 `app.cppm`,零 `#if`,两个世界:**
+
+| 后端 | 实现 | 结果 |
+|---|---|---|
+| **hosted x86_64-linux** | 转发到真 `::write(2)` | ✅ **实际运行输出 `hello from one source`** |
+| **riscv64-none-elf 裸机** | 转发到 MMIO UART | ✅ 链接零未定义符号,**157 字节** |
+
+**KA3 —— 应用对 KAL 的全部依赖面是一个可审计的符号集**,而且两侧完全相同:
+
+```
+裸机构建的 app.o   外部符号:  kal_write
+hosted 构建的 app.o 外部符号:  kal_write
+```
+
+**KA2 —— 换后端不重编应用**:同一个 `app_b.o` 换掉后端目标文件重链即成(C ABI 缝的性质)。
+
+#### 11.2.4 ⚠️ KAL 用 C ABI 是对的 —— 与 AAL 相反
+
+这两层的正确 ABI 形态**恰好相反**,而且两边都有实测支撑:
+
+| | **AAL** | **KAL** |
+|---|---|---|
+| 典型操作 | `local_irq_disable()` —— **本该是一条 `csrci`** | `write()` —— 本来就要陷入内核 |
+| 一次 call 的相对成本 | **灾难性**(1 条指令 vs 一次调用) | 可忽略(远小于 syscall 本身) |
+| 正确形态 | **concept + LTO**(K3) | **C ABI**(KA2:换后端不重编) |
+| 依据 | K3:跨模块 `-O2` 退化成 `jal`,LTO 恢复 | H1 + KA1–KA3 |
+
+⚠️ 这也正是 Linux 的实际做法(`asm/` 里的 `static inline` vs 导出的 syscall 入口)—— **不是巧合**。
+
+#### 11.2.5 ⚠️ KAL 最大的风险:它会想长成 POSIX
+
+然后你就重写了一遍 musl,并且继承了 POSIX 所有不可移植的部分。
+
+**WASI 的教训是最值钱的一条:不要模仿 POSIX,而是定义真正可移植的那部分。** POSIX 模拟层(Cygwin / MSYS)出了名地漏;能力式重设计(WASI 的 preopened dirs 而不是假装有全局文件系统)才立得住。
+
+⚠️ **K2 的语义鸿沟在这一层会重现且更严重**:`open()` 在没有文件系统的裸机上是什么?返回 `ENOSYS` 假装存在,就是 K2 那个「类型对、语义错」的老问题放大版。
+
+⇒ **正确做法:KAL 的每个操作都挂在能力轴上**,后端声明提供哪些,**不提供的就是编译期不存在**(而不是运行期报错)。这正好复用 §5.3.3 的能力集,不需要新机制。
+
+#### 11.2.6 ⭐ openkal 的第一个真实用户应该是 std,不是假想内核
+
+**KAL = `std` 的后端接口。** Rust 的 `std` 有 `sys/unix` / `sys/windows` / `sys/wasi` —— 那就是 KAL。
+
+而 mcpp 侧的证据已经在手:`std::vector` 在裸机上能用,是因为 `operator new` 这个缝(T3b);`std::print` 需要一个 sink。**把这些缝集合起来命名,就是 KAL。**
+
+⇒ **`mcpplibs.std.freestanding` 是 openkal 天然的第一个消费者**,这给了它一个立刻可验证的验收标准:*同一份 std 子集,在 hosted 与裸机两个后端下行为一致。* 比「为某个假想内核设计 ABI」踏实得多。
+
+#### 11.2.7 后端选择是 target 轴的函数,不是运行期插件
+
+⚠️ 若做成运行期分发(函数指针表),每次调用付一次间接跳转,且丢掉 LTO。**后端应在构建期由 target 决定** —— 零成本,且落回 mcpp 已有的 target 模型(§2.2),不新增轴。
+
+#### 11.2.8 线程模型建在 KAL 上:可行,但有两条边界(TH1–TH6 实测)
+
+**契约面小,而且两家形状几乎一样** —— 这是这条路可行的关键数字:
+
+| | 契约面 |
+|---|---|
+| libc++ `__external_threading` | **36 个名字**(~30 函数 + 8 类型):mutex×4 · recursive_mutex×5 · condvar×5 · thread×9 · once×1 · tls×3 |
+| libstdc++ gthreads | 71 个,**但 17 个是 Objective-C 遗留** ⇒ 真实面 ~30,与 libc++ 高度重合 |
+
+而且 libc++ 已经有 `__thread/support/{pthread,windows,c11,external}.h` **四个后端** —— **这个形状在标准库里已经存在**,openkal 只是在它下面统一。
+
+**经济账:**
+
+```
+没有 KAL:  N 个内核后端 × 2 个标准库 = 2N 份实现
+有   KAL:  2 个 shim + N 个后端     = 2 + N
+```
+
+##### ⚠️ 边界一:KAL 转发调度器,KAL 不包含调度器
+
+契约里的 `thread_create` / `condvar_wait` / `sleep_for` 都要求**有东西能调度**。裸机无 RTOS 时:
+
+- `thread_create` —— 无处可创建
+- `condvar_wait` —— 阻塞即死锁(没人能运行来唤醒)
+- `mutex_lock` —— 单核无调度器只能自旋,而自旋等一个永不被调度的持有者 = 死锁
+
+⇒ 准确说法:**KAL 让「有调度器的后端」自动适配;「没有调度器的后端」不是适配问题,是它没有这个能力。**
+
+落回能力集(§5.3.3)。X4 已实测不提供时行为是干净的:`no type named 'mutex' in namespace 'std'` —— **编译期不存在,不是运行期坏掉**。
+
+⭐ **推论**:想在裸机上要线程,就**把 RTOS 作为 KAL 后端引进来** —— FreeRTOS / Zephyr 成为 openkal 的后端实现。比「自己写调度器」清晰,且生态可复用。
+
+##### ⚠️ 边界二:`thread_local` 不在 KAL 里,而且今天会静默坏掉
+
+契约里的 `__libcpp_tls_create/get/set` 是**动态 TLS**(pthread_key 风格),KAL 能转发。但 C++ 的 `thread_local` **关键字**用的是编译器 + ABI 级 TLS。TH4–TH6 实测:
+
+```
+thread_local int counter;   →  编译 ✅  链接 ✅  零未定义符号 ✅  零诊断 ✅
+
+bump():
+    lw  a0, 0x0(tp)      ← 通过 tp 寄存器寻址
+    sw  a0, 0x0(tp)
+
+start.S 里设过 tp 吗?  → 没有,只设了 sp
+```
+
+⇒ **编过、链过、零诊断,运行期静默读写垃圾地址。**
+
+`thread_local` 属于 **AAL(TLS 寄存器约定)+ BSP(`start.S` 设 `tp` + 链接脚本 `.tdata/.tbss` 布局)**,KAL 转发不了。⚠️ 而且 libstdc++/libc++ 内部有些地方自己用 `thread_local` —— 所以这不是「用户不写就没事」。
+
+**⇒ BSP 契约必须包含「初始化 TLS 基址」这一条**,并且裸机验收用例里要有一个 `thread_local`,否则这个静默失败会活很久。
+
+#### 11.2.9 三层的形态不一样 —— 统一的是能力模型,分层的是绑定机制
+
+**⚠️ 「AAL/KAL/HAL 都是接口包、都用 concept 吗」的答案是:都是接口包,但形态不同,而且理由都是实测的。**
+
+| 层 | 典型操作 | 一次 call 的相对成本 | 绑定时机 | **正确形态** | 证据 |
+|---|---|---|---|---|---|
+| **AAL** | `local_irq_disable()` = **1 条 `csrci`** | **灾难性** | 编译期,**单选** | **concept + LTO** | K3 |
+| **KAL** | `write()` = 本来就要陷入内核 | 可忽略 | **链接期,单选** | **C ABI** | KA2 / H1 |
+| **HAL** | `uart.write(span)` = MMIO 循环 | 中等,但**需要多实例** | 编译期,**多选** | **concept** | H3 |
+
+三条判据各自独立:AAL 因为**内联是刚需**;KAL 因为**要能换后端不重编**;HAL 因为**一块板子有两个 UART**。
+
+**⇒ 统一的是能力模型(§5.3.3 的声明 / 检查 / 诊断),分层的是绑定机制。** 不要为了「一致」把三层压成同一种形态 —— 那会在 AAL 上丢掉内联,或在 HAL 上丢掉多实例。
+
+##### ⚠️ 可组合的失败模式:链接器只在三分之一的情况下会报错
+
+实测「两个提供者提供同一个 C ABI 能力」:
+
+| 组合 | 链接器行为 |
+|---|---|
+| 两个 `.o` 都定义 `operator new` | ✅ **`duplicate symbol` 硬错误**(响亮) |
+| 一个 `.o` + 一个 `.a`(如 BSP 分配器 + picolibc malloc) | ⚠️ **静默选 `.o`**(归档只在缺符号时才拉) |
+| 两个 `.a` | ⚠️ **静默选第一个** |
+| concept 形态的两个提供者(H3) | ✅ 正常共存,各自实例化 |
+
+**⇒ 「恰好一个提供者」必须由 resolver 在包图层面保证,不能指望链接器** —— 三种情况里两种是静默的。
+
+⭐ **好消息:mcpp 的能力模型本来就是这么设计的**(`2026-06-29-feature-capability-model-design.md`:「依赖声明一个 capability 而非具体包,resolver 绑定**恰好一个**提供者」)⇒ **复用它,不要新造。**
+
+#### 11.2.10 ⭐ KAL 的后端不必是内核
+
+**「基于 KAL 实现时不关心 backend 的具体实现,不是内核也没关系」—— 这条已被 KA1 实测。**
+
+裸机后端就是 `kal_write` 转发到 MMIO UART,**根本没有内核**,而应用侧完全不知道(两侧 `app.o` 的外部符号完全相同,都是 `kal_write`)。
+
+⇒ **KAL 的后端是「能力的提供者」,内核只是其中最丰富的一种。** T3b 的 bump 分配器连一行内核代码都没有,但它是一个合格的 heap 能力提供者。
+
+heap 最能说明可组合:
+
+```
+std::vector
+   ↕ operator new / delete          ← C++ 标准的扩展点(已存在,openkal 不发明)
+heap 提供者:picolibc malloc  |  BSP bump 分配器  |  KAL 后端的分配器
+```
+
+**三种不同层次的东西都能提供同一个能力,应用完全不知道。**
+
+⚠️ **但正因如此,openkal 不该重新定义 `kal_alloc`** —— heap 的契约 C++ 标准已经定义了(§5.3.4)。**openkal 只定义标准没定义的那些**(文件、时钟、进程、网络、随机源…)。否则就是那条被否掉的「第三套 ABI」。
+
+#### 11.2.11 ⭐ openkal 的正确位置:在 libc 之下,C++ std 建在它上面
+
+**⚠️ 修正 §11.2.10 末尾那条**:那里说「openkal 不该定义 `kal_alloc`,因为 heap 契约 C++ 标准已定义」——**那是把 `operator new` 当成了契约。在这个分层里它是适配器,契约在它下面。**
+
+正确的分层是:
+
+```
+std::vector · std::print · std::thread                    ← C++ 标准 API
+    ↕  适配器:operator new · __external_threading · stdio sink
+                                                          ← C++/标准库自己的扩展点(已存在)
+openkal SPEC(POSIX 形状,精简)                            ← ⭐ 要定义的就是这一层
+    ↕  后端
+Linux syscall · 自研内核 · 裸机 BSP · WASI · semihosting
+```
+
+`operator new` **不是契约,是适配器**:它把 C++ 的分配请求转成 openkal 的 `kal_alloc`。T3b 那个 bump 分配器实际上就是这个形状 —— 只是当时把两层写在了一起。
+
+##### SY1–SY3 实测:这个位置是真实存在的,而且面很小
+
+picolibc 已经**把这个接口留好了** —— 它要求下层实现一组 host 函数。从 `libsemihost.a`(一个完整后端)反查,去掉 semihosting 实现细节(`sys_semihost_*`),真正的**契约面**是:
+
+```
+close · _exit · fstat · getentropy · getpid · gettimeofday · isatty · kill
+lseek · lseek64 · open · read · sysconf · times · unlink · write · _map_stdio
+```
+
+**17 个 POSIX 形状的函数。** 另一端 `libdummyhost.a` 是最小后端 —— **只定义了 `_exit` 一个**。
+
+⇒ **openkal v0 的规模是可估的:**
+
+| 组成 | 数量 | 来源 |
+|---|---|---|
+| libc 位置原语(文件/时间/随机/进程/退出) | **~17** | SY2 实测 |
+| 线程原语 | **~30** | TH1/TH2 实测 |
+| 分配(`sbrk` 或 arena) | ~2 | T3b |
+| **合计** | **≈ 50** | |
+
+**≈50 个函数是一个季度能写完 SPEC 的规模,不是 POSIX 那 1000+。**
+
+⭐ 而且 **openkal 的第一个后端不用从零写**:picolibc 的 `libsemihost.a` 就是现成的一个,`libdummyhost.a` 是最小骨架。**openkal 要做的是把这个位置标准化,不是发明它。**
+
+##### ⚠️ 三个必须先回答的问题
+
+**1. openkal 与 libc 的关系**
+
+| 选项 | 后果 |
+|---|---|
+| (a) openkal **替代** libc | 等于重写 musl —— §11.2.5 警告的那条路 |
+| (b) openkal 在 libc **之上** | 只是包装,价值小 |
+| **(c) openkal 在 libc 之下,libc 与 C++ std 都建在它上面** | ✅ **WASI / picolibc 的实际形态** |
+
+⇒ **(c)**。picolibc 已经把接口留好了(SY2 的那 17 个),这不是假设。
+
+**2. ⚠️ 为什么不直接用 WASI?**
+
+WASI 已经占了这个位置,有完整 SPEC 和成熟的能力式设计。**这个问题必须先回答,否则会被反复问。** 诚实的立场:
+
+- WASI 的 **ABI 是 wasm-specific**(线性内存、模块 import),映射到裸机 ELF 不自然;
+- 但 WASI 的**语义设计极其值得借鉴** —— 能力式、preopen、拒绝「全局环境」的假设。
+
+⇒ **借鉴 WASI 的语义,不采用它的 wasm ABI。** 并且这条要写进 SPEC 的开头,而不是留给别人猜。
+
+**3. ⚠️ 范围纪律**
+
+50 是 v0;POSIX 是 1000+。**每加一个原语都必须回答「哪个后端做不到它」** —— 做不到的就该是**能力**(§5.3.3),不该是原语。⚠️ 这是 §11.2.5「KAL 会想长成 POSIX」那条风险的具体防线。
+
+#### 11.2.12 ⚠️ 方向性修正:openkal 不能是 POSIX/libc 形状
+
+§11.2.11 用「libc 位置的 17 个函数」来估规模,**那已经把 POSIX 偏见带进了 SPEC**。openkal 的核心价值是**「基于它开发的库天然跨 OS」**,而 Windows 的原生层不是 libc —— 是 Win32/NT(句柄不是 fd、没有 `lseek` 语义、错误模型不同、没有 `fork`)。
+
+**把 openkal 定义成 POSIX 形状 ⇒ Windows 后端只能靠模拟 ⇒ 就是 Cygwin**,出了名地漏且慢,Windows 永远二等公民。
+
+##### 正确的形状:看什么真的做到了「一套 API 多个 OS」
+
+**Rust `std` / Go / .NET / Java NIO 全都不是 POSIX 形状。** `std::fs::File` 没有 fd、没有 `lseek`,它自然映射到 `open()` **和** `CreateFile()` 两边。
+
+| POSIX 形状(会锁死在 Unix) | 中立形状(两边都自然) |
+|---|---|
+| `int open(path, flags)` → fd | `kal_file_open(path, mode)` → **handle** |
+| `lseek(fd, off, whence)` | `kal_file_seek(handle, off, origin)` |
+| `fstat` → POSIX `struct stat` | → 中立 `kal_file_info`(size/kind/mtime) |
+| **`errno` 全局变量** | **返回值携带错误码**(errno 是线程局部全局,跨 OS 极别扭) |
+| `fork()` | ❌ **不进 SPEC**(Windows 没有,且它是能力不是原语) |
+
+##### ⚠️ 但上面这张表的推导方向仍然是错的 —— 见 §11.2.14
+
+那张表做的是「**POSIX 的中立化重命名**」(`open` → `kal_file_open`),它仍然继承了 POSIX 的世界观:文件是字节流、路径是全局命名空间、句柄是整数、错误在一个统一空间里。**正确的方向是反过来的**,见下一节。
+
+##### ⭐ 可执行的设计规则(这条仍然成立)
+
+> **每个原语必须能在 Linux syscall / Win32 / 裸机 / WASI 四个后端上「自然实现」,不需要模拟层。做不到的就不是原语,是能力(§5.3.3)。**
+
+⚠️ **反直觉的推论:这会让 SPEC 更小,不是更大。** POSIX 里大量东西(`fork` / signal / fd 继承 / `/proc` / 权限位)在中立形状下根本进不去。
+
+重估 v0 规模(形状变了,数字反而更清楚):
+
+| 组 | 数量 |
+|---|---|
+| 文件(open/close/read/write/seek/info/remove/rename) | 8 |
+| 目录(WASI 式 preopen) | 3 |
+| 时间(monotonic / realtime / sleep) | 3 |
+| 随机 · 退出 · 控制台 sink · 分配 | 6 |
+| **中立核心** | **≈ 20** |
+| 线程(**是能力,不是核心**) | ~30 |
+
+⚠️ **Windows 后端要直接接 Win32,不经过 MSVC CRT 的 POSIX 兼容层**(`_open`/`_read` 那套)—— 否则绕一圈又回到模拟。
+
+#### 11.2.13 openhal 能否统一现代 OS 与嵌入式:能,但有一堵硬墙
+
+**能统一的部分已被生态验证,不是设想。** `linux-embedded-hal`(rust-embedded 官方 WG)把 `embedded-hal` 的 trait 实现在 **Linux userspace** 上,走 spidev / i2cdev / gpio-cdev / serialport ⇒ **同一个驱动 crate 既跑裸机 MCU,又跑树莓派 Linux。**
+
+**⚠️ 不能统一的部分是一堵硬墙**:现代 OS 的应用**碰不到设备寄存器**,也**注册不了 ISR** —— 那是内核的领地。抽象跨不过去。
+
+⇒ 干净的切分:
+
+| 层 | 内容 | 能否统一 |
+|---|---|---|
+| **openhal(设备服务)** | Console / Serial / Spi / I2c / Gpio / Pwm / Adc | ✅ 裸机走 MMIO,Linux 走 `/dev/*`,Windows 走对应 API |
+| **寄存器 / ISR / DMA** | 直接 MMIO、中断向量、DMA 描述符 | ❌ 只有 kernel / 裸机侧能做 ⇒ 属 **AAL / 驱动层**,不进 openhal |
+
+##### ⚠️ K2 的语义鸿沟在这里必然重现,而且更隐蔽
+
+一个假设 **µs 级 GPIO 翻转**的 openhal 驱动,在 Linux 上**类型完全正确、能编能跑,但慢 1000 倍且非确定性**(syscall + 调度抖动)。
+
+⇒ **时序 / 实时性必须建模成能力**(`realtime` · `direct-mmio` · `isr`),**不是可以藏起来的实现差异** —— 与 `mmu`(§11.4)是同一类问题、同一个解法。
+
+#### 11.2.14 ⭐ 正确的推导方向:openkal 是可组合的能力接口 SPEC,不是 POSIX 的重命名
+
+**两种推导方向,结果完全不同:**
+
+| | 方向 A(§11.2.12 那张表) | **方向 B(正确)** |
+|---|---|---|
+| 怎么来的 | 看 POSIX 有什么 → 中立化 → openkal | **openkal 独立定义可组合的能力接口 → 各 kernel 用自己的机制去实现它** |
+| 结果 | 换了名字的 POSIX,继承其世界观 | 真正中立的 SPEC |
+
+**⚠️ 这不是理论之争 —— WASI 自己走过这两步并付了学费:**
+
+- **WASIp1** = POSIX-like(fd、POSIX 风格文件系统调用)= 方向 A
+- **WASIp2** = **推倒重来**,「capability-based,**redesigned around interfaces instead of POSIX-ish file descriptors**」,引入 **WIT interface + world + resource**
+- 官方定性:**"Preview 2 isn't an upgrade to Preview 1. It's a complete redesign."**
+
+⇒ **openkal 应该直接从方向 B 起步,不要重走一遍 p1。**
+
+##### 形状上具体变了什么
+
+| | 方向 A | **方向 B** |
+|---|---|---|
+| SPEC 的单位 | **函数列表**(~50 个) | **能力接口**(io/streams · clocks · random · filesystem · threads …) |
+| 目标环境怎么描述 | 「支持哪些函数」 | **world = 接口的组合** |
+| 句柄 | 整数 fd / handle | **resource:有类型、有所有权、生命周期明确** |
+| 错误 | 返回码 / 统一错误空间 | **每个接口定义自己的错误类型**(`result<T, E>`) |
+| 后端职责 | 实现这 50 个函数 | **用自己的机制实现它能实现的那些接口** |
+| 缺能力时 | 返回 `ENOSYS` | **接口根本不在这个 world 里 ⇒ 编译期不存在** |
+
+⭐ **最后一行与前面所有实测对齐**:X4 测到 `std::mutex` 不提供时是 `no type named 'mutex' in namespace 'std'` —— **编译期不存在,不是运行期 ENOSYS**。**能力缺失应该在类型系统里,不在返回值里。**
+
+##### ⇒ 「openkal v0 ≈ 50 个函数」这个说法要换掉
+
+正确说法:**openkal v0 = 少数几个接口 + 少数几个命名 world。**
+
+```
+接口(各自独立版本化、独立实现):
+  kal:io/streams            字节流读写      —— 不预设「文件」
+  kal:clocks/monotonic      单调时钟
+  kal:clocks/wall           墙钟
+  kal:random                随机源
+  kal:memory/alloc          分配
+  kal:filesystem            文件系统        —— 只有有 FS 的后端提供
+  kal:concurrency/threads   线程            —— 只有有调度器的后端提供(§11.2.8)
+  kal:sockets               网络
+
+world(= 能力集的命名预设,与 §5.3.3 同一条原则):
+  world bare    = { io/streams, clocks/monotonic, memory/alloc }
+  world rtos    = bare + concurrency/threads
+  world posix   = rtos + filesystem + clocks/wall + random + sockets
+  world windows = 同 posix,后端不同
+```
+
+⭐ **KA1 实测跑通的那个形态,正好就是 `world bare` 的一个片段**(`kal_write` 一个函数撑起 hosted + 裸机两个后端)。起点已经在手。
+
+##### ⚠️ 四条必须先想清楚的
+
+**A. 与 C ABI 的张力 —— 这是真实工作量,不能省。**
+WIT 有一整套 canonical ABI 表达 resource / `result<T,E>` / string。**纯 C ABI 上表达「有类型的 resource + 结构化错误」要自己定 calling convention。** 而 H1 已证明 C++20 模块下跨包提供实现**只有 C ABI 一条路** ⇒ **openkal 必须自带一份「C ABI 映射规范」。**
+
+**B. 组合爆炸要靠命名 world 压住。**
+20 个独立接口理论上 2^20 种组合。必须定义**少量命名 world** 作预设 —— 与 §5.3.3「档位是能力集上的命名预设」是同一条原则,在 SPEC 层复用。
+
+**C. ⚠️「后端用自己的东西实现」会撞上语义不可实现。**
+例:接口定义「原子重命名」,FAT 后端做不到。此时是接口分裂,还是能力再细分?**WASI 在 filesystem 上就卡了很久。** 这是 SPEC 设计里最耗时的部分,是设计问题不是编码问题。
+
+**D. ⭐ 最重要:先做窄的。**
+WASIp1 想一步到位覆盖 POSIX,结果被迫推倒重来。**openkal 从最小可用 world 起步**(`io/streams` + `clocks/monotonic` + `memory/alloc`)—— 正好是 KA1 已跑通的那个形状。
+
+#### 11.2.15 现代 C++ 惯用法:每个特性解决哪个具体问题(M1–M5 实测)
+
+抽象层要同时做到 **可组合 / 简单使用 / 能组合出复杂**,靠的是几个各司其职的特性 —— 不是「用上新特性」,而是**每个特性对应一个具体问题**。
+
+| 问题 | 特性 | 怎么用 |
+|---|---|---|
+| **能力契约** | `concept` | `OutputStream` / `MonotonicClock` / `Allocator` / `Threads` |
+| **world = 接口的组合** | **concept 的 `&&`** | `RtosWorld = BareWorld<W> && requires(W& w){{ w.threads() }->Threads;}` |
+| **结构化错误(替代 errno)** | `std::expected` | `write() -> expected<size_t, io_error>`;⭐ E5 实测 `<expected>` **零 libc 即可用** |
+| **后端只写最小面** | **deducing this**(C++23) | 后端只实现 `write()`,基类的 `write_all()` 用 `this auto&& self` 免费给出 |
+| **可选能力做增强** | `if constexpr` | 有 `MonotonicClock` 就加时间戳,没有就不加 |
+| **能力缺失的诊断** | 受约束模板 / `static_assert` | `static_assert(!RtosWorld<W>)` 双向钉住 |
+| **零成本** | 模板单态化 + **LTO** | K3:跨模块必须 LTO |
+
+##### M1/M2 实测:整套在裸机上跑通
+
+```cpp
+// SPEC:接口 = concept,world = concept 的组合
+template <class W> concept BareWorld = requires(W& w){{ w.out() }->OutputStream;}
+                                    && requires(W& w){{ w.clock() }->MonotonicClock;}
+                                    && requires(W& w){{ w.mem() }->Allocator;};
+template <class W> concept RtosWorld = BareWorld<W> && requires(W& w){{ w.threads() }->Threads;};
+
+// deducing this:后端只实现 write(),write_all() 免费
+struct stream_ops {
+    auto write_all(this auto&& self, std::span<const char> b) -> std::expected<void, io_error> {
+        while (!b.empty()) { auto n = self.write(b); if (!n) return std::unexpected(n.error());
+                             b = b.subspan(*n); }
+        return {};
+    }
+};
+
+// if constexpr:可选能力是「增强」,不是「降级」
+template <BareWorld W> void log(W& w, std::span<const char> msg) {
+    if constexpr (MonotonicClock<decltype(w.clock())>) { /* 加时间戳 */ }
+    (void)w.out().write_all(msg);
+}
+```
+
+应用侧用 `static_assert` **双向**钉住:
+
+```cpp
+static_assert( kal::BareWorld<bsp::BareWorld>);
+static_assert(!kal::RtosWorld<bsp::BareWorld>);   // ⭐ 反向也钉,防止 world 悄悄变宽
+```
+
+链接零未定义符号,**text 698 字节**。
+
+##### ⭐ M3:零成本是实测的,不是声称的
+
+`kmain` 的反汇编里 **`jal` 条数 = 0** —— `log` → `write_all` → `write` → `expected` 整条链、`rdtime` 读时钟、取模运算,全部内联成直线代码。
+
+⚠️ **前提是 LTO**(K3):跨模块 `-O2` 会退化成真实调用。
+
+##### ⭐ M4/M5(已修正):诊断本身是优秀的 —— ICE 的真因是 BMI flag 不一致
+
+⚠️ **本节初稿断言「clang 22 + 模块 + concept 诊断 = ICE,是路线前置阻塞」。那是错的**,而且错在一个不合格的对照:崩溃组与对照组**同时换了两个变量**(模块 vs 头文件、以及 target/标准库配置)。逐个隔离后:
+
+| 隔离步骤 | 结果 |
+|---|---|
+| ISO-1 宿主 + 正常 libc++ + 模块 + 失败 concept | ✅ 诊断完美 |
+| ISO-2 加回 `--target=riscv64-none-elf -ffreestanding` | ✅ 正常 |
+| ISO-3 概念里用 `std::` 类型(import std 子集) | ✅ 正常 |
+| ISO-4 两个 `import` 写同一行 | ✅ 正常(clang 接受;⚠️ GCC 会报解析错) |
+| ISO-6 `deducing this` + 跨模块继承 | ✅ 正常 |
+| **真因:BMI 建于 `-O2`,另一个 BMI 建于 `-O2 -flto`,混用** | ❌ **ICE** |
+| **同一组 flag 重建全部 BMI** | ✅ **诊断完美** |
+
+flag 一致后的实际诊断质量(比预期好得多 —— 精确到缺哪个成员):
+
+```
+error: static assertion failed: world 缺 threads 能力
+note: because 'bsp::BareWorld' does not satisfy 'RtosWorld'
+note: because 'w.threads()' would be invalid: no member named 'threads' in 'bsp::BareWorld'
+```
+
+GCC 16.1 + 模块同样干净,并标出模块归属(`bsp::BareWorld@bsp.bare`)。
+
+⇒ **惯用法完全成立,不存在路线阻塞。**
+
+##### ⚠️ 但这条更正带出一个更重要的结论
+
+**「BMI 的 flag 一致性」不是优化问题,是「不一致会让编译器崩」。**
+
+- 这**抬高了 §9 风险 5(BMI 缓存键必须含 freestanding 轴)的等级**:后果不是「结果不对」,而是**编译器崩溃栈**。
+- ⭐ **而 mcpp 恰恰有整套指纹/缓存键系统就是为了防这个**(`toolchain/fingerprint.cppm` + BMI cache key)。我这次是手敲命令行**绕过了 mcpp 的保护**才踩到 —— **mcpp 的用户按设计不会遇到**。
+- 与 C++20 档位设计「跨档位 BMI 硬拒」是同一族问题,那条先例现在有了更硬的理由。
+
+⚠️ ICE 本身仍是 clang 的 bug(正确行为应是「BMI 以不兼容的 flag 构建」这类诊断,而不是崩溃),值得上报 —— 但**它不阻塞这条路线**。
+
+⚠️ 另有一条 GCC 模块小坑(与 ICE 无关):`import a; import b;` 写在**同一行**会被 GCC 报 `expected end of line before 'import'`(clang 接受)。**每行一个 import。**
+
+##### 两层 API:可组合在下,简单在上
+
+⚠️ 别让所有用户都写模板参数。正确做法是**两层**:
+
+| 层 | 形态 | 给谁 |
+|---|---|---|
+| **底层(可组合)** | 模板 + concept,**显式传 world / device 对象** | 库作者、多实例、可测试(注入假 world 做单测) |
+| **上层(简单)** | 对**构建期选定的那一个 world** 的薄封装,自由函数 | 90% 的应用作者 |
+
+```cpp
+// 底层:可组合、可注入
+template <BareWorld W> void log(W& w, std::span<const char> msg);
+
+// 上层:简单
+namespace kal { inline void log(std::span<const char> msg) { log(default_world(), msg); } }
+```
+
+⭐ **而 world 由构建期 target 轴选定(§11.2.7),所以上层那个 `openkal` 模块接口可以「按 world 生成」** —— 后端没有的能力**在模块接口里根本不导出**。这给出最干净的「编译期不存在」:`kal::spawn` 是**未声明的标识符**,而不是一个受约束模板报 constraint 失败(也就绕开了上面那个 clang ICE)。
+
+这与 libc++ 每目标一份 `__config_site`(E5)是同一个模式,不是新发明。
+
+### 11.3 ⚠️ AAL 与「内核策略」:这条线必须画死
+
+以下针对的是 **KAL-A 那种读法**(抽象内核内部),它与 §11.2 的 KAL-B 是两件事。
+
+| | **HAL** | **KAL** |
+|---|---|---|
+| 抽象的对象 | UART / SPI / GPIO / 定时器 | 上下文切换 / 陷入向量 / 页表 / 调度 / 锁 |
+| 结构 | **叶子** —— 一个 UART 驱动不关心系统里任何别的东西 | **横切且相互约束** —— 内存模型约束调度器,中断模型约束加锁 |
+| 实例 | 多个(两个 UART) | 单例(一个 MMU 模型、一套陷入向量) |
+| 现实中的成功先例 | ✅ **`embedded-hal`(Rust)—— 广泛采用** | ❌ **没有成功的「可复用生态契约」先例** |
+
+**KAL 不是没人试过,而是既有先例全都在「一个内核内部」**:Windows NT 的 `HAL.DLL`、Linux 的 `arch/`、NetBSD 的 `sys/arch/`。它们都服务于**一套固定的内核策略**,不是跨生态的契约。
+
+⇒ **建议把野心拆成两半,分别对待:**
+
+| 层 | 内容 | 可行性 |
+|---|---|---|
+| **AAL(arch 机制抽象)** | 上下文保存/恢复、陷入向量安装、页表项操作、原子/屏障/cache、per-CPU、tick 源、boot 交接 | **形状已被证明**(Rust 的 `x86_64` / `riscv` crate、Linux `arch/` 的大部分)。签名清晰、按 arch 不同、**不编码策略** |
+| **内核策略** | 调度算法、内存分配策略、IPC 设计、安全模型 | **这就是内核本身**。抽象它 = 写内核框架,是另一件事,历史成功率低得多 |
+
+**⚠️ 命名会招来范围蔓延**:叫 "KAL" 会不断把策略吸进来。建议边界写死在名字里(AAL),或在文档第一行就把「机制 vs 策略」的线画出来。
+
+### 11.4 ⚠️ K1/K2:「不管有没有 MMU」是一条藏不住的缝
+
+实测:同一个 `AddressSpace` concept 下
+
+```
+RiscvSv39::map(0x8000_0000, 0x9000_0000) → true    真重映射
+NoMmu    ::map(0x8000_0000, 0x9000_0000) → false   只能恒等
+```
+
+**两者都完全满足 concept,编译期无法区分。** 通用代码做非恒等重映射,在 NoMmu 上静默失败。
+
+**concept 表达语法,不表达语义。** MMU 的有无决定了上面的代码分成两族(有 fork / demand paging / 地址空间隔离 vs 没有),**不是一个统一接口能覆盖的**。
+
+⇒ 正确建模:**MMU 是能力轴(`cfg(mmu)` / `requires=["mmu"]`),不是契约的一个实现**。这恰好落回 §5.3.3 的能力集模型 —— 好消息是不需要新机制,坏消息是「一套 KAL 通吃有无 MMU」这个具体承诺不成立。
+
+### 11.5 ⚠️ K3:零成本抽象跨模块默认失效,LTO 是必需项
+
+同一段通用代码 `setup(arch, va)`,三种构建:
+
+| 构建 | `disable()`(应为一条 `csrci`) | |
+|---|---|---|
+| 同 TU + `-O2` | **完全内联**:`csrci`/`csrsi` + 3 条指令 | ✅ |
+| **跨模块 + `-O2`** | **真实 `jal` 调用** | ❌ |
+| 跨模块 + `-flto` | `jal` = 0,内联进来 4 条 csr | ✅ |
+
+⇒ **内核热路径(irq 开关、per-cpu、页表项)一旦跨包,默认退化成函数调用。** `local_irq_disable()` 本该是一条指令。
+
+**KAL 的构建模型必须把 LTO 当必需项,不是优化项。** 而 LTO 在内核上有自己的代价(链接脚本 section 放置、inline asm 约束、编译期),这条要提前进设计,不能等热路径慢了再补。
+
+⚠️ 同时回顾 §6.2.2-H1:跨包提供实现**只有 C ABI 一条路**(模块归属烙进符号名)。两条合起来给出 KAL 的形态约束:
+
+- **inline 关键的原语**(irq、per-cpu、页表项、原子)→ **concept/模板 + LTO**,不能走 C ABI 边界
+- **粗粒度操作**(boot 交接、驱动注册)→ C ABI 可以
+- 这恰好是 Linux 的实际做法(`asm/` 里的 `static inline` vs 导出函数)—— **不是巧合**
+
+### 11.6 战略边界(必须守住的两条)
+
+1. **⚠️ mcpp 引擎永远不认识 HAL/KAL 任何概念。** 引擎只有 L1–L3 三条缝,openhal/openkal 是**包**。一旦引擎开始理解 KAL,§1「不做板子数据库」的失败模式会以大得多的规模回来。
+2. **这是与「mcpp = 构建现代 C++23 应用的最佳工具」不同的产品。** 十年尺度、不同用户群。这是维护者的战略选择;但它**必须是显式决策**,而不是作为 freestanding 工作的自然延伸悄悄发生。
+
+### 11.7 如果要走,第一步该测什么
+
+**不是设计整套 KAL,而是拿最硬的两个原语试抽象会不会碎** —— 碎在这里,后面全是幻觉:
+
+1. **上下文切换** —— 寄存器保存布局按 arch 完全不同,且与调度器 ABI 耦合;
+2. **页表项** —— x86-64 四/五级、riscv Sv39/48/57、aarch64 stage-1/2、无 MMU,**差异巨大且语义不对齐**(K2 已经在最简单的形态上碎了一次)。
+
+判据不是「编过了」,而是:**一段通用内核代码能不能在两个真实不同的 arch 上既类型正确又语义正确,且 LTO 后无额外指令。**
+
+---
+
+## 12. 三层架构合成:成形了什么,没成形什么
+
+> 本节把 §11 全部讨论收敛成一张可 review 的表。**结论:机制层面成形了,内容层面没有。**
+
+### 12.0 成形度诚实评估
+
+| | 状态 |
+|---|---|
+| **每层的形态**(concept vs C ABI、绑定时机) | ✅ **实测确定**(K3 / H1 / KA2 / H3) |
+| **每层的边界**(什么进来、什么不进来) | ✅ 确定,且每条边界都有反例支撑(K2 / TH6 / linux-embedded-hal) |
+| **横切模型**(能力集 + 编译期不存在) | ✅ 确定,且复用 mcpp 已有机制 |
+| **现代 C++ 惯用法** | ✅ 实测跑通且零成本(M1–M3:`jal` = 0) |
+| **具体接口清单**(每层有哪些接口、每个什么形状) | ❌ **未定** |
+| **KAL 的 C ABI 映射规范**(resource / `result<T,E>` 怎么在 C ABI 上表达) | ❌ **未定,且是真实工作量** |
+| **AAL 两个最硬原语**(上下文切换、页表项)会不会碎 | ❌ **未验证** —— §11.7 的第一步 |
+| 语义不可实现的处理策略(FAT 做不到原子重命名那类) | ❌ 未定,SPEC 设计里最耗时的部分 |
+| 治理(谁维护、怎么提案、怎么版本化) | ❌ 未定 |
+
+**⇒ 架构成形 ≠ SPEC 成形。** 现在可以开始写 SPEC 了,但 SPEC 本身还没写。
+
+### 12.1 三层各自是什么
+
+#### AAL — Arch Abstraction Layer
+
+| | |
+|---|---|
+| **解决的问题** | 内核 / bootloader / RTOS 的代码怎么跨 CPU 架构,**而不失去零成本** |
+| **设计** | **concept + LTO**(K3:跨模块 `-O2` 会退化成 `jal`,LTO 恢复到 0);编译期单选;**只含机制不含策略** |
+| **边界** | 上下文切换 · 陷入向量 · 页表项 · 原子/屏障 · per-CPU · tick · boot 交接。**调度算法 / 分配策略 / IPC / 安全模型不进来** —— 那就是内核本身 |
+| **⚠️ 已知裂缝** | K2:MMU 有无**不是一个接口能藏的**(`NoMmu` 满足 concept 但只能恒等映射)⇒ 是能力轴 `cfg(mmu)`,不是实现差异 |
+| **应用场景** | **最窄的一层** —— 只有写内核 / hypervisor / bootloader / RTOS 的人用。应用开发者永远不接触 |
+| **生态** | 每个 arch 一个包(`aal-riscv64` / `aal-x86_64` / `aal-aarch64`)。数量少(arch 就那么几个)但每个都深。对标 Rust 的 `riscv` / `x86_64` crate、Linux 的 `arch/` |
+| **风险** | 最高。两个最硬原语(上下文切换、页表项)**没验证过**;先例全在「单个内核内部」,没有跨生态成功案例 |
+
+#### KAL — Kernel ABI Layer
+
+| | |
+|---|---|
+| **解决的问题** | 库 / 应用怎么跨 OS(**包括「没有 OS」**)而只写一遍 |
+| **设计** | **C ABI**(H1:跨包提供实现只有这一条路;KA2:换后端不重编);**能力接口 + world 组合**(WASIp2 形状,不是 POSIX 函数列表);位置**在 libc 之下**,libc 与 C++ std 都建其上 |
+| **边界** | 后端**不必是内核**(KA1:裸机后端就是 MMIO 转发,没有内核)。KAL **转发**调度器,**不包含**调度器。⚠️ `thread_local` 不在 KAL 里(TH6:属 AAL + BSP,且今天会静默坏) |
+| **⚠️ 已知裂缝** | 语义不可实现(FAT 做不到原子重命名);POSIX 化冲动(WASIp1 的教训) |
+| **应用场景** | **最宽的一层** —— 任何想跨 hosted/裸机的库与应用;也是 `mcpplibs.std.freestanding` 的后端接口 |
+| **生态** | 接口包(openkal SPEC)+ N 个后端包(linux / windows / bare / wasi / rtos)+ **2 个 stdlib shim**(gthreads / `__external_threading`)。⭐ **第一个后端是 Linux,不用写内核** |
+| **风险** | 中。形状已被 WASI/POSIX/Rust `std` 反复验证;主要风险是**范围失控**和 C ABI 映射规范的工作量 |
+
+#### HAL — Hardware Abstraction Layer
+
+| | |
+|---|---|
+| **解决的问题** | 外设驱动怎么跨板子,**以及跨「裸机 vs 现代 OS」** |
+| **设计** | **concept + 对象注入**(H3:`Uart` 与 `Uart2` 共存、零成本);编译期**多选**(一块板子多个 UART) |
+| **边界** | **设备服务层**(Console / Serial / Spi / I2c / Gpio / Pwm / Adc)。⚠️ **寄存器 / ISR / DMA 进不来** —— 现代 OS 应用碰不到,那是 AAL/驱动层 |
+| **⚠️ 已知裂缝** | 假设 µs 级 GPIO 的驱动在 Linux 上**类型全对、能跑、慢 1000 倍且非确定** ⇒ 时序/实时性必须是能力(`realtime` / `direct-mmio` / `isr`) |
+| **应用场景** | 写外设驱动的人 + 用驱动的应用。嵌入式最常见的日常工作 |
+| **生态** | **规模最大的一层** —— 每个外设一个驱动包,每个板子一个 BSP。对标 `embedded-hal` 生态(数百个驱动 crate)。⭐ **`linux-embedded-hal` 已证明同一套 trait 能同时服务裸机 MCU 与 Linux** |
+| **风险** | 最低。先例最厚、机制已验证(H3) |
+
+### 12.2 三层怎么互相依赖(以及不依赖)
+
+```
+写应用的人        →  KAL          (+ HAL 的设备,如果碰硬件)
+写驱动的人        →  HAL
+写内核的人        →  AAL  +  提供 KAL
+```
+
+⭐ **HAL 与 KAL 互不依赖**(一个管设备,一个管 OS 服务);**AAL 只有内核作者接触**。三层不是一个栈,是**三个正交的接缝**。
+
+### 12.3 唯一的横切概念:能力模型
+
+三层的绑定机制不同,但**声明 / 检查 / 诊断是同一套**:
+
+| | |
+|---|---|
+| 谁提供 | 目标规格(§2.2)∪ BSP ∪ KAL 后端 ∪ HAL 提供者 |
+| 谁需要 | 库的 `tier` ∪ `requires`(§5.3) |
+| 判据 | **缺能力 = 编译期不存在**(X4 实测:`no type named 'mutex'`),不是运行期 `ENOSYS` |
+| ⚠️ 唯一性 | **resolver 必须保证「恰好一个提供者」** —— 链接器只在三种情况里的一种会报错(两个 `.o` 冲突响亮;`.o`+`.a` 与两个 `.a` **都静默**) |
+| 验证 | 符号审计(Y5);裸机链接天然是硬门(§7.5.3) |
+
+⚠️ **一条贯穿所有层的硬约束**:**BMI 的 flag 必须一致** —— 不一致不是「结果不对」,是**编译器崩溃**(ISO 系列)。mcpp 的指纹/缓存键系统正是防这个的。
+
+### 12.4 建议的推进顺序(按「门槛 × 先例厚度」排)
+
+| 顺序 | 层 | 为什么排这里 |
+|---|---|---|
+| **1** | **KAL 最小 world** | KA1 已跑通(`kal_write` 一个函数撑起两个后端);**第一个后端是 Linux,不用写内核**;而且它是 `mcpplibs.std.freestanding` 的天然后端,验收标准立刻可验证 |
+| **2** | **HAL** | 先例最厚(`embedded-hal` + `linux-embedded-hal`),机制已验证(H3),生态规模最大 |
+| **3** | **AAL** | 只有真要写内核时才需要;⚠️ 且有两个未验证的硬原语(§11.7)—— **碎在那里,后面全是幻觉** |
+
+⚠️ 三条都建立在 §1–§10 的引擎三条缝之上,而**那三条缝无论这三层做不做都需要**。
+
+---
+
+## 13. 未定项收敛(本节把 §12.0 的 ❌ 逐条做掉)
+
+### 13.1 ✅ AAL 两个最硬原语:不碎,但裂缝分两类(AAL-1/AAL-2 实测)
+
+§11.7 说「碎在这里后面全是幻觉」。实测做了:`Context`(不透明)+ `PageTable`(map/unmap/translate)两个 concept,两个**真实不同**的 arch 实现(riscv Sv39 风格 PTE 位 V/R/W/X/U vs x86-64 风格 P/RW/US/NX,Context 布局完全不同),一段通用内核代码。
+
+**AAL-1:通过。** 同一段 `setup_task()` 对两个 arch 各实例化一次,**`call` 条数 = 0**(零成本)。
+
+**AAL-2:主动找裂缝,找到三条,而且分成两类 —— 这是本节的核心结论。**
+
+| # | 裂缝 | 表现 | 类型 |
+|---|---|---|---|
+| 1 | **execute-only 权限**:riscv 支持 X 不带 R,x86-64 经典分页做不到 | **两边都编过**,x86-64 实现静默给了 R+X | **A 类** |
+| 2 | **页大小按下标取** `page_sizes[1]` | 编过;riscv/x86 恰好都是 2M,但 aarch64 16K granule 下是 32M | **A 类** |
+| 3 | **通用代码想设 syscall 返回值** `c.a0 = v` | `error: no member named 'a0' in 'RvSv39::Context'` | **B 类** |
+
+| 类 | 特征 | 处理 |
+|---|---|---|
+| **A 类:语义鸿沟(危险)** | **类型对、能编、静默错** | **必须提到能力轴**,不能留在接口里 |
+| **B 类:表达缺失(安全)** | **编译期硬错** | 说明这件事**本来就不该通用** —— 走 arch 专属接口 |
+
+**⇒ 定下来的设计规则:**
+
+> **凡是「能编但语义可能不同」的,提到能力轴;凡是「编不过」的,承认它不属于通用层。**
+
+具体修正(三条裂缝各对应一条):
+
+1. `Perm` **不做自由 bitset**,改成**命名组合**(`RO` / `RW` / `RX` / `RWX`),`XO`(execute-only)是**能力** `perm-xo`,arch 声明支不支持;
+2. 页大小**不按下标取**,按**语义命名**(`PageSize::Base` / `Large` / `Huge`),或直接传字节数由 arch 拒绝;
+3. Context 的**细粒度寄存器访问不进通用层** —— 需要它的操作(如 syscall 返回值)是 arch 专属接口。
+
+⚠️ 这与 K2(MMU)、§11.2.13(实时性)是**同一条规则的三次应用**。它现在是 AAL/KAL/HAL 三层共用的判据。
+
+### 13.2 ✅ KAL 的 C ABI 映射规范 v0(CABI 实测)
+
+§11.2.14-A 说这是「真实工作量」。规范定如下,**编码选择有实测支撑**。
+
+#### resource → 不透明有类型指针
+
+```c
+typedef struct kal_stream_s* kal_stream_t;   // C 层就类型安全,不同 resource 不能互串
+```
+
+⚠️ **所有权 C ABI 表达不了** ⇒ 约定 `kal_<t>_close(h)`;**所有权归 C++ 包装层的 RAII**,SPEC 只文档化不变量。
+
+#### `result<T,E>` → **2 字结构返回**(不是出参)
+
+```c
+typedef struct { kal_err err; size_t value; } kal_result_usize;   // 0 == ok
+```
+
+**实测两个 arch 都更便宜:**
+
+| 编码 | x86-64 | riscv64 |
+|---|---|---|
+| **2 字结构返回** | **9 条指令** | **10 条指令,2 次内存存取** |
+| 出参 + 错误码 | 12 条指令,3 次栈存取 | 12 条指令,4 次内存存取 |
+
+riscv 反汇编显示结果直接走 `a0`(err)/`a1`(value),`snez`/`and` 就地做了分支消除,**不落栈**。
+
+⚠️ **限制:`T` 必须 ≤ 一个机器字**,否则结构返回退化成隐藏指针。更大的载荷走 resource 句柄。
+
+#### 其余四条
+
+| 项 | 规范 |
+|---|---|
+| 错误码 | **每个接口自己的 `kal_err` 枚举空间**,高位段标接口 ID(不是全局 errno) |
+| 字符串 / 缓冲 | `(const char*, size_t)` 对,**不拥有**;返回值走调用方缓冲或 resource |
+| 缺失能力 | **符号根本不存在**(不返回 `ENOSYS`)⇒ 链接期硬错;上层模块接口也不导出(§11.2.15) |
+| 命名 | `kal_<interface>_<op>`,接口名与 SPEC 的 interface 一一对应 |
+
+### 13.3 ✅ 接口清单 v0(三层各自)
+
+**原则:先做窄的**(§11.2.14-D)。以下是 v0,**不是终态**;每加一条都要过 §13.1 的规则。
+
+**KAL** —— world `bare` 是必须先落地的最小集:
+
+| interface | 操作 | 属于 |
+|---|---|---|
+| `kal:io/streams` | `write` · `read` · `flush` · `close` | **bare** |
+| `kal:clocks/monotonic` | `now_ns` · `resolution_ns` | **bare** |
+| `kal:memory/alloc` | `alloc` · `free` · `realloc` | **bare** |
+| `kal:process/exit` | `exit` | **bare** |
+| `kal:random` | `fill` | rtos+ |
+| `kal:clocks/wall` | `now_unix_ns` | posix+ |
+| `kal:concurrency/threads` | ~30(TH1/TH2 实测的面) | rtos+(**需调度器**) |
+| `kal:filesystem` | `open` · `close` · `read` · `write` · `seek` · `info` · `remove` · `rename` · 目录 3 | posix+ |
+| `kal:sockets` | 待定 | posix+ |
+
+**HAL** —— 对标 `embedded-hal` 的已验证集合:`Console` · `Serial` · `SpiBus` · `I2c` · `Gpio` · `Pwm` · `Adc` · `Delay`。
+
+**AAL** —— 只含机制:`Context`(init/switch)· `Trap`(vector 安装)· `AddressSpace`(map/unmap/translate)· `Atomics/Barriers` · `PerCpu` · `Tick` · `BootHandoff`。
+
+### 13.4 ✅ 语义不可实现的处理策略(FAT 做不到原子重命名那类)
+
+**三选一,按顺序试:**
+
+| 顺序 | 做法 | 何时用 | 例 |
+|---|---|---|---|
+| **1** | **提到能力轴**(细分能力) | 差异是「有/没有」,且两边都合法 | `perm-xo` · `atomic-rename` · `mmu` · `realtime` |
+| **2** | **接口分裂** | 差异大到语义完全不同,共享签名会误导 | `filesystem` vs `filesystem-flat`(无目录) |
+| **3** | **明确不支持,硬错** | 差异无法用能力表达,且勉强支持会静默错 | 通用代码碰 arch 寄存器(§13.1 B 类) |
+
+⚠️ **禁止的第四种:返回 `ENOSYS` / 静默降级。** 那正是 K2 / TH6 那类「类型对、语义错」的来源。
+
+**判据**:如果一个操作在某后端上「能调用但行为不同」,它**必须**走 1 或 2;只有「根本没法表达」才走 3。
+
+### 13.5 ✅ 治理与版本化
+
+| 项 | 定下来 |
+|---|---|
+| 维护方 | **mcpp-community 官方维护 SPEC**(openkal / openhal / AAL 各一份),对标 rust-embedded WG |
+| 仓库形态 | **SPEC 与 mcpp 引擎分仓** —— §11.6 的硬边界:引擎永远不认识这三层任何概念 |
+| 版本化单位 | **每个 interface 独立版本**(不是整份 SPEC 一个版本)⇒ 加接口不动老的 |
+| 兼容规则 | interface 内**只增不改**;要改就出新版本 interface,老版本保留一个发布列 |
+| world 的角色 | **命名预设**,可加不可减;减 = 新 world 名 |
+| 提案流程 | 新 interface 需附:① 至少 **2 个真实后端**的实现草案 ② 过 §13.1 规则的分析 ③ 一个 §5.3 的一致性示例 |
+| ⚠️ 准入判据 | **「能在 Linux / Win32 / 裸机 / WASI 四个后端自然实现,不需模拟层」**(§11.2.12);做不到就是能力不是原语 |
+
+### 13.6 ✅ D9(b):CI 硬需求语义
+
+§9.1 留的唯一未决项。定下来:
+
+- e2e harness 增加 **`# requires-hard: <cap>`** —— 能力缺失时 **FAIL 而不是 SKIP**(现有 `# requires:` 保持 SKIP 语义,用于真正可选的能力);
+- 裸机相关 e2e **一律用 `requires-hard`**;
+- CI 汇总输出**实际执行条数**,判据是 **「裸机 e2e 执行条数 > 0」**,不是「全绿」。
+
+### 13.7 收敛后的 §12.0 状态
+
+| 项 | 原状态 | 现状态 |
+|---|---|---|
+| 每层形态 / 边界 / 横切模型 / C++ 惯用法 | ✅ | ✅ |
+| 具体接口清单 | ❌ | ✅ **§13.3(v0)** |
+| KAL 的 C ABI 映射规范 | ❌ | ✅ **§13.2(编码选择有实测)** |
+| AAL 两个最硬原语会不会碎 | ❌ | ✅ **§13.1 —— 不碎,裂缝分两类,规则已定** |
+| 语义不可实现的处理策略 | ❌ | ✅ **§13.4(三选一 + 禁止第四种)** |
+| 治理 / 版本化 | ❌ | ✅ **§13.5** |
+| D9(b) CI 硬需求 | ❌ | ✅ **§13.6** |
+
+**⇒ 剩下的不再是「未定」,而是「未写」** —— SPEC 正文、接口签名细节、以及每个 interface 的一致性示例。那是执行,不是设计。
+
+---
+
+## 14. mcpp 引擎侧适配总清单
+
+> 前面各节把引擎改动散落在 §2–§7 和 §11–§13。本节**汇总成一张可逐条 review 的清单**,并补上一个之前未定的关键项(§14.0)。
+>
+> ⚠️ **贯穿原则**:引擎**永远不认识 AAL / KAL / HAL 任何概念**(§11.6)。下表每一项都必须能在「不知道这三层存在」的前提下成立。
+
+### 14.0 ⚠️ 撤回:后端选择根本不是 mcpp 的事(本节初稿是过度设计)
+
+初稿把「KAL/HAL 后端怎么被选中」当成一个 mcpp 待定项,并「补定」为 capability provider。**那个前提本身就是错的** —— 它假设了 mcpp 需要为后端选择做点什么。
+
+**实测:已有机制完全够用,零新增。** 条件依赖(`ConditionalConfig::dependencies`)已实现,且在**依赖解析之前**合并(`prepare.cppm:1387`:「#229: merge_conditional_config MUST run here — before dependency resolution」);谓词不匹配的依赖**根本不会被解析**(用一个不存在的包名验证过,构建正常通过)。
+
+```toml
+[target.'cfg(freestanding)'.dependencies]
+openkal-bare  = "1.0"
+
+[target.'cfg(unix)'.dependencies]
+openkal-linux = "1.0"
+```
+
+⇒ **后端选择 = 写一个依赖。** 要可替换就用已有的 capability provider 机制;不要可替换就直接写包名。**两条路都不需要 mcpp 认识「后端」这个概念,也不需要任何新轴。**
+
+⚠️ **教训**:「这个决策放哪一层」如果答案是「mcpp 要新增一个轴」,先问一遍**「用户能不能用已有的依赖/条件依赖表达它」**。这次的答案是能。
+
+### 14.0b ⚠️ 修正:契约形态 与 绑定时机 是两个正交的轴
+
+初稿把「运行期插件表」一刀否掉(理由:间接跳转 + 丢 LTO)。**那是把两个轴混成了一个。**
+
+| 绑定时机 | 用在哪 | 代价 | 契约形态 |
+|---|---|---|---|
+| **编译期** | arch(AAL)· 板级已知设备(HAL) | 零(LTO 后) | concept / 模板 |
+| **链接期** | KAL 后端 · 单例能力 | 一次直接调用 | **C ABI** |
+| **运行期** | 热插拔设备 · 插件 · 宿主上运行期发现的外设 | 一次间接跳转 + 丢 LTO | **C ABI + 函数表 / dlopen** |
+
+⭐ **关键:C ABI 这一个契约形态,同时支持链接期和运行期绑定** —— `kal_write(handle, …)` 既可以链接期解析,也可以从函数表里取。这是 C ABI 作为契约的**额外好处**,初稿只讲了「跨包唯一可行」(H1),漏了这一条。
+
+⇒ **运行期绑定不该被否掉,它有正当场景**(热插拔、插件式驱动)。而且它**不是构建期的事** —— mcpp 已有 `[runtime] dlopen_libs`(2026-07-24 决策 #7),又落回 §14.0c 的第 ③ 类。
+
+### 14.0c ⭐ 责任划分:三类,判据不同
+
+这是本节真正的组织原则 —— 上面两条撤回都是因为没先做这个划分。
+
+| 类 | 判据 | 内容 | 何时做 |
+|---|---|---|---|
+| **① mcpp 必须做** | **不做则谁都做不了**(只有构建工具在这个位置) | 裸机 target 表达 · Freestanding 链接模型 · runner · **不静默错构** · BMI/指纹正确性 · 依赖解析与能力绑定(**已有**) | **先做** |
+| **② mcpp 可以做** | 做了更好用,**不做也能用** | 契约层声明/证据/索引展示 · 能力差集的解析期诊断 · 符号审计 | **可后做** |
+| **③ mcpp 不该做** | 生态 / SPEC 的领域 | AAL/KAL/HAL 的**接口内容** · **后端实现** · **后端选择策略** · 板子数据库 · libc 实现 · 运行期绑定机制 | **永不做** |
+
+**② 为什么可以后做**:§7.5.4 已论证 —— **兜底是链接期硬错**(`-nostdlib` 下没有 libc 静默满足符号)。所以契约层只影响**错误发生的时机和可读性**,不影响正确性。
+
+**③ 的判据**:如果一个东西**用户能用已有的 manifest 语法表达**(依赖、条件依赖、能力),它就是 ③。§14.0 的后端选择就是被这条判据踢出去的。
+
+⇒ **按此重排 §14 的 39 项:**
+
+| 类 | 项 | 数量 |
+|---|---|---|
+| **①必须** | A(6)· C(5)· D(3)· G(3)· H(1)· I(2)· J(1)· K(2) | **23** |
+| **②工效** | B(2)· E(4)· F(6) | **12** |
+| **③不该做 / 非引擎** | L 载荷(4) —— 是分发不是引擎 | 4 |
+
+⚠️ **①里唯一的实施前置是 J(探测普查)**;K(harness)决定这条线是否真跑。**②的 12 项可以整体推迟到 ①跑通之后**,不影响正确性。
+
+### 14.A 目标层### 14.A 目标层(`src/toolchain/triple.cppm`)
+
+| # | 项 | 依据 |
+|---|---|---|
+| A1 | `parse()`:`none` 仅当整串无其它 OS token 时作 OS 段;否则维持 vendor 语义。**正反两侧单测** | §2.1 / `triple.cppm:299` |
+| A2 | `TargetInfo` 增 `TargetSpec` 列(isa · abi · codeModel · linker · clib · **envCaps**) | §2.2 |
+| A3 | `kKnownTargets` 加 `riscv64-none-elf` 行 | §2.2 |
+| A4 | `artifact_naming` 处理 `os=none`(`.elf` + objcopy 产 `.bin`) | §2.2 |
+| A5 | `family()` 对 `os=none` 返回空 —— **现状已正确,加测试钉住** | §2.1 |
+| A6 | **单一取值口** `resolve_target_spec()`,消费方逐个核对(compile/link flags · cfg · 产物命名 · runner · BMI 键 · hermetic 白名单) | §2.2 ⚠️ #195 病灶 |
+
+### 14.B cfg 谓词
+
+| # | 项 | 依据 |
+|---|---|---|
+| B1 | `cfg(freestanding)` / `cfg(os = "none")` | §2.1 |
+| B2 | **`cfg(capability = "heap")`** 类谓词 —— 条件编译需要它(能力检查在 resolver,条件编译在这里) | §7.5.6 |
+
+### 14.C 链接层(`src/toolchain/linkmodel.cppm`)
+
+| # | 项 | 依据 |
+|---|---|---|
+| C1 | **`CLibMode::Freestanding` 新态**(不复用 `None`) | §3.1 |
+| C2 | 链接器按**载荷绝对路径**寻址 + 用前校验 `--version` 含 `LLD` | §3.3 ⚠️ E6-1 |
+| C3 | `-T <script>` 通道(来自 provision 或 `[target]`) | §3.2 |
+| C4 | hermetic 检查语义反转:`os=none` 下宿主路径**致命**,`allow_host_libs` **不生效** | §3.4 |
+| C5 | ⚠️ LTO 是**兜底项**(§16.2 修正):真正的必需项是 SPEC 要求热路径原语标 `inline`;LTO 覆盖漏标与跨包复杂情况 | K3 / §16.2 |
+
+### 14.D provisions(`src/build/provisions.cppm`)
+
+| # | 项 | 依据 |
+|---|---|---|
+| D1 | `LinkerScript` kind —— **单值,冲突即报错** | §3.5 |
+| D2 | `StartupObjects` kind —— **两个具名槽 `prologue`/`epilogue`,槽内数组序**(§19.3 定;提供者唯一 ⇒ 无跨包排序问题) | §3.5 / §19.3 |
+| D3 | `Runner` kind | §4.1 |
+
+### 14.E 能力模型(复用 `2026-06-29-feature-capability-model-design.md`)
+
+| # | 项 | 依据 |
+|---|---|---|
+| E1 | 把 `provides`/`requires` 从**运行期宿主能力**扩到**构建/环境能力** | §7.5.6 |
+| E2 | ⚠️ resolver 保证「**恰好一个提供者**」—— 链接器只在 1/3 情况会报错(两个 `.o` 响亮;`.o`+`.a` 与两个 `.a` **都静默**) | §11.2.9 |
+| E3 | 能力集来源合并:`TargetSpec.envCaps ∪ BSP ∪ KAL 后端 ∪ HAL 提供者` | §6.0.3 |
+| E4 | 差集非空 ⇒ **解析期**指名道姓诊断(而非链接期 mangled 符号) | §7.5.4 |
+
+### 14.F 契约层
+
+| # | 项 | 依据 |
+|---|---|---|
+| F1 | `[freestanding]` manifest 段(`tier` / `requires` / `example`)—— **可选,未声明 ≠ 不支持** | §5.3 |
+| F2 | 一致性示例的构建 + 符号审计(`llvm-nm -u` 分类) | §5.3.5 / §5.4 |
+| F3 | 证据写入 xpkg 描述符 `[freestanding.verified]` | §5.4 |
+| F4 | ⚠️ **手写的证据字段在发布时被覆盖**(证据是机器输出不是人输入) | §5.4 |
+| F5 | 索引展示三态(已验证 / 已声明未验证 / 未声明)**永不合并** | §5.6 |
+| F6 | ⚠️ 新键名与 `kKnownXpkgKeys` 的 26 个键**编辑距离要足够远**(否则老客户端刷 did-you-mean 噪音) | §5.8 / C4 |
+
+### 14.G run / test
+
+| # | 项 | 依据 |
+|---|---|---|
+| G1 | `[target].runner` argv 模板 + **产物路径追加尾部**(Cargo 同款) | §4.1 |
+| G2 | `mcpp test` 走 semihosting 退出码(picolibc `crt0-semihost.o` 现成) | §4.2 / X12 |
+| G3 | BSP 提供 runner 的 provision 通道,`[target]` 可覆写 | §4.1 / D3 |
+
+### 14.H import std
+
+| # | 项 | 依据 |
+|---|---|---|
+| H1 | `os=none` ⇒ `hasImportStd = false`,诊断**说明为什么**并指向 `mcpplibs.std.freestanding` | §6.4 / E4 |
+
+### 14.I BMI / 缓存(⚠️ 等级已被 ISO 抬高)
+
+| # | 项 | 依据 |
+|---|---|---|
+| I1 | ⚠️ **freestanding 进 BMI 缓存键** —— 不一致的后果不是「结果不对」,是**编译器崩溃** | ISO 系列 |
+| I2 | `TargetSpec` 全字段进指纹(isa/abi/codeModel 变了 BMI 必须失效) | §2.2 / I1 |
+
+### 14.J ⚠️ 探测代码普查(实施前必做)
+
+| # | 项 | 依据 |
+|---|---|---|
+| J1 | 所有「编个小程序链一下」的探测在 `os=none` 下会**假失败** —— doctor · 工具链能力探测 · `hasImportStd` 探测,**逐个普查** | §2.3(CMake `TRY_COMPILE_TARGET_TYPE` 教训) |
+
+### 14.K e2e harness
+
+| # | 项 | 依据 |
+|---|---|---|
+| K1 | **`# requires-hard: <cap>`** —— 缺能力 **FAIL 而非 SKIP**(现有 `# requires:` 保持 SKIP) | §13.6 |
+| K2 | CI 汇总输出**实际执行条数**;判据是「裸机 e2e 执行条数 > 0」不是「全绿」 | §13.6 ⚠️ PR#451 |
+
+### 14.L 载荷 / 分发
+
+| # | 项 | 依据 |
+|---|---|---|
+| L1 | per-target compiler-rt builtins;⚠️ **验收用例必须含 64 位除法或软浮点** | E3 |
+| L2 | picolibc 载荷;⚠️ 发行版包**无 rv64gc 变体**,须自建 multilib 或采纳 LLVM Embedded Toolchain | X11 |
+| L3 | libc++ 每目标 freestanding `__config_site` | E5 |
+| L4 | qemu 进 xim-pkgindex(xlings/mcpp 双生态复用) | §9.1 |
+
+### 14.M 统计
+
+| 组 | 项数 | 性质 |
+|---|---|---|
+| A 目标层 | 6 | 已有结构加列 |
+| B cfg | 2 | 词表扩展 |
+| C 链接层 | 5 | 已有结构加态 |
+| D provisions | 3 | ⚠️ 含唯一的新语义(带序) |
+| E 能力模型 | 4 | **复用现有 capability,不新造** |
+| F 契约层 | 6 | manifest 可选段 + 索引侧 |
+| G run/test | 3 | 纯新增,无兼容负担 |
+| H import std | 1 | 挂现有门 |
+| I BMI | 2 | ⚠️ 等级已抬高 |
+| J 探测普查 | 1 | ⚠️ 实施前置 |
+| K harness | 2 | ⚠️ 决定整条线是否真跑 |
+| L 载荷 | 4 | 分发侧,非引擎 |
+| **合计** | **39** | 其中引擎代码 ~29,载荷/CI ~10 |
+
+⭐ **没有一项需要引擎理解 AAL/KAL/HAL** —— §14.0 的 (c) 让三层退化成普通的 capability provider。
+
+---
+
+## 15. 使用侧全景:九个场景,每个只多一件事
+
+> 每个场景标注 **[实测]**(本轮真跑过)或 **[设计]**(形态已定,未实现)。
+> 每个场景只比上一个多**一件**事 —— 这是检验「简单容易」的方式:如果某一步跳跃太大,说明抽象漏了。
+
+### S0 — hosted 应用(对照组)**[实测:今天就是这样]**
+
+```toml
+[package]
+name = "app"
+version = "0.1.0"
+```
+```cpp
+import std;
+int main() { std::println("hi"); }
+```
+```console
+$ mcpp build && mcpp run
+```
+
+⭐ **整套裸机/三层架构对这个场景的影响 = 0。** 不写 `[freestanding]`、不加 `--target`,一切照旧。**这是所有设计的基线约束。**
+
+---
+
+### S1 — 纯裸机内核,零依赖 **[实测:E2 / §7.3]**
+
+**+1 件事:一个裸机 target 段。**
+
+```toml
+[package]
+name = "toy_kernel"
+version = "0.1.0"
+
+[target.riscv64-none-elf]                    # ← 新增
+toolchain     = "llvm@22.1.8"
+linker-script = "link.ld"                    # 自己写
+runner = ["qemu-system-riscv64", "-machine", "virt", "-nographic",
+          "-bios", "default", "-kernel"]
+```
+```cpp
+export module toy_kernel;
+namespace { volatile char* const kUart = (volatile char*)0x10000000; }
+export extern "C" void kmain() {
+    for (const char* s = "bare metal\n"; *s; ++s) *kUart = *s;
+}
+```
+```console
+$ mcpp build --target riscv64-none-elf     # → 136 字节裸镜像,零未定义符号
+$ mcpp run   --target riscv64-none-elf
+```
+
+⚠️ 你还得自己写 `link.ld` 和 `start.S`。**没有 `import std`**(E4)。
+
+---
+
+### S2 — 裸机 + BSP **[设计;BSP 机制已验证]**
+
+**+1 件事:一个依赖。−2 件事:`link.ld` 和 `start.S` 都删掉。**
+
+```toml
+[dependencies]
+riscv-virt-rt = "1.0"                        # ← BSP:start.S + link.ld + runner + _init
+
+[target.riscv64-none-elf]
+toolchain = "llvm@22.1.8"                    # linker-script / runner 都由 BSP 提供
+```
+```cpp
+export module toy_kernel;
+export extern "C" void kmain() { /* 只有业务逻辑 */ }
+```
+
+⭐ **手写的裸机知识:0 行。** 换板子 = 换 BSP 包(`hifive-rt` / `stm32f4-rt`),`kmain` 一行不改。
+
+---
+
+### S3 — 裸机 + std 子集 **[实测:X10]**
+
+**+1 件事:一个 import。**
+
+```toml
+[dependencies]
+riscv-virt-rt         = "1.0"
+mcpplibs.std.freestanding = "1.0"            # ← 新增
+```
+```cpp
+import mcpplibs.std.freestanding;            // ← 新增
+
+export extern "C" void kmain() {
+    std::array<Task, 4> t{...};
+    std::ranges::sort(t, {}, &Task::prio);   // ⭐ 名字就是 std::,不是影子命名空间
+    std::optional<Task> top = ...;
+    std::atomic<int> seen{0};
+}
+```
+
+⭐ **代码搬回 hosted 一行不用改**(导出的是同一个实体)。
+⚠️ `std::thread` / `std::mutex` **编译期不存在**(X4:`no type named 'mutex'`),不是运行期惊喜。
+
+---
+
+### S4 — 裸机 + 堆 **[实测:T3b]**
+
+**+1 件事:换一个提供 heap 能力的 BSP。代码零改动。**
+
+```toml
+[dependencies]
+riscv-virt-rt = { version = "1.0", features = ["heap"] }   # ← BSP 提供 sbrk/operator new
+```
+```cpp
+export extern "C" void kmain() {
+    std::vector<int> v;                      // ⭐ 突然可用了 —— 因为环境多了 heap 能力
+    v.push_back(7);
+}
+```
+
+⭐ **档位是环境的函数,不是代码的函数**(Y4)。你没改一行代码,只是环境提供了 `operator new`。
+
+---
+
+### S5 — 跨 hosted / 裸机的库(KAL)**[实测:KA1–KA3]**
+
+**+1 件事:面向 KAL 接口写,而不是面向 OS 写。**
+
+```toml
+[dependencies]
+"kal:io/streams" = "1.0"                     # ← 接口包(能力),不是具体后端
+
+[target.'cfg(freestanding)'.dependencies]
+openkal-bare  = "1.0"                        # ← 后端由条件依赖选,mcpp 不认识「后端」
+[target.'cfg(unix)'.dependencies]
+openkal-linux = "1.0"
+```
+```cpp
+export module mylib;
+import openkal.io;
+export void greet() { kal::write(1, "hello", 5); }   // ⭐ 零 #if
+```
+```console
+$ mcpp build                                  # → hosted:转发真 write(2),实际跑出 hello
+$ mcpp build --target riscv64-none-elf        # → 裸机:转发 MMIO UART,157 字节
+```
+
+⭐ **应用对 KAL 的全部依赖面是一个可审计符号集**,两侧完全相同:`kal_write`。
+⭐ 换后端**不重编应用**(C ABI 缝的性质)。
+
+---
+
+### S6 — 写外设驱动(HAL)**[实测:H3]**
+
+**+1 件事:驱动对 concept 编程,不对板子编程。**
+
+```cpp
+export module mydriver;
+import mcpplibs.hal;
+
+export template <hal::Console C, hal::Clock K>       // ⭐ 两个能力组合
+void banner(C& c, K& k) { c.write(...); k.ticks(); }
+```
+```cpp
+// 用它的人
+bsp::Uart u1; bsp::Uart2 u2; bsp::Timer t;
+banner(u1, t);
+banner(u2, t);          // ⭐ 同一驱动,两个提供者共存,各实例化一次,零成本
+```
+
+⭐ 同一个驱动包既跑裸机 MCU,又跑 Linux(`linux-embedded-hal` 已证明这个形状)。
+⚠️ 但假设 µs 级 GPIO 的驱动在 Linux 上**类型全对、能跑、慢 1000 倍** ⇒ 时序是能力(`realtime`),不是能藏的差异。
+
+---
+
+### S7 — 写内核(AAL)**[实测:AAL-1 / K3]**
+
+**+1 件事:对 arch concept 编程,并且必须开 LTO。**
+
+```toml
+[target.'cfg(arch = "riscv64")'.dependencies]
+aal-riscv64 = "1.0"
+[target.'cfg(arch = "x86_64")'.dependencies]
+aal-x86_64  = "1.0"
+
+[profile.release]
+lto = true                                   # 兜底;热路径原语应已标 inline(§16.2)
+```
+```cpp
+template <aal::Arch A>
+void schedule(A& a, typename A::Context& cur, typename A::Context& next) {
+    a.ctx_switch(cur, next);                 // 通用调度代码
+}
+```
+
+⚠️ **不开 LTO,`local_irq_disable()` 会变成真实 `jal`**(K3)—— 内核热路径不可接受。
+⚠️ Context 的**细粒度寄存器访问不进通用层**(AAL-2 B 类裂缝:`no member named 'a0'`)。
+
+---
+
+### S8 — RTOS:裸机上要线程 **[设计;契约面已实测 TH1/TH2]**
+
+**+1 件事:换一个提供 threads 能力的 BSP(RTOS 作为 KAL 后端)。**
+
+```toml
+[dependencies]
+freertos-rt = "1.0"                          # ← RTOS 作为 KAL 后端,提供调度器
+```
+```cpp
+import mcpplibs.std.freestanding;
+export extern "C" void kmain() {
+    std::thread t{[]{ /* ... */ }};          // ⭐ 因为环境提供了 threads 能力
+    t.join();
+}
+```
+
+⭐ **KAL 转发调度器,不包含调度器** —— RTOS 是后端,不是 KAL 的内容。
+⚠️ `thread_local` **不在 KAL 里**(TH6):它需要 BSP 初始化 `tp` + 链接脚本 `.tdata/.tbss`,否则**编过链过零诊断,运行期静默写坏内存**。
+
+---
+
+### S9 — 库作者的四级投入 **[设计;符号审计已实测 Y5/Z1]**
+
+```toml
+# L0:什么都不做 ——「未声明 ≠ 不支持」,hosted 用户零影响,裸机用户靠链接期兜底
+[package]
+name = "mcpplibs.tinyfsm"
+
+# L1:跑一次审计(常见结果:发现自己其实已经 clean)
+# L2:条件化
+[target.'cfg(freestanding)'.build]
+sources = ["!src/uses_heap.cppm"]
+
+# L3:声明 + CI
+[freestanding]
+tier    = "core"
+example = "examples/freestanding.cpp"        # ← CI 在裸机目标上编它 + 审计符号
+```
+
+⚠️ **L0 永远可用是硬承诺** —— 一旦「不标注就被排除」,生态立刻分裂。
+
+---
+
+### S-E — 错误场景:要了环境没有的能力 **[实测:ISO(flag 一致时)]**
+
+```cpp
+import mcpplibs.std.freestanding;
+export extern "C" void kmain() { std::mutex m; }     // 环境无 threads
+```
+
+**解析期**(有声明时,②工效档):
+```
+error: 包 'mylib' 需要能力 'threads';目标 riscv64-none-elf + riscv-virt-rt 未提供
+       提供 threads 的 BSP:freertos-rt, zephyr-rt
+```
+
+**编译期**(总是有效,①必须档):
+```
+error: no type named 'mutex' in namespace 'std'
+```
+
+**链接期兜底**(总是有效):
+```
+ld.lld: error: undefined symbol: __libcpp_thread_create
+```
+
+⭐ **三道防线由外向内收紧,而只有最内一道是必须的**(§14.0c)—— 这就是为什么②可以后做。
+
+---
+
+### 15.X 场景差异一览
+
+| 场景 | 比上一个多了什么 | 用户手写的裸机知识 |
+|---|---|---|
+| S0 hosted | — | 0 |
+| S1 纯裸机 | 一个 target 段 | `link.ld` + `start.S` |
+| S2 + BSP | 一个依赖 | **0** |
+| S3 + std 子集 | 一个 import | 0 |
+| S4 + 堆 | **换 BSP,代码零改** | 0 |
+| S5 跨 OS 库 | 面向 KAL 接口写 | 0(**零 `#if`**) |
+| S6 写驱动 | 对 concept 编程 | 0 |
+| S7 写内核 | arch concept + **必须 LTO** | 只剩 arch 相关 |
+| S8 RTOS | **换 BSP,代码零改** | 0 |
+
+⭐ **S2→S8 之间,用户手写的裸机知识始终是 0**;变化的是**依赖**和**环境能力**,不是代码。
+
+---
+
+## 16. 两处澄清:依赖形状,与 LTO 的真实必要性
+
+### 16.1 接口与实现必须分离,而且接口要显式依赖
+
+§15-S5 的写法给全了但没解释为什么。**规则:**
+
+```toml
+[dependencies]
+openkal.io   = "1.0"          # ① 接口:编译依赖 —— 你 import 它,必须显式写
+
+[target.'cfg(freestanding)'.dependencies]
+openkal-bare = "1.0"          # ② 实现:链接依赖 —— 按 target 选
+[target.'cfg(unix)'.dependencies]
+openkal-linux = "1.0"
+```
+
+**为什么接口必须显式依赖(不能只依赖实现让它 re-export):**
+
+你的代码写了 `import openkal.io` —— 那是**编译依赖**。若只依赖实现包、靠它把接口 re-export 出来,接口就成了**隐式依赖**:换一个实现,它 re-export 的接口版本可能不同,而你的 manifest 里**看不出来**。这与 mcpp 的 usage-requirements scope 模型(公开/私有边必须显式)是同一条原则。
+
+**实现侧有两种写法,取舍不同:**
+
+| 写法 | 今天可用 | 何时用 |
+|---|---|---|
+| **条件依赖**(上例) | ✅ **零机制,已实测**(§14.0) | 后端由 target 唯一决定 —— 覆盖绝大多数情况 |
+| **能力 provider**(`provides` + resolver 绑定恰好一个) | ⚠️ **需要 §14.E1** —— 今天 `requires` 是 **feature 级**(`featureRequires`),包级/构建级的 require 还没有 | 同一 target 上有多个候选实现,要可替换/可 pin |
+
+⚠️ **不建议的第三种:接口包自带默认实现**(如 hosted 上默认 fallback 到 libc)。它会造成「在一个平台上悄悄能用、换平台神秘失败」——正是本文档反复标记的那类静默失败。
+
+### 16.2 ⚠️ 修正:AAL 不是「必须 LTO」,是「热路径原语必须显式 `inline`」
+
+§15-S7 写的是「LTO 是必需项」。**实测把这条改了 —— 而且真因反直觉。**
+
+同一个模块接口里四种写法,跨模块 `-O2`、**不开 LTO**:
+
+| 写法 | 结果 |
+|---|---|
+| `void off() { asm(...); }` —— **类内定义(隐式 inline)** | ❌ `jal` = 1,**没内联** |
+| **`inline void off()`** —— 显式 `inline` 关键字 | ✅ **`csrci` 内联进来** |
+| `[[gnu::always_inline]] void off()` —— **只有 attribute** | ❌ `jal` = 1,**没内联** |
+| **`[[gnu::always_inline]] inline void off()`** | ✅ **内联** |
+
+**⇒ 决定内联的是 `inline` 关键字,不是 `always_inline` attribute。**
+
+**为什么(机理):**
+
+1. **内联需要消费者 TU 能看到函数体。** 同 TU 时定义就在眼前(K3-a 实测:`csrci` 直接嵌入,零调用)。
+2. **非模块世界**里,类内定义是隐式 inline,而且**头文件把定义物理复制进了每个 TU** —— 所以「隐式 inline 能跨 TU 内联」是头文件模型的副产品,不是 inline 本身的功劳。
+3. **模块世界**里没有这个复制。消费者只有 BMI。实测:clang 22 对**隐式** inline 的模块附着函数,不把可内联的定义暴露给消费者;**显式 `inline`** 才暴露。
+4. `always_inline` 单独无效,因为它只说「**如果**要内联就必须内联」——**函数体压根不可见时,它没有作用对象**。
+5. **LTO 修好它的原理不同**:LTO 把所有 TU 的 **IR** 推到链接期统一优化,那时优化器能看到 `off()` 的 IR 定义 ⇒ 内联。**它工作在 IR 层,与 BMI 里有没有 AST 层面的 body 无关。**
+
+**⇒ 修正后的指导:**
+
+| 层次 | 做法 |
+|---|---|
+| **首选(免费)** | **AAL / HAL 的热路径原语,在模块接口里显式写 `inline`** —— 这应写进 SPEC 纪律 |
+| **兜底** | LTO —— 覆盖没标 `inline` 的、以及跨包的复杂情况 |
+| **无效** | 只加 `always_inline` 而不加 `inline` |
+
+⚠️ 这条实测于 clang 22;是 QoI 差异还是 bug 未定,但**显式 `inline` 在两种解释下都安全且免费**,所以是无条件推荐的写法。
+
+⚠️ 同时 §14-C5 的措辞要改:LTO 从「必需项」降为「**兜底项**」;真正的必需项是 **SPEC 要求热路径原语标 `inline`**。
+
+---
+
+## 17. 仍待确认清单
+
+### 17.1 ⚠️ 最大的一条:战略决策从未被确认
+
+本文档从「issue #403 调研」一路推到「openkal / openhal / AAL 三层生态」。**但 §10 的 D1–D16 决策回执至今没有被 review 过。**
+
+⚠️ 后续所有讨论**隐含选择了超出 Route C 的方向**(三层 SPEC + 官方维护 + 可组合内核愿景),而这从未被明说。⇒ **需要显式确认:**
+
+| # | 待确认 | 为什么现在必须问 |
+|---|---|---|
+| 17.1a | **D1**:E1 静默失败**立刻修**(独立于路线) | 这是唯一「无论选什么都要做」的义务,不该被大方向讨论淹没 |
+| 17.1b | **D2 的实际选择**:B(最小缝)/ C(全栈)/ **超出 C(三层 SPEC 生态)** | §14 的 39 项与 §11–16 的三层是**两个不同规模**的承诺 |
+| 17.1c | **§14 的 39 项**(除已讨论的后端选择、LTO 两条外) | 输出过但未逐条表态 |
+
+### 17.2 设计上确实还没讨论过的
+
+| # | 项 | 现状(实测) |
+|---|---|---|
+| 17.2a | ⚠️ ~~workspace 多 target~~ **已由 §20 更正:今天就能用** | `cmd_build.cppm:110-122`:fan-out 把**同一个** `ov.target_triple` 传给每个成员 ⇒ 「hosted 成员 + 裸机成员」在**一条命令里表达不了**(`-p` 逐个构建可以)。而 **openkal SPEC 仓库天然是 workspace**(接口包 + N 个后端 + 测试),成员 target 不同 |
+| 17.2b | **裸机 `mcpp test` 的粒度** | hosted 是每个 `tests/*.cpp` 一个 binary;裸机每个用例要**链一个完整镜像 + 跑一次 qemu**。要不要合并成「一个镜像多个用例」?这直接决定裸机测试能不能用 |
+| 17.2c | **裸机产物的 `mcpp pack` / 分发** | `.elf` + `.bin`(+ `.hex`?)+ 符号表/map 文件。§14 完全没有这一项 |
+| 17.2d | **IDE / `compile_commands.json`** | 裸机 target 的 flags 与 hosted 完全不同(`-ffreestanding -march=... -nostdinc++`)。mcpp 有 configure-only CDB,但**多 target 下 CDB 该出哪一份**未定 |
+
+### 17.3 命名
+
+| # | 项 |
+|---|---|
+| 17.3a | **AAL 这个名字**是本文引入的(原始表述是「KAL + 硬件 HAL」)。KAL=syscall 层已确认,**AAL 未确认**。⚠️ §11.3 提醒过「叫 KAL 会招来范围蔓延」,AAL 同理 —— 名字决定边界会不会被侵蚀 |
+
+### 17.4 不是设计问题
+
+| # | 项 |
+|---|---|
+| 17.4a | 谁写 SPEC、第一版时间线 —— §13.5 定了**治理形态**,没定**人和排期** |
+
+### 17.5 已核实为「不需要」的(避免重复讨论)
+
+| 项 | 核实结果 |
+|---|---|
+| `[profile.*] lto` | ✅ **已存在**(`types.cppm:796`)⇒ §16.2 的兜底零新增 |
+| 后端选择需要新轴 | ✅ **不需要**(§14.0,条件依赖已实测) |
+| 运行期绑定机制 | ✅ **不需要**(已有 `[runtime] dlopen_libs`) |
+| 契约层影响正确性 | ✅ **不影响**(§7.5.4:兜底是链接期硬错)⇒ 12 项可后做 |
+
+---
+
+## 18. 仓库布局:接口与实现分仓(定)
+
+### 18.1 决定
+
+**接口仓与实现仓分离**,不走 Linux「所有实现收进内核树」的路子。官方只维护少数几个后端,其余社区。
+
+```
+mcpp-community/
+├── openkal            SPEC:接口包           ← target 中立
+├── openhal            SPEC:接口包           ← target 中立
+├── openkal-conformance  一致性测试套件       ← §18.3,分仓的必需配套
+├── openkal-linux      官方后端
+├── openkal-windows    官方后端
+├── openkal-bare       官方后端(通用裸机骨架)
+└── openhal-linux      官方(对标 linux-embedded-hal)
+
+社区/
+├── openkal-freertos · openkal-zephyr · openhal-stm32f4 · …
+```
+
+### 18.2 ⭐ 这直接解掉了 §17.2a
+
+**接口包是 target 中立的** —— 一份 concept / 一份 C ABI 声明,不针对任何 target。所以:
+
+| 仓库 | 成员 target | 撞不撞 workspace 多 target 限制 |
+|---|---|---|
+| 接口仓(openkal / openhal) | **中立**(或统一 host) | ❌ 不撞 |
+| 后端仓(openkal-bare-riscv) | **单一** target | ❌ 不撞 |
+
+⚠️ 但要把一致性示例**放在后端仓**,不放接口仓 —— 接口本身没有实现,无从验证;**是后端证明自己满足接口**。放错地方就会把多 target 需求带回接口仓。
+
+⚠️ **§17.2a 本身仍是 mcpp 的真实限制**,只是 openkal 生态绕开了它。一般用户仍会撞上 —— **「固件 + 上位机工具」在同一个产品仓库里是极常见的组合**。这条留在 §17。
+
+### 18.3 ⚠️ 分仓的必需配套:一致性测试套件(新增,之前没有)
+
+**分仓 = 没有任何一个地方能一次跑所有后端。** 那么「两个后端行为是否一致」谁来保证?
+
+⇒ **接口仓必须提供一份 conformance suite**,每个后端仓引入并运行:
+
+```toml
+# openkal-freertos/mcpp.toml
+[dev-dependencies]
+openkal-conformance = "1.0"     # ← 引入官方一致性套件
+
+[freestanding]
+example = "examples/conformance.cpp"
+```
+
+- 这是 **WASI 的做法**(`wasi-testsuite`),不是新发明;
+- 它同时是 §5.3 `example` 机制的自然归宿:**后端的一致性示例 = 跑 conformance suite**;
+- ⚠️ **没有它,分仓会退化成「N 个各自解释接口的实现」** —— 那正是 POSIX 生态几十年的老问题。
+
+### 18.4 官方维护哪几个后端:判据不是「用户多」
+
+⭐ **判据是:能让 SPEC 的准入规则可执行。**
+
+§11.2.12 定的准入判据是「每个原语必须能在 **Linux / Win32 / 裸机 / WASI** 四个后端自然实现,不需模拟层」。**要执行这条判据,官方就必须自己持有那几个后端** —— 否则每次提案都要求社区先实现一遍才能审。
+
+| 后端 | 官方维护的理由 |
+|---|---|
+| `openkal-linux` | POSIX 世界的代表 |
+| `openkal-windows` | **非 POSIX 世界的代表** —— 没有它,SPEC 会不知不觉长成 POSIX(§11.2.12) |
+| `openkal-bare` | 无 OS 世界的代表 |
+| `openkal-wasi` | 可选/参考(WASI 自身已是成熟 SPEC,可作对照而非必须) |
+
+⇒ **官方维护这三个不是为了服务用户,是为了让准入判据可执行。** 其余(FreeRTOS / Zephyr / 各 MCU)交社区。
+
+### 18.5 ⚠️ 分仓的代价与缓解
+
+| 代价 | 缓解 |
+|---|---|
+| **改接口要跨仓协调**(加一个接口 = SPEC 仓 + N 个后端仓都要动) | §13.5 已定「**每个 interface 独立版本 + 只增不改**」⇒ 加接口时老后端**不用动**(它只是不提供新接口)。**这条现在有了更硬的理由** |
+| 版本对齐:`openkal-linux 1.2` 实现的是接口的哪个版本 | 后端 manifest 显式声明依赖的接口版本;conformance suite 按接口版本分支 |
+| 社区后端质量参差 | §5.6 的三态展示(已验证 / 已声明未验证 / 未声明)—— 索引照实显示,不背书 |
+
+---
+
+## 19. 八项决策的落定(2026-08-19 review)
+
+### 19.1 A4 产物形态 —— **要**
+
+`os=none` 目标的产物集(工具全部已在载荷内):
+
+| 产物 | 默认 | 怎么来 | 理由 |
+|---|---|---|---|
+| `.elf` | ✅ 总是 | 链接产物 | 调试器 / qemu `-kernel` 都吃它 |
+| `.bin` | ✅ 默认产 | `llvm-objcopy -O binary` | 多数 loader / 烧录器要裸镜像 |
+| `.map` | ✅ 默认产 | `-Wl,-Map=` | **裸机最常见的问题是尺寸和段布局**,事后补不了 |
+| `.hex` | ⬜ 可选 | `llvm-objcopy -O ihex` | MCU 烧录常用,非通用 |
+| size 摘要 | ✅ 构建后打印 | `llvm-size` | text/data/bss 一行 —— 裸机第一关心项 |
+
+⚠️ `.map` 与 size 摘要默认开的理由是**不可回溯**:出问题时再想要,得重新构建一次并且可能已经改了代码。
+
+### 19.2 C4 hermetic 逃生舱 —— **`os=none` 下失效**
+
+`allow_host_libs` / `MCPP_ALLOW_HOST_LIBS` 在 `os=none` 下**完全不生效**(不是降级为警告)。裸机链宿主库没有正当用例。
+
+### 19.3 ⭐ D2 链接顺序 —— 简洁设计(依赖图**不适用**)
+
+**先回答「依赖图 ok 吗」:❌ 不 ok。**
+
+`crti → crtbegin → 用户对象 → crtend → crtn` **不是依赖关系** —— `crtn.o` 并不「依赖」用户对象,它只是必须排在后面。依赖图给出的是**包之间**的拓扑序,而这里要的是**同一条链接线内的位置**。两者不同构。
+
+**简洁方案:两个具名槽,槽内保持数组序。**
+
+```toml
+# BSP 包的 mcpp.toml
+[provides.startup-objects]
+prologue = ["src/crti.S", "src/crtbegin_shim.S"]   # 排在用户对象之前
+epilogue = ["src/crtend_shim.S", "src/crtn.S"]     # 排在用户对象之后
+```
+
+链接线 = `prologue(数组序) → 用户对象 → epilogue(数组序)`。
+
+**为什么这样就够(而不需要序号):**
+
+1. **语义上真的只有两个位置** —— 「用户代码之前」和「之后」。OSDev 的五段式正是这两组;
+2. ⭐ **提供者唯一**(§3.5:`LinkerScript` 单值,`StartupObjects` 同规则)⇒ **跨包排序问题根本不存在**,顺序退化成「一个包内的数组顺序」;
+3. 其余对象(如 `.init_array` 遍历器)**顺序无关**,当普通目标文件处理;段落布局由链接脚本管。
+
+⚠️ **两个 BSP 同时提供 `startup-objects` = 硬错误**(与 `LinkerScript` 同规则)。
+
+⇒ **新语义被压到最小:不是「带序的 provision」,而是「两个具名槽」。** 实现上是两个有序 `vector`,不是排序算法。
+
+### 19.4 E1 `requires` 扩到包级 —— **ok**
+
+从 `featureRequires`(feature 级)扩到包级 / 构建级。是**已有模型的作用域扩展**,不是新模型。
+
+### 19.5 F1 `[freestanding]` manifest 段 —— **ok**
+
+按 §5.3 落地(`tier` / `requires` / `example`)。⚠️ 保持②工效档定位:**未声明 ≠ 不支持**,正确性不依赖它。
+
+### 19.6 G2 裸机 `mcpp test` 粒度 —— **可选,默认「一个镜像跑一次」**
+
+| 模式 | 行为 | 何时 |
+|---|---|---|
+| **`batch`(默认)** | 所有用例链进**一个镜像**,**一次 qemu**,用例间用 semihosting 输出分隔 | qemu 启动开销大,默认要快 |
+| `isolated`(可选) | 每个用例一个镜像、一次 qemu | 定位问题时 |
+
+⚠️ **batch 的代价必须写进文档**:裸机上一个用例挂死(坏 MMIO 写、跑飞)会**带走整批**。缓解:
+- 每个用例开始时通过 semihosting 打**用例名**,超时后能指出「卡在哪个用例」;
+- 超时后**自动重跑一次 `isolated`** 以定位 —— 这让默认档的风险可控。
+
+### 19.7 K1 `# requires-hard` —— **加**
+
+- `# requires:` 保持 SKIP 语义(真正可选的能力);
+- **`# requires-hard: <cap>`** —— 能力缺失时 **FAIL 而非 SKIP**;
+- 裸机 e2e 一律用后者;
+- CI 汇总输出**实际执行条数**,判据是「> 0」不是「全绿」。
+
+### 19.8 ⭐ 17.2d 是什么:多 target 下的 `compile_commands.json`
+
+**问题(实测)**:CDB 写到 `<projectRoot>/compile_commands.json` —— **一个文件,项目根,不按 target 区分**(`compile_commands.cppm:445`)。
+
+于是在双 target 项目里:
+
+```console
+$ mcpp build                              # 写入 host flags 的 CDB
+$ mcpp build --target riscv64-none-elf    # ⚠️ 覆盖成裸机 flags 的 CDB
+```
+
+clangd 只看得到**最后一次**。而两套 flags 差异巨大(`-ffreestanding -march=rv64gc -nostdinc++ -isystem <picolibc>` vs 宿主的一切)⇒ **在 IDE 里,固件代码和上位机工具必有一方满屏红波浪线。**
+
+⚠️ 这不是裸机独有 —— 任何「固件 + 上位机工具」「主程序 + 交叉编译的插件」项目都会撞上,只是裸机把它放大了(flags 差异最大)。
+
+**方案:**
+
+| 层次 | 做法 |
+|---|---|
+| **默认(零变化)** | 跟最后一次 build 走 —— 单 target 项目完全无感 |
+| ⭐ **多 target 项目** | **CDB 本来就是 per-file 的** ⇒ `mcpp build --configure-only` 遍历项目声明的 target,**按文件合并成一份 CDB**:每个文件用**它所属 target** 的 flags |
+
+⭐ 关键洞察:**clangd 的 CDB 是逐文件的,所以根本不需要「选一个 IDE target」** —— 内核文件用裸机 flags、工具文件用 host flags,**同一份 CDB 里共存**即可。
+
+⚠️ 前提:**文件到 target 的归属必须明确**。workspace 成员级最自然(成员 A 是固件、成员 B 是工具);单包内混合则需要 `[target.<triple>]` 声明它管哪些源。
+
+⚠️ 而这条又依赖 §17.2a(workspace 多 target)—— **两条是同一个根**:mcpp 今天假设「一次构建 = 一个 target」。
+
+---
+
+## 20. ⚠️ §17.2a 更正:workspace 多 target 已经能用(WS1–WS3 实测)
+
+### 20.1 我判错了
+
+§17.2a 断言「fan-out 把同一个 target 传给每个成员 ⇒ 混合 workspace 表达不了」。**错。** 我读了 `cmd_build.cppm:110` 的 `mo.target_triple = ov.target_triple` 就下了结论,**漏了 `ov` 为空时成员 manifest 会填**(`prepare.cppm:1225-1226`)。
+
+**WS1 实测** —— 一个 workspace,两个成员各自声明 `[build] target`:
+
+```console
+$ mcpp build --workspace          # 不带 --target
+firmware/target/x86_64-linux-musl/…/firmware   → statically linked (musl)
+hosttool/target/x86_64-linux-gnu/…/hosttool    → dynamically linked (glibc)
+```
+
+**一条命令,两个成员各自用了自己的 target。** ⇒ 「固件 + 上位机工具」在一个 workspace 里**今天就能表达**。
+
+⚠️ 这是本轮第三次「读代码下结论、实测推翻」(前两次:ISO 的不合格对照、E1 的判断)。**代码读出的是意图,实测读出的是行为。**
+
+### 20.2 剩下的两条(都比原判小得多)
+
+#### (a) `--target X --workspace` 是全局覆盖 —— 需要一个决策
+
+**WS3 实测**:显式 `--target x86_64-linux-gnu` **覆盖了** firmware 的 `[build] target = musl`,firmware 被编进了 `target/x86_64-linux-gnu/`。
+
+对混合 workspace 这是错的语义:`mcpp build --workspace --target riscv64-none-elf` 会把 `hosttool` 也编成裸机。
+
+| 选项 | 后果 |
+|---|---|
+| **(a) 冲突即报错**(推荐) | 「成员 `firmware` 声明了 target `A`,与 `--target B` 冲突」—— **说出来,不猜**,与 E1 的教训一致 |
+| (b) `--target` 只填空,不覆盖显式声明 | 同构 workspace(无人声明)的主用例仍然可用;但「我就是要全部编到 X」失去表达 |
+| (c) 保持现状(全局覆盖) | 混合 workspace 上静默做用户没要求的事 |
+
+⇒ **建议 (a)**:把静默覆盖变成显式错误。要逐个覆盖用 `-p`。
+
+#### (b) ⭐ CDB:形状变了,而且变简单了
+
+**WS2 实测**:CDB 是**每成员一份**(`firmware/compile_commands.json`、`hosttool/compile_commands.json`),**workspace 根没有** ⇒ 在根目录打开编辑器时 clangd 找不到。
+
+⚠️ 这是**与裸机无关的已有 gap**,裸机只是让它更痛(flags 差异最大)。
+
+⭐ **但它比 §19.8 描述的情况简单**:不是「一个文件被两个 target 反复覆盖」,而是「每成员一份、根上没有」。⇒ **解法就是合并到 workspace 根**。
+
+而且**每个成员已经有自己正确的 target flags** ⇒ 合并出来的 CDB **天然就是「每个文件用它所属 target 的 flags」** —— §19.8 提的「per-file 正确」**不需要新机制,合并即得**。
+
+⇒ **§19.8 的方案简化为一句:`--workspace` 构建后,把各成员 CDB 合并到 workspace 根。**
+
+### 20.3 更正后的 §17 状态
+
+| 项 | 原判 | 现状 |
+|---|---|---|
+| 17.2a workspace 多 target | ❌ 表达不了 | ✅ **已能用**(WS1);剩 `--target` 覆盖语义一个小决策 |
+| 17.2d 多 target CDB | 需要 per-file 合并机制 | ✅ **合并各成员 CDB 到根即可**,per-file 正确性免费 |
+
+---
+
+## 21. 剩余项:推荐方案(**2026-08-19 已全部批准**)
+
+### 21.0 已定:`--target` + `--workspace` = 冲突即报错
+
+成员声明了 `[build] target` 而命令行给了不同的 `--target` ⇒ **报错说明冲突**,不静默覆盖。要逐个覆盖用 `-p`。(§20.2a 选项 a)
+
+### 21.1 ✅ 17.2c 裸机 `mcpp pack` —— **已定**:复用现有机制,只换产物集
+
+**先划边界**:烧录 / OTA 是**设备侧**的事,mcpp 不碰(与 2026-07-24 决策 #1「不做发行版构建器」一致)。`pack` 的边界是**产出一个可分发的目录/压缩包**,不是把它送进设备。
+
+| 场景 | 方案 |
+|---|---|
+| **固件镜像发布**(新) | 产物集(§19.1:`.elf` `.bin` `.map` + size)+ **sha256** + **构建元数据**(target · toolchain · 版本 · BSP 版本) |
+| **裸机库分发** | ⚠️ **不是新东西** —— #433 / `2026-08-17-library-distribution-design.md` 已覆盖;只需确认 `kind` 轴接受 `os=none` |
+| **BSP 分发** | 源码包,走普通包路径,零新增 |
+
+⚠️ **构建元数据是刚需不是装饰**:现场排障时第一个问题永远是「这台设备上跑的是哪个构建」。镜像本身不带版本 ⇒ 无法回答。
+
+⇒ **推荐:`mcpp pack` 在 `os=none` 下换一套产物集 + 一份 metadata,不发明新格式、不新增命令。**
+
+### 21.2 ✅ D1 —— **已定**:立即修,作为独立 PR,不进任何路线 scope
+
+三条理由:
+
+1. 它是**当下唯一「已发布能力可达的错误行为」**(2026.8.15.3 上可复现);
+2. **修法与路线无关** —— 无论做不做裸机,「`--target` 被静默丢弃、报告成功」都是缺陷;
+3. ⚠️ **不先修会污染后面所有验收**:S1 的判据「产物 `file` 含 `UCB RISC-V`」在 E1 未修时同时在验两件事,红了分不清是谁的锅。
+
+⇒ **独立 PR 先落,规模:`prepare.cppm` 一处 + 回归测试(直接断言 `file` 输出)。**
+
+### 21.3 ✅ D2 路线 —— **已定**:承诺 B,C 按需,D 先做「可证伪探针」而非承诺
+
+| | 推荐 | 理由 |
+|---|---|---|
+| **B(23 项)** | ✅ **现在承诺** | issue #403 闭环;全在已有结构上加列/加态;**D 完全依赖 B,B 不依赖 D** ⇒ 先做 B 零损失 |
+| **C(载荷 + std 子集)** | ⏸ **按需** | 等有真实用户要 std 子集时再做。载荷是真工程量(builtins × target、picolibc multilib、per-target `__config_site`) |
+| **D(三层 SPEC 生态)** | ⚠️ **不承诺,先做最小可证伪探针** | 见下 |
+
+**为什么 D 不该现在承诺:**
+
+- ⚠️ **D 是不同产品**:openkal SPEC 是**多年期、跨组织**的标准化工作;mcpp 是构建工具。用户群、节奏、成功判据都不同。
+- ⚠️ **SPEC 类项目的失败模式是「没有实现者」**,而不是「设计不好」。WASI 背后是 Bytecode Alliance;embedded-hal 背后是 rust-embedded WG 加几年积累。**这个变量不能靠设计质量决定。**
+- ⚠️ §18.4 已定:官方必须自持 **linux / windows / bare 三个后端**才能执行准入判据 —— **那个成本是硬的**,不是可选的。
+
+**推荐的探针形态**(小到可以扔掉):
+
+> B 落地后,用它做一个 `openkal` **最小 world**(`io/streams` + `clocks/monotonic` + `memory/alloc`)+ **两个后端**(linux / bare)+ conformance suite 骨架。
+> **KA1 已经证明这个规模能跑通**(`kal_write` 一个函数撑起两个后端)。
+> **判据不是「设计好不好」,而是「有没有第三方来实现第三个后端」** —— 那才是 D 能否成立的真变量。
+
+⇒ **用最小成本先测那个变量,比先建完整 SPEC 再等人来,风险低一个数量级。**
+
+### 21.4 ✅ AAL 命名 —— **已定**:`openarch`
+
+| 候选 | 取舍 |
+|---|---|
+| `openaal` | 与 `openkal`/`openhal` 命名一致,但 "AAL" 三个字母本身不自解释 |
+| **`openarch`**(推荐) | 打破 `-al` 的对称,但 **"arch" 明确排除了 "kernel" 的联想** |
+
+⚠️ §11.3 的判据是「**名字决定边界会不会被侵蚀**」—— 叫 KAL 会把策略吸进来,叫 AAL 同理。**清晰性优先于对称性。**
+
+---
+
+## 22. 决策收尾(2026-08-19)
+
+**全部决策已定,本设计文档进入实施阶段。**
+
+| 决策 | 结论 |
+|---|---|
+| **D1** E1 静默失败 | ✅ **立即修,独立 PR**,不进任何路线 scope |
+| **D2** 路线 | ✅ **承诺 B(23 项)· C 按需 · D 先做可证伪探针不承诺** |
+| A4 产物形态 | ✅ `.elf` + `.bin` + `.map` + size 默认,`.hex` 可选 |
+| C4 hermetic 逃生舱 | ✅ `os=none` 下 `allow_host_libs` 失效 |
+| D2(provision)链接顺序 | ✅ **两个具名槽** `prologue`/`epilogue`,槽内数组序 |
+| E1 `requires` 扩包级 | ✅ |
+| F1 `[freestanding]` 段 | ✅(②工效档) |
+| G2 裸机 test 粒度 | ✅ 默认 `batch`,`isolated` 可选 + 超时自动重跑 isolated |
+| K1 `requires-hard` | ✅ 加 |
+| `--target`+`--workspace` | ✅ **冲突即报错** |
+| 17.2c 裸机 pack | ✅ 复用现有机制 + 产物集 + metadata |
+| AAL 命名 | ✅ **`openarch`** |
+
+**⇒ 实施计划独立成文:`.agents/docs/2026-08-19-freestanding-baremetal-implementation-plan.md`**

--- a/.agents/docs/2026-08-19-freestanding-baremetal-implementation-plan.md
+++ b/.agents/docs/2026-08-19-freestanding-baremetal-implementation-plan.md
@@ -1,0 +1,308 @@
+# 裸机 / freestanding 支持 — 实施计划(2026-08-19)
+
+- Date: 2026-08-19
+- Status: **实施计划,待 review**
+- 上游:`2026-08-19-freestanding-baremetal-design.md`(方案,决策已全部落定见其 §22)
+- 证据:`2026-08-18-freestanding-baremetal-analysis.md`(E/X/Y/Z/C/K/KA/TH/M/ISO/AAL/CABI/WS 全部复现命令)
+- **范围 = Route B(方案 §21.3)+ `mcpplibs.std.freestanding`**(2026-08-19 追加,见 §1.6)
+- D 档(openkal / openhal / openarch)路线图见 §7 —— **规划清楚但不并入本计划的里程碑**。
+
+---
+
+## 0. 拆解原则
+
+1. **每个工作单元 = 一个可独立落地、可独立验收的 PR。** 不做「大 PR 拆成子任务」。
+2. **判据是可执行断言,不是「跑通了」。** 每个单元的验收写成命令 + 期望输出。
+3. **最大化解耦**:凡是不在关键路径上的,都标为并行线,不排在里程碑里等。
+4. ⚠️ **两个前置先行**:`W0`(止血)与 `W12+P1`(CI 能真跑)必须最先落 —— 否则**后面所有里程碑的绿色都不可信**。
+
+---
+
+## 1. 工作单元
+
+### 1.1 关键路径(串行,7 个)
+
+| ID | 内容 | 依赖 | 验收判据(可执行) | 规模 |
+|---|---|---|---|---|
+| **W0** | **修 E1 静默失败**:门的判据从「triple 认不认识」改成「这次构建为哪个 target 发了 `--target`」(方案 §2.4 三条) | — | `mcpp build --target riscv64-none-elf` 无裸机配置时**指名道姓报错**;⚠️ **不存在「成功且产物是 x86-64」的路径**;回归测试直接断言 `file` 输出 | S |
+| **W1** | **triple 收 `os=none`**:`parse()` 的 `none` 仅当整串无其它 OS token 时作 OS 段(`triple.cppm:299`) | W0 | `--target riscv64-none-elf` 解析成功;⚠️ `x86_64-none-linux-gnu` **仍解析为 linux**(正反两侧单测);`family()` 对 none 返空 | S |
+| **W2** | **TargetSpec 表 + 单一取值口**:`TargetInfo` 加 `spec` 列;新增 `resolve_target_spec()`;消费方逐个改为从它取 | W1 | 消费方清单(compile/link flags · cfg · 产物命名 · runner · BMI 键 · hermetic 白名单)**逐个核对无第二处推导**;`kKnownTargets` 含 `riscv64-none-elf` 行 | M |
+| **W4** | **`CLibMode::Freestanding`**:新态发 `-nostdlib -nostartfiles -static -T`;链接器按**载荷绝对路径**寻址 + 校验 `--version` 含 `LLD`;hermetic 语义反转(`allow_host_libs` 在 `os=none` 下失效) | W2, W3 | 产物 `file` 含 `UCB RISC-V`;`readelf -l` **无 PT_INTERP**;`llvm-nm -u` **空**;`build.ninja` 里 `--target` 出现次数 **> 0** | M |
+| **W8** | **provisions 三种**:`LinkerScript`(单值,冲突报错)· `StartupObjects`(**两个具名槽 `prologue`/`epilogue`,槽内数组序**)· `Runner` | W4 | BSP 包提供的 `link.ld` + `crti/crtn` 按 `prologue → 用户对象 → epilogue` 进链接线;⚠️ 两个 BSP 同时提供 = **硬错误** | M |
+| **W9** | **`mcpp run` runner**:`[target].runner` argv 模板 + 产物路径追加尾部;BSP 亦可经 provision 提供 | W2, W8 | `mcpp run --target riscv64-none-elf` 在 qemu 里打印出预期串 | S |
+| **W11** | **`mcpp test` 裸机**:默认 `batch`(一镜像一次 qemu,semihosting 打用例名)· `isolated` 可选 · **超时后自动重跑一次 isolated 定位** | W9, P1 | 一个含 3 个用例的裸机测试,batch 模式一次 qemu 全过;人为让第 2 个跑飞 ⇒ **超时后能指出是第 2 个** | M |
+
+### 1.2 前置线(必须早于关键路径的对应节点)
+
+| ID | 内容 | 必须早于 | 验收判据 | 规模 |
+|---|---|---|---|---|
+| **W3** | ⚠️ **探测代码普查**:所有「编个小程序链一下」的探测(doctor · 工具链能力探测 · `hasImportStd` 探测)在 `os=none` 下会**假失败**(CMake `TRY_COMPILE_TARGET_TYPE` 教训) | **W4** | 逐个列出探测点并标注 `os=none` 下的行为;修掉会假失败的 | S–M |
+| **W12** | ⚠️ **e2e harness `# requires-hard:`**:能力缺失时 **FAIL 而非 SKIP**(`# requires:` 保持 SKIP);CI 汇总输出**实际执行条数** | **W4 的验收** | 故意不装 qemu ⇒ 裸机 e2e **job 红**,不是绿着跳过 | S |
+| **P1** | **qemu 进 xim-pkgindex**(xlings/mcpp 双生态复用) | **W12 生效** | `mcpp` 侧能经 `[xlings] deps` 装到 `qemu-system-riscv64` | S,非引擎 |
+
+### 1.3 并行线(不在关键路径,任何时候可做)
+
+| ID | 内容 | 依赖 | 验收判据 | 规模 |
+|---|---|---|---|---|
+| **W5** | **BMI 缓存键 + 指纹**:`TargetSpec` 全字段进指纹;freestanding 进 BMI 键 | W2 | 同源码在 hosted / freestanding 下 BMI **互不复用**;⚠️ 判据取自 ISO 系列:**混用不同 flag 的 BMI 会让编译器崩** | S |
+| **W6** | **`import std` 关断**:`os=none` ⇒ `hasImportStd=false` + 说明「为什么」并指向 `mcpplibs.std.freestanding` | W1 | `import std;` 在 `os=none` 下给出 mcpp 自己的诊断,**不是 libstdc++ 内部报错** | S |
+| **W7a** | **`cfg(freestanding)` / `cfg(os="none")` 谓词** | W1 | `[target.'cfg(freestanding)'.build]` 在裸机 target 下生效、hosted 下不生效 | S |
+| **W13** | **产物形态**:`.elf` + `.bin`(objcopy)+ `.map`(`-Wl,-Map=`)+ **size 摘要**默认;`.hex` 可选 | W4 | 四件产物齐备;构建后打印 text/data/bss | S |
+| **W15** | ⚠️ **CDB 合并到 workspace 根**(与裸机无关的已有 gap:实测每成员一份、根上没有) | — | `mcpp build --workspace` 后 workspace 根有一份 CDB,**每个文件带它所属成员 target 的 flags** | S |
+| **W16** | **`--target` + `--workspace` 冲突即报错**(成员声明了 `[build] target` 而命令行给了不同的) | — | 混合 workspace 上 `--workspace --target X` **报错说明冲突**,不静默覆盖 | S |
+| **W17** | **裸机 `mcpp pack`**:产物集 + sha256 + 构建元数据(target · toolchain · 版本 · BSP 版本) | W13 | 打出的包含元数据,能回答「这台设备上是哪个构建」 | S |
+
+### 1.4 ②工效档(可整体推迟到关键路径跑通之后)
+
+> ⚠️ 方案 §7.5.4 已论证:**兜底是链接期硬错** ⇒ 这一档只影响**错误发生的时机与可读性**,不影响正确性。
+
+| ID | 内容 | 依赖 | 规模 |
+|---|---|---|---|
+| **W10** | **能力模型扩到包级**:`requires` 从 `featureRequires`(feature 级)扩到包/构建级;resolver 保证「**恰好一个提供者**」;能力集合并(`TargetSpec.envCaps ∪ BSP ∪ 后端 ∪ HAL 提供者`) | — | M |
+| **W7b** | **`cfg(capability = "heap")` 谓词** | W10 | S |
+| **W14** | **契约层**:`[freestanding]` 段(tier/requires/example)· 一致性示例构建 + 符号审计 · 证据写 xpkg 描述符(**手写字段被覆盖**)· 索引三态展示 | W10 | M–L |
+
+### 1.5 载荷 / 生态(非引擎,完全并行)
+
+| ID | 内容 | 依赖 | ⚠️ 判据 | 状态 |
+|---|---|---|---|---|
+| **P1** | qemu 进 xim-pkgindex | — | `mcpp` 侧能经 `[xlings] deps` 装到 `qemu-system-riscv64` | ✅ **已合入**(见 §1.5.1) |
+| **P2** | per-target compiler-rt builtins | — | ⚠️ 判据见 §1.5.2 —— **原判据「含一次 64 位除法」已被实测推翻** | ✅ **已发布**(与 P3 同包,§1.5.3) |
+| **P3** | picolibc 载荷 | — | ⚠️ 发行版包**无 rv64gc 变体**(X11)⇒ 自建 | ✅ **已发布**(§1.5.3) |
+| **P4** | libc++ 每目标 freestanding `__config_site` | P3 | 17 个抽样头在 `riscv64-none-elf` 下可编 | 未做 |
+| **E-BSP** | `riscv-virt-rt` BSP 包 | W8 | 方案 §7.1 的三文件工程端到端通过 | — |
+| **E-STD** | `mcpplibs.std.freestanding` | 见 §1.6(**分三阶段,Stage 1 零载荷依赖**) | ⚠️ 热路径薄封装**必须标 `inline`**(方案 §16.2) | — |
+
+#### 1.5.1 P1 已落地(2026-08-19,xim-pkgindex #651 已 squash 合入)
+
+`xim:qemu-riscv@9.2.4-1`,取 **xPack** 官方预编译 —— 唯一为本索引服务的全部五个宿主目标
+(linux x64/arm64 · darwin x64/arm64 · win32 x64)从同一次版本化发布出货、且每个资产带
+`.sha` sidecar 的上游。⭐ 顺带在 CI 里落了一条 `baremetal riscv smoke`:**用 llvm 载荷把
+一个 C++20 模块接口单元编成裸机内核,在这个 qemu 里启动,断言 OpenSBI banner + 内核自
+己的输出**。这条流水线就是 M3「能跑」的现成载体。
+
+⚠️ 过程中在**索引基础设施**上撞出两个从没人走过的缺陷,已一并修掉:
+
+1. `arch_alias` + `ci.mirror` 在 **spec 文档写的字段顺序**下把 SHA256 当架构名拼进镜像 URL;
+2. 版本 bump 机器人会把 `["latest"]` **往回搬**(实测 `fd 10.4.2→10.4.1`、`qemu-riscv 9.2.4-1→8.2.6-1`)。
+
+⚠️ 还有一条与 **mcpp 自身载荷处理同形**的教训:xlings 的 elfpatch **整条替换 `DT_RPATH`
+而不是前置追加**,自带库的载荷(`RPATH=$ORIGIN/../libexec`)一旦声明 loader 依赖就全部
+失联 —— **而 install 报成功**,只有真运行才炸。参见记忆里 PR#414 的 `$ORIGIN` 优先级问题:
+这是同一条边的另一侧。
+
+#### 1.5.2 ⚠️ 实测推翻 P2 的原判据
+
+原写的是「验收用例必须含一次 64 位除法或软浮点」。**在默认档 `rv64gc/lp64d` 上,64 位除
+法根本不需要 builtins** —— `rv64gc` 含 `M` 扩展,有硬件 `divu`;`lp64d` 是硬浮点。实测:
+
+| march/mabi | 缺的 builtins |
+|---|---|
+| `rv64gc/lp64d`(**默认裸机档**) | **无** |
+| `rv64imac/lp64` | `__muldf3` |
+| `rv64i/lp64` · `rv32imac/ilp32` | `__muldf3` + `__udivdi3` |
+
+⭐ **但 builtins 在 rv64gc 上仍然是真需要的** —— 触发者不是除法,是 **128 位移位**:
+picolibc 的 `printf` 浮点格式化(ryu)引用 `__ashlti3` / `__lshrti3`,rv64 无对应指令。
+
+⇒ **新判据**:验收用例必须**用 picolibc 的 `printf` 打一个浮点数**(或显式做 128 位移位),
+而不是「含一次 64 位除法」。前者在默认档上就能暴露缺口,后者不能。
+
+#### 1.5.3 P2+P3 已发布为一个包(`xim:picolibc-riscv@1.8.12`)
+
+picolibc 1.8.12 + compiler-rt builtins(LLVM 22.1.8),用 **mcpp 自己的 LLVM 载荷**
+交叉编两个档位:
+
+| profile | triple | 内容 |
+|---|---|---|
+| `rv64gc/lp64d` | `riscv64-none-elf` | 139 头 + 37 个 lib 文件 |
+| `rv32imac/ilp32` | `riscv32-none-elf` | 同上 |
+
+⭐ **关键架构性质:目标侧产物,与宿主无关** —— 一份 5.4MB 归档服务全部平台/架构,
+不做宿主矩阵。已发到 `xlings-res/picolibc-riscv`(GitHub + GitCode,两端哈希一致)。
+
+⚠️ **P2 与 P3 必须同包**:picolibc 的 `printf` 没有 builtins 链不上(§1.5.2)。
+
+**端到端已验**(sysroot 与 qemu 都来自 xlings):C++20 模块 → `printf` 浮点 →
+`malloc` → semihosting 跑出 `picolibc-riscv sysroot: 42 / 3.1416 / ok` + `malloc=yes`;
+同一模块按 rv32imac/ilp32 链出 32 位软浮点 ELF。
+
+⚠️ **三条与 W4 直接相关的实测**:
+
+1. **E6-1 独立复现**:`-fuse-ld=lld` 解析到了**宿主的 GNU ld**
+   (`xim-x-binutils/2.42/bin/ld`,报 `unrecognised emulation mode: elf64lriscv`)。
+   **W4 必须用链接器的绝对路径**,这条不是理论风险。
+2. ⭐ **llvm 载荷的 `bin/clang.cfg` 无条件注入宿主 glibc 头 + 写死的 x86-64
+   `--dynamic-linker` + 宿主架构 `-L`,一条都不按 target 设防**。不加
+   `--no-default-config`,宿主 `<limits.h>` 会盖过 freestanding 那份。
+   ✅ **mcpp 已经躲开了**(`src/build/flags.cppm:495` 显式 `--no-default-config`
+   并自己提供全部内容)—— 这条记下来是为了让 W3/W4 不必再推导一次。
+3. ⚠️ **sysroot 的目标头绝不能进 subos sysroot**(会遮住宿主 libc)。消费者自己把
+   `--sysroot`/`-isystem` 指到 `<install>/{include,lib}/<march>/<mabi>/`。
+   **这就是 W4 该消费它的形状。**
+
+### 1.6 ⭐ `mcpplibs.std.freestanding` —— 提入承诺范围,分三阶段
+
+**为什么必须做**:没有 std 子集,mcpp 的裸机故事就退化成「C with classes」——**证明不了 mcpp 自己的价值**(modules + 现代 C++)。它是这条线唯一能验证「mcpp 裸机 ≠ 退回 C」的东西。
+
+**实测:它可以分三阶段,而且 Stage 1 不依赖任何载荷工作。**
+
+| 阶段 | 交付 | 依赖 | 实测状态 |
+|---|---|---|---|
+| **S-1 零 libc 档** | 8 个头 + 基础类型:`type_traits` `concepts` `span` `expected` `bit` `utility` `tuple` `charconv` + `size_t/byte/uintN_t` | **仅需 freestanding `__config_site`**(4 个 `#define` 翻转,**包可用 `build.mcpp` 从宿主那份生成**)⚠️ 外加 BSP 提供 `memcpy/memmove/memset/memcmp` | ✅ **模块编译通过、消费者编译通过**;链接只缺 `memmove`(ST1) |
+| **S-2 +picolibc 头** | **52 个头的可移植子集**(两家标准库交集,Y4) | P3 的**头文件部分**(不需要 `libc.a`) | ✅ 17/17 抽样、103/110 全量可编(X2/X3) |
+| **S-3 +目标版 libc++.a** | `std::format` · 标量 `std::sort` · `std::string` 全功能 | P4 完整 | ⚠️ 需为目标编 libc++ |
+
+⭐ **S-1 的关键性质:零载荷工作。** `__config_site` 是包自己生成的文件,picolibc 也不需要。⇒ **E-STD 可以承诺,而不必同时承诺全部载荷工程。**
+
+⚠️ **`memcpy/memmove/memset/memcmp` 是编译器可自行发出的四个函数** —— 任何裸机工程都要提供,**归 BSP**(`E-BSP`),不归 std 子集包。这条要写进 BSP 契约。
+
+**判据:**
+
+| 阶段 | 验收 |
+|---|---|
+| S-1 | `import mcpplibs.std.freestanding;` + `std::to_chars` + `std::span` 在 `riscv64-none-elf` 上链接**零未定义符号**(BSP 提供四个 mem 函数) |
+| S-2 | 方案 §7.1 的三文件工程跑通(`std::array`/`ranges::sort`/`optional`/`atomic`/`string_view`) |
+| S-3 | `std::format_to` + `std::vector` 在裸机跑通 |
+
+⚠️ 三阶段各自**独立可发布**,S-1 就能证明能力。
+
+---
+
+## 2. 依赖拓扑
+
+```
+                 ┌──────────────────────────────────────────────┐
+前置(最先落)   │  W0 止血        W12 harness ── P1 qemu       │
+                 └───────┬──────────────────┬───────────────────┘
+                         │                  │(让后面的绿色可信)
+关键路径                 ▼                  │
+                       W1 triple            │
+                         │                  │
+                         ▼                  │
+                       W2 TargetSpec ◄──────┼──── W3 探测普查(必须早于 W4)
+                         │                  │
+                         ▼                  │
+                       W4 Freestanding 链接 │
+                         │                  │
+                         ▼                  │
+                       W8 provisions        │
+                         │                  │
+                         ▼                  │
+                       W9 runner            │
+                         │                  │
+                         ▼                  │
+                       W11 test ◄───────────┘
+
+并行线(挂在 W1/W2/W4 之后,互不阻塞):
+   W5 BMI键(←W2)   W6 import std关断(←W1)   W7a cfg(←W1)   W13 产物形态(←W4)
+   W17 pack(←W13)
+
+完全独立(任何时候):
+   W15 CDB合并      W16 workspace target冲突      P2 builtins   P3 picolibc
+
+②工效档(整体可推迟):
+   W10 能力模型 ──► W7b cfg(capability)
+              └──► W14 契约层
+
+生态:
+   E-BSP(←W8;并提供 memcpy/memmove/memset/memcmp)
+   E-STD S-1(←零载荷,任何时候可做)──► S-2(←P3 头)──► S-3(←P4)
+```
+
+**关键路径长度 = 7 个单元**(W0→W1→W2→W4→W8→W9→W11),其余 **13 个可并行**。
+
+---
+
+## 3. 里程碑与验收
+
+| 里程碑 | 含 | ⚠️ 验收判据(必须是这句) |
+|---|---|---|
+| **M0 止血 + 可信** | W0 · W12 · P1 | ① E1 **不可复现**;② 故意不装 qemu ⇒ 裸机 e2e **job 红而不是绿着跳过** |
+| **M1 能表达** | W1 · W2 · W3 | `--target riscv64-none-elf` 解析成功;无裸机配置时**指名道姓报错**;⚠️ 探测点普查清单已产出 |
+| **M2 能构建** | W4 · W5 · W6 · W13 | 产物 `file` 含 `UCB RISC-V` · `readelf -l` **无 PT_INTERP** · `llvm-nm -u` **空** · `build.ninja` 中 `--target` **> 0**;⚠️ **验收工程必须含一次 64 位除法**(P2 假绿防线)且**至少有一个依赖**(flags 作用域防线) |
+| **M3 能跑** | W8 · W9 · E-BSP | qemu 里打印出预期串;⚠️ 判据是**「裸机 e2e 实际执行条数 > 0」**,不是「全绿」 |
+| **M4 能测** | W11 | 3 用例 batch 一次 qemu 全过;人为让第 2 个跑飞 ⇒ **超时后指出是第 2 个** |
+| **M5 工效** | W10 · W7b · W14 · W15 · W16 · W17 | 缺能力时**解析期**指名道姓;索引三态可见 |
+| **M6 生态 S-1** | E-STD **S-1** | ⭐ `import mcpplibs.std.freestanding` + `std::to_chars` + `std::span` 在裸机链接**零未定义符号** —— **这是「mcpp 裸机 ≠ 退回 C」的最小证明** |
+| **M7 生态 S-2/S-3** | P2 · P3 · P4 · E-STD S-2/S-3 | 52 头子集跑通;`std::format_to` + `std::vector` 在裸机跑通 |
+
+---
+
+## 4. ⚠️ 实施期风险(每条都有实测出处)
+
+| # | 风险 | 防线 |
+|---|---|---|
+| 1 | **CI 绿着但从没跑过** | M0 的 W12 前置;判据是**执行条数 > 0** |
+| 2 | **hello-kernel 是 builtins 缺口的假绿**(E3:测试内核 `llvm-nm -u` 为空,一路全绿) | M2 验收工程**必须含 64 位除法/软浮点** |
+| 3 | **单包验证会得出错误结论**(§4.1:flags 作用域,加第二个包才碎) | M2 验收工程**至少一个依赖** |
+| 4 | **探测代码在 `os=none` 下假失败** | W3 必须早于 W4 |
+| 5 | **BMI flag 不一致 ⇒ 编译器崩**(ISO 系列,不只是结果不对) | W5 与 W4 同期 |
+| 6 | **新门被逃生舱绕开**(E1 的原始形状:守卫挂在 `known` 分支) | 每个新门自问「**逃生舱走不走这里**」并写测试 |
+| 7 | **`ld.lld` 按名字解析到 GNU ld**(E6-1) | W4 强制绝对路径 + `--version` 校验 |
+| 8 | **`thread_local` 静默写坏内存**(TH6:编过链过零诊断) | ⚠️ 裸机验收用例**必须含一个 `thread_local`** |
+| 9 | **带序 provision 被顺手做成集合** | W8 判据显式检查链接线顺序 |
+| 10 | **读代码下结论**(本轮三次被实测推翻:ISO 对照 / E1 / WS 多 target) | 每个单元的判据都是**命令 + 期望输出**,不是「看代码应该对」 |
+
+---
+
+## 5. 解耦说明:哪些可以完全独立开工
+
+**零依赖,今天就能开:**
+- `W0` 止血 · `W12` harness · `P1` qemu · `W15` CDB 合并 · `W16` workspace 冲突 · `W10` 能力模型 · `P2` builtins · `P3` picolibc
+
+**⇒ 8 个单元可以在关键路径开始前或并行进行。**
+
+**关键路径上只有 7 个**,且每个都是「在已有结构上加列/加态/加行」,不是新子系统:
+- `triple.cppm` 加列 · `linkmodel.cppm` 加态 · `provisions.cppm` 加行 · `cmd_build` 加 runner
+
+**⚠️ 唯一真正的新语义**:`W8` 的 `StartupObjects` 两个具名槽(现有 provision 全是无序集合)。
+
+---
+
+## 6. 不在本计划内
+
+| 项 | 去向 |
+|---|---|
+| C 档载荷(P2/P3/P4) | **按需**;⚠️ 但 `E-STD` **已提入承诺范围**(§1.6),其 S-1 阶段零载荷依赖 |
+| D 档(openkal / openhal / openarch) | **不并入本计划里程碑**;⭐ **路线图见 §7**(分四阶段 + 每阶段的继续/停止判据) |
+| 烧录 / OTA | ⚠️ **设备侧的事,mcpp 不碰**(方案 §21.1) |
+| AAL/KAL/HAL 接口内容 · 后端实现 · 后端选择策略 | ⚠️ 生态侧;**引擎永不认识这三层**(方案 §11.6 / §14.0) |
+
+---
+
+## 7. D 档路线图:openkal / openhal / openarch
+
+> ⚠️ **不并入 §3 的里程碑。** 这里规划清楚是为了让「什么时候该继续、什么时候该停」有明确判据 —— 而不是为了排期。
+>
+> **顺序依据**(方案 §12.4):按「门槛 × 先例厚度」排 —— openkal 最先(门槛最低、先例最厚、且是 std 子集的天然后端),openarch 最后(风险最高、两个硬原语未验证)。
+
+### 7.1 四个阶段与门
+
+| 阶段 | 交付 | 前置 | ⭐ 继续的判据(gate) | ⚠️ 停止的信号 |
+|---|---|---|---|---|
+| **D0 探针** | `openkal` 最小 world(`io/streams` + `clocks/monotonic` + `memory/alloc`)· **两个后端**(linux / bare)· conformance 骨架 | Route B 的 M3 | ⭐ **有第三方实现了第三个后端** —— 这才是 D 能否成立的真变量 | 半年内无人实现第三个后端 ⇒ **停在 D0,当作 mcpp 内部设施用** |
+| **D1 openkal SPEC v0.1** | 接口清单冻结 · **C ABI 映射规范**(方案 §13.2)· **三个官方后端**(linux / **windows** / bare)· conformance suite 正式版 | D0 通过 | 三个官方后端**全部过 conformance**;⚠️ windows 后端**不经 MSVC CRT 的 POSIX 兼容层** | windows 后端做不出来而不模拟 ⇒ **SPEC 形状错了**(方案 §11.2.12),回炉重设计 |
+| **D2 openhal** | 设备服务接口(Console/Serial/Spi/I2c/Gpio/Pwm/Adc/Delay)· `openhal-linux` 官方实现 | D1 通过 | **同一个驱动包既跑裸机 MCU 又跑 Linux**(对标 `linux-embedded-hal` 已证明的形状) | 驱动作者不来 ⇒ 停;openhal 不影响 openkal |
+| **D3 openarch** | arch 机制接口(Context/Trap/AddressSpace/Atomics/PerCpu/Tick/Boot)· 两个 arch 实现 | D2 通过 **且**有真实内核项目 | ⚠️ **两个最硬原语不碎**:一段通用内核代码在两个真实不同 arch 上**既类型正确又语义正确,且 LTO 后无额外指令**(方案 §11.7) | 上下文切换或页表项抽象碎掉 ⇒ **停**;⚠️ 碎在这里,后面全是幻觉 |
+
+### 7.2 每阶段的已知约束(全部来自实测)
+
+| 阶段 | 必须遵守 |
+|---|---|
+| 全部 | **引擎永不认识这三层**(方案 §11.6 / §14.0);后端选择 = **条件依赖**,零新增轴 |
+| D0/D1 | 契约 = **C ABI**(H1:跨包提供实现只有这一条路);`result<T,E>` = **2 字结构返回**(CABI 实测更便宜);⚠️ **`T` ≤ 一个机器字** |
+| D1 | ⚠️ **不要模仿 POSIX** —— WASIp1 的教训;准入判据是「四后端自然实现,不需模拟层」;**每个 interface 独立版本 + 只增不改** |
+| D2 | 契约 = **concept**(H3:多提供者共存、零成本);⚠️ **寄存器/ISR/DMA 进不来**;时序/实时性是**能力**不是可藏的差异 |
+| D3 | 契约 = **concept + `inline`**(§16.2:显式 `inline` 是首选,LTO 是兜底);⚠️ **只含机制不含策略**;A 类裂缝(能编但语义不同)**必须提到能力轴** |
+
+### 7.3 ⚠️ 贯穿 D 档的三条纪律
+
+1. **缺能力 = 编译期不存在**,不是运行期 `ENOSYS`(X4 实测:`no type named 'mutex'`)。禁止静默降级。
+2. **conformance suite 是分仓的必需配套**,不是可选项 —— 没有它,分仓会退化成「N 个各自解释接口的实现」(方案 §18.3)。
+3. **官方维护 linux/windows/bare 三个后端不是为了服务用户,是为了让准入判据可执行**(方案 §18.4)。
+
+### 7.4 与 Route B 的关系
+
+- **D 完全依赖 B;B 不依赖 D** ⇒ 先做 B **零损失**。
+- ⭐ **D0 的最小 world 与 `E-STD` 天生互补**:`mcpplibs.std.freestanding` 是 openkal 的**第一个真实消费者**,给了 D0 一个立刻可验证的验收标准 —— *同一份 std 子集,在 hosted 与裸机两个后端下行为一致*。

--- a/.github/workflows/ci-linux-e2e.yml
+++ b/.github/workflows/ci-linux-e2e.yml
@@ -138,6 +138,13 @@ jobs:
           # would skip — which is what this job exists to prevent.
           command -v qemu-system-riscv64
           qemu-system-riscv64 --version | head -1
+          # The target sysroot, into the home MCPP uses. Test 131's BSP
+          # declares it as an `[xlings] deps` entry and finds it through
+          # `xpkg_dir`; installed into the ambient xlings home instead, the
+          # test would SKIP and the seam would go unexercised.
+          XLINGS_HOME="${MCPP_HOME:-$HOME/.mcpp}/registry" \
+            "$XLINGS_BIN" install xim:picolibc-riscv -y
+          test -d "${MCPP_HOME:-$HOME/.mcpp}/registry/data/xpkgs/xim-x-picolibc-riscv"
 
       - name: Bare-metal e2e
         timeout-minutes: 25
@@ -151,13 +158,15 @@ jobs:
           # llvm is the toolchain a freestanding target pins; install it
           # explicitly rather than relying on whatever the sandbox cache holds.
           "$MCPP" toolchain install llvm 22.1.8
-          bash tests/e2e/run_all.sh 130 2>&1 | tee e2e.log
-          # The assertion this job exists for: the test RAN. `run_all.sh`
+          bash tests/e2e/run_all.sh 13 2>&1 | tee e2e.log
+          # The assertion this job exists for: the tests RAN. `run_all.sh`
           # exits 0 on a skip, so its exit code cannot answer this.
           grep -q 'PASS: freestanding riscv64 build + run' e2e.log || {
-            echo "the bare-metal e2e did not run (skipped?) — see above"; exit 1; }
-          if grep -q '^SKIP: 130' e2e.log; then
-            echo "the bare-metal e2e SKIPPED on the runner that must run it"; exit 1
+            echo "130 (engine chain) did not run — see above"; exit 1; }
+          grep -q 'PASS: BSP supplies the sysroot' e2e.log || {
+            echo "131 (ecosystem chain) did not run — see above"; exit 1; }
+          if grep -qE '^SKIP: 13[01]' e2e.log; then
+            echo "a bare-metal e2e SKIPPED on the runner that must run it"; exit 1
           fi
 
   # ──────────────────────────────────────────────────────────────────

--- a/.github/workflows/ci-linux-e2e.yml
+++ b/.github/workflows/ci-linux-e2e.yml
@@ -132,10 +132,18 @@ jobs:
 
       - name: Install the emulator (xim:qemu-riscv)
         run: |
+          # ⚠️ BOTH homes. The shim on PATH dispatches against whichever home
+          # owns it, and `mcpp run` runs the runner through that shim — so an
+          # emulator installed only in the ambient xlings home answers
+          # "xlings: 'qemu-system-riscv64' is not installed" when mcpp asks.
+          # Measured: the job installed it once, the shim resolved, and the
+          # run still failed.
           "$XLINGS_BIN" install xim:qemu-riscv -y
-          # Assert it is reachable BEFORE the suite runs. Without this the
-          # capability probe simply would not add `qemu-riscv`, and the test
-          # would skip — which is what this job exists to prevent.
+          XLINGS_HOME="${MCPP_HOME:-$HOME/.mcpp}/registry" \
+            "$XLINGS_BIN" install xim:qemu-riscv -y
+          # Assert it is reachable AND runnable BEFORE the tests. Without this
+          # the capability probe simply would not add `qemu-riscv` and the
+          # tests would skip — which is what this job exists to prevent.
           command -v qemu-system-riscv64
           qemu-system-riscv64 --version | head -1
           # The target sysroot, into the home MCPP uses. Test 131's BSP

--- a/.github/workflows/ci-linux-e2e.yml
+++ b/.github/workflows/ci-linux-e2e.yml
@@ -99,6 +99,68 @@ jobs:
           bash tests/e2e/run_all.sh
 
   # ──────────────────────────────────────────────────────────────────
+  # Bare metal: the one chain the sharded suite above cannot be trusted
+  # to exercise.
+  #
+  # tests/e2e/130_freestanding_riscv_build_and_run.sh declares
+  # `# requires: qemu-riscv`, which is legitimately absent on the macOS and
+  # Windows runners — so it must be a SOFT token, and a soft token means the
+  # test skips in silence on a Linux runner that lost qemu too. That is the
+  # exact shape this repository has been burned by twice (65_* never ran at
+  # all; ten pack e2e skipped on two platforms), and no token can tell the two
+  # cases apart.
+  #
+  # So the guard lives here, where it can be exact: install qemu, run the one
+  # test, and assert its PASS line appeared. A skip fails this job.
+  # ──────────────────────────────────────────────────────────────────
+  baremetal:
+    name: bare-metal e2e (riscv64-none-elf, qemu)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    env:
+      MCPP_HOME: /home/runner/.mcpp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/bootstrap-mcpp
+
+      - name: Build mcpp from source (self-host)
+        run: |
+          export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
+          "$XLINGS_BIN" config --mirror GLOBAL 2>/dev/null || true
+          "$MCPP" self config --mirror GLOBAL 2>/dev/null || true
+          "$MCPP" build
+
+      - name: Install the emulator (xim:qemu-riscv)
+        run: |
+          "$XLINGS_BIN" install xim:qemu-riscv -y
+          # Assert it is reachable BEFORE the suite runs. Without this the
+          # capability probe simply would not add `qemu-riscv`, and the test
+          # would skip — which is what this job exists to prevent.
+          command -v qemu-system-riscv64
+          qemu-system-riscv64 --version | head -1
+
+      - name: Bare-metal e2e
+        timeout-minutes: 25
+        run: |
+          MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
+          test -x "$MCPP"
+          export MCPP
+          export MCPP_VENDORED_XLINGS="$XLINGS_BIN"
+          export MCPP_E2E_TOOLCHAIN_MIRROR=GLOBAL
+          "$MCPP" self config --mirror "$MCPP_E2E_TOOLCHAIN_MIRROR"
+          # llvm is the toolchain a freestanding target pins; install it
+          # explicitly rather than relying on whatever the sandbox cache holds.
+          "$MCPP" toolchain install llvm 22.1.8
+          bash tests/e2e/run_all.sh 130 2>&1 | tee e2e.log
+          # The assertion this job exists for: the test RAN. `run_all.sh`
+          # exits 0 on a skip, so its exit code cannot answer this.
+          grep -q 'PASS: freestanding riscv64 build + run' e2e.log || {
+            echo "the bare-metal e2e did not run (skipped?) — see above"; exit 1; }
+          if grep -q '^SKIP: 130' e2e.log; then
+            echo "the bare-metal e2e SKIPPED on the runner that must run it"; exit 1
+          fi
+
+  # ──────────────────────────────────────────────────────────────────
   # Hermetic (no host toolchain): the ONLY environment class that
   # faithfully reproduces issue #195. Standard runners ship gcc +
   # libc6-dev, so a sandbox toolchain that leaks to the host's CRT

--- a/.github/workflows/ci-linux-e2e.yml
+++ b/.github/workflows/ci-linux-e2e.yml
@@ -158,16 +158,28 @@ jobs:
           # llvm is the toolchain a freestanding target pins; install it
           # explicitly rather than relying on whatever the sandbox cache holds.
           "$MCPP" toolchain install llvm 22.1.8
-          bash tests/e2e/run_all.sh 13 2>&1 | tee e2e.log
-          # The assertion this job exists for: the tests RAN. `run_all.sh`
-          # exits 0 on a skip, so its exit code cannot answer this.
-          grep -q 'PASS: freestanding riscv64 build + run' e2e.log || {
-            echo "130 (engine chain) did not run — see above"; exit 1; }
-          grep -q 'PASS: BSP supplies the sysroot' e2e.log || {
-            echo "131 (ecosystem chain) did not run — see above"; exit 1; }
-          if grep -qE '^SKIP: 13[01]' e2e.log; then
-            echo "a bare-metal e2e SKIPPED on the runner that must run it"; exit 1
-          fi
+          # Run the two scripts DIRECTLY rather than through run_all.sh.
+          # They are standalone (they take $MCPP and nothing else), run_all.sh
+          # accepts no filter — it would run the whole 250-test suite here for
+          # two tests — and, more to the point, run_all.sh exits 0 on a skip.
+          # Invoked directly, a skip is visible: the script either prints its
+          # PASS line or it does not.
+          for t in tests/e2e/130_freestanding_riscv_build_and_run.sh \
+                   tests/e2e/131_freestanding_bsp_supplies_everything.sh; do
+            echo "=== $t ==="
+            bash "$t" 2>&1 | tee "$(basename "$t").log"
+            rc=${PIPESTATUS[0]}
+            [ "$rc" = "0" ] || { echo "$t failed (exit $rc)"; exit 1; }
+          done
+          # The assertion this job exists for: both tests RAN. Each has an
+          # early `exit 0` for a missing capability, so a zero exit code alone
+          # does not distinguish "passed" from "skipped".
+          grep -q 'PASS: freestanding riscv64 build + run' \
+            130_freestanding_riscv_build_and_run.sh.log || {
+            echo "130 (engine chain) skipped on the runner that must run it"; exit 1; }
+          grep -q 'PASS: BSP supplies the sysroot' \
+            131_freestanding_bsp_supplies_everything.sh.log || {
+            echo "131 (ecosystem chain) skipped on the runner that must run it"; exit 1; }
 
   # ──────────────────────────────────────────────────────────────────
   # Hermetic (no host toolchain): the ONLY environment class that

--- a/docs/05-mcpp-toml.md
+++ b/docs/05-mcpp-toml.md
@@ -915,7 +915,7 @@ mcpp run   --target-triple riscv64-none-elf     # via [target.<triple>].runner
 |---|---|
 | Link line | `-nostdlib -nostartfiles -static`, and nothing hosted — no crt files, no dynamic linker, no C++ runtime. The linker is addressed by **absolute path** (`-fuse-ld=<payload>/bin/ld.lld`), because `-fuse-ld=lld` resolves through `PATH` and finds GNU ld on any machine with binutils earlier on it. |
 | ISA flags | `-march` / `-mabi` / `-mcmodel` come from the target table, so `--target <triple>` alone is enough to produce a correct object file. |
-| `import std` | **Unavailable.** `std` is one module over the entire library — threads, filesystem and iostreams included — so there is no subset of it to build without an OS. Use the freestanding subset package instead (mcpp says so, and names it, if you try). |
+| `import std` | **Unavailable.** `std` is one module over the entire library — threads, filesystem and iostreams included — so there is no subset of it to build without an OS. The freestanding subset package replaces it, and mcpp's diagnostic names it. |
 | Entry point | There is no `main`. Declare the target explicitly and point `main` at the file carrying `_start`. |
 
 **A minimal firmware**

--- a/docs/05-mcpp-toml.md
+++ b/docs/05-mcpp-toml.md
@@ -897,6 +897,59 @@ for arch/env conditions and combinators.
   cross target, so put them under `[target.<triple>]` (above), not under a bare
   alias or `cfg(...)`.
 
+### 2.7.2 Bare metal (`os = none`) — freestanding targets
+
+`riscv64-none-elf` and `riscv32-none-elf` are targets with no operating system
+underneath. They need no per-host cross toolchain: clang and lld are
+cross-compilers by construction, so any host that can install the llvm payload
+can produce them.
+
+```bash
+mcpp build --target riscv64-none-elf
+mcpp run   --target-triple riscv64-none-elf     # via [target.<triple>].runner
+```
+
+**What changes on a freestanding target**
+
+| | |
+|---|---|
+| Link line | `-nostdlib -nostartfiles -static`, and nothing hosted — no crt files, no dynamic linker, no C++ runtime. The linker is addressed by **absolute path** (`-fuse-ld=<payload>/bin/ld.lld`), because `-fuse-ld=lld` resolves through `PATH` and finds GNU ld on any machine with binutils earlier on it. |
+| ISA flags | `-march` / `-mabi` / `-mcmodel` come from the target table, so `--target <triple>` alone is enough to produce a correct object file. |
+| `import std` | **Unavailable.** `std` is one module over the entire library — threads, filesystem and iostreams included — so there is no subset of it to build without an OS. Use the freestanding subset package instead (mcpp says so, and names it, if you try). |
+| Entry point | There is no `main`. Declare the target explicitly and point `main` at the file carrying `_start`. |
+
+**A minimal firmware**
+
+```toml
+[package]
+name    = "fw"
+version = "0.1.0"
+
+[build]
+ldflags = ["-T", "/abs/path/to/link.ld"]
+
+[targets.firmware]
+kind = "bin"
+main = "src/start.S"          # the entry lives in assembly, not in main()
+
+[target.riscv64-none-elf]
+runner = ["qemu-system-riscv64", "-machine", "virt", "-nographic",
+          "-no-reboot", "-bios", "default", "-kernel"]
+```
+
+**`runner` — how `mcpp run` executes something this machine cannot run**
+
+A bare-metal image has the wrong ISA, no loader, and expects to own the address
+space; exec'ing it directly gives "Exec format error". `runner` is the argv
+template that stands in front of it. The artifact path is **appended**, or
+substituted for `{}` when the template contains it.
+
+mcpp ships **no default runner**, deliberately. Which emulator, which machine
+model and which firmware mode are board facts — two boards on the same ISA need
+different argv (`-bios default` for an OpenSBI boot, `-bios none -semihosting`
+for a picolibc image) — and an engine that guesses one is an engine the other
+board has to fight. A board-support package normally supplies it.
+
 ### 2.8 `[features]` — Features (Cargo-style, additive)
 
 ```toml

--- a/docs/07-build-mcpp.md
+++ b/docs/07-build-mcpp.md
@@ -52,6 +52,7 @@ is ignored, so diagnostics may be logged freely.
 | `mcpp:source=<path>` *(0.0.100+)*  | select a **pre-existing** source file into the build (absolute, or relative to the package root). Same downstream effect as `generated=`; use it for files the program *chose* (payload/vendored tree) rather than wrote — e.g. a per-target source selection over a large tarball |
 | `mcpp:include-dir=<dir>` *(0.0.100+)* | add a **private** include directory (`-I`) for this package's own TUs (absolute, or relative to the package root; normalized). Replaces the `cxxflag=-I` + `cflag=-I` double emission |
 | `mcpp:include-dir-after=<dir>` *(0.0.100+)* | like `include-dir`, but searched **after** the system directories (`-idirafter`) — for payload trees that shadow system headers |
+| `mcpp:link-script=<path>` *(2026.8.19+)* | link with this **linker script** (`-T`; relative resolves against the package root, and the emitted path is absolute because the link runs in the build directory). Reaches the **consumer**, unlike `include-dir` — a board's memory layout is the one thing a consumer cannot write for itself |
 | `mcpp:rerun-if-changed=<path>`     | re-run `build.mcpp` when this file changes |
 | `mcpp:rerun-if-env-changed=<VAR>`  | re-run `build.mcpp` when this env var changes |
 
@@ -99,7 +100,38 @@ int main() {
 | `mcpp::rerun_if_changed(p)` / `mcpp::rerun_if_env_changed(v)` | the matching `rerun-*` directives |
 | `mcpp::rerun_if_changed_glob(pat)` *(2026.8.6.2+)* | `mcpp:rerun-if-changed-glob=` — re-run when the **set** of files matching `pat` changes (see below) |
 | `mcpp::dep_bin(pkg, tool)` *(2026.8.5.1+)* | reads `MCPP_DEP_<PKG>_BIN_<TOOL>` — the absolute path of a **host tool** built by a dependency (see below) |
+| `mcpp::link_script(p)` *(2026.8.19+)* | `mcpp:link-script=` |
+| `mcpp::xpkg_dir(ns, name)` / `mcpp::xpkg_dir(name)` *(2026.8.19+)* | the payload directory of a package this manifest declared in `[xlings] deps`; `""` when it was not declared or is not installed (see below) |
 | `mcpp::action{…}.submit()` *(2026.8.5.1+)* | `mcpp:action=` — declares a **build-graph node** instead of doing the work here (see below) |
+
+### Finding an `[xlings] deps` payload: `xpkg_dir` (2026.8.19+)
+
+`dep_dir` answers for **mcpp** dependencies. An xlings package is a different
+namespace with a different store layout, and `xpkg_dir` is the interface for it:
+
+```cpp
+// mcpp.toml
+//   [xlings]
+//   deps = ["xim:picolibc-riscv@1.8.12"]
+
+const char* sysroot = mcpp::xpkg_dir("xim", "picolibc-riscv");   // exact
+const char* same    = mcpp::xpkg_dir("picolibc-riscv");          // bare name
+```
+
+The namespaced form answers only for a package declared under that namespace
+and is the one to prefer; the bare form is a convenience for the common single
+declaration, and when two namespaces claim one name it answers for the first
+**declared**. Both return `""` when the package was not declared or is not
+installed — a program that needs it should say so itself, because only it knows
+whether the absence is fatal.
+
+It is an interface rather than a documented path because the alternative is a
+build program encoding `<home>/data/xpkgs/<ns>-x-<name>/<version>`, which is
+store internals mcpp is free to change — the same reason `dep_dir` exists.
+
+⚠️ A **pinned** reference resolves to exactly that version or to nothing. A
+build that asked for `1.8.12` and silently got `1.9.0` is an answer only
+discovered later, in the artifact.
 
 ### Host tools from a dependency (2026.8.5.1+)
 

--- a/docs/zh/05-mcpp-toml.md
+++ b/docs/zh/05-mcpp-toml.md
@@ -796,6 +796,56 @@ cxxflags = ["-march=x86-64-v2"]
 - **`toolchain` / `linkage` 仅限精确三元组** —— 它们描述某一个具体的交叉目标,
   因此写在 `[target.<triple>]` 下(见上),而不是裸别名或 `cfg(...)` 下。
 
+### 2.7.2 裸机(`os = none`)—— freestanding target
+
+`riscv64-none-elf` 与 `riscv32-none-elf` 是底下没有操作系统的 target。它们不需要
+逐宿主的交叉工具链:clang 与 lld 天生是交叉编译器,任何能装 llvm 载荷的宿主都能
+产出它们。
+
+```bash
+mcpp build --target riscv64-none-elf
+mcpp run   --target-triple riscv64-none-elf     # 经 [target.<triple>].runner
+```
+
+**freestanding target 上有什么不同**
+
+| | |
+|---|---|
+| 链接线 | `-nostdlib -nostartfiles -static`,且不带任何 hosted 的东西 —— 没有 crt 文件、没有动态链接器、没有 C++ 运行时。链接器用**绝对路径**寻址(`-fuse-ld=<载荷>/bin/ld.lld`),因为 `-fuse-ld=lld` 走 `PATH` 解析,在任何 binutils 排前面的机器上都会找到 GNU ld。 |
+| ISA flag | `-march` / `-mabi` / `-mcmodel` 来自 target 表,所以只写 `--target <triple>` 就足以产出正确的目标文件。 |
+| `import std` | **不可用。** `std` 是覆盖整个库的一个模块 —— 线程、文件系统、iostreams 全在内 —— 没有 OS 就没有它的子集可编。freestanding 子集包取代它,mcpp 的诊断会点名。 |
+| 入口点 | 没有 `main`。显式声明 target,并把 `main` 指向携带 `_start` 的那个文件。 |
+
+**一个最小固件**
+
+```toml
+[package]
+name    = "fw"
+version = "0.1.0"
+
+[build]
+ldflags = ["-T", "/abs/path/to/link.ld"]
+
+[targets.firmware]
+kind = "bin"
+main = "src/start.S"          # 入口在汇编里,不在 main()
+
+[target.riscv64-none-elf]
+runner = ["qemu-system-riscv64", "-machine", "virt", "-nographic",
+          "-no-reboot", "-bios", "default", "-kernel"]
+```
+
+**`runner` —— `mcpp run` 如何执行本机跑不了的东西**
+
+裸机镜像的 ISA 不对、没有 loader、且期望独占整个地址空间;直接 exec 它得到的是
+"Exec format error"。`runner` 就是挡在它前面的 argv 模板。产物路径会被**追加**,
+或者在模板含 `{}` 时替换进去。
+
+mcpp **刻意不提供默认 runner**。用哪个模拟器、哪个机器型号、哪种固件模式都是板级
+事实 —— 同一 ISA 的两块板需要不同 argv(OpenSBI 启动用 `-bios default`,picolibc
+镜像用 `-bios none -semihosting`)—— 引擎一旦猜一个,另一块板就得跟它打架。板级
+支持包通常会提供它。
+
 ### 2.8 `[features]` —— Feature(Cargo 风格,可加性)
 
 #### 表形式 —— 让 feature 贡献的不止是隐含 feature

--- a/docs/zh/07-build-mcpp.md
+++ b/docs/zh/07-build-mcpp.md
@@ -49,6 +49,7 @@ mcpp build      # 编译 + 运行 build.mcpp,然后构建工程
 | `mcpp:source=<path>` *(0.0.100+)*  | 把一份**既有**源文件选入构建(绝对路径,或相对包根)。下游效果与 `generated=` 相同;语义区别在于文件是程序*选中*的(tarball payload / vendored 源树)而非程序写出的——例如对大型源码包做 per-target 源选择 |
 | `mcpp:include-dir=<dir>` *(0.0.100+)* | 为本包自身 TU 增加一个**私有** include 目录(`-I`;绝对路径或相对包根,自动规范化)。取代过去 `cxxflag=-I` + `cflag=-I` 的双重裸发 |
 | `mcpp:include-dir-after=<dir>` *(0.0.100+)* | 同 `include-dir`,但排在系统目录**之后**搜索(`-idirafter`)——用于会遮蔽系统头的 payload 源树 |
+| `mcpp:link-script=<path>` *(2026.8.19+)* | 用这个**链接脚本**链接(`-T`;相对路径按包根解析,发出的是绝对路径,因为链接是在构建目录里跑的)。与 `include-dir` 不同,它**到达消费者** —— 板子的内存布局恰恰是消费者写不出来的那一项 |
 | `mcpp:rerun-if-changed=<path>`     | 该文件变化时重跑 `build.mcpp` |
 | `mcpp:rerun-if-env-changed=<VAR>`  | 该环境变量变化时重跑 `build.mcpp` |
 
@@ -92,7 +93,34 @@ int main() {
 | `mcpp::rerun_if_changed(p)` / `mcpp::rerun_if_env_changed(v)` | 对应的 `rerun-*` 指令 |
 | `mcpp::rerun_if_changed_glob(pat)` *(2026.8.6.2+)* | `mcpp:rerun-if-changed-glob=` —— 匹配 `pat` 的文件**集合**发生变化时重跑(见下) |
 | `mcpp::dep_bin(pkg, tool)` *(2026.8.5.1+)* | 读 `MCPP_DEP_<PKG>_BIN_<TOOL>` —— 依赖构建出的 **host 工具**的绝对路径(见下) |
+| `mcpp::link_script(p)` *(2026.8.19+)* | `mcpp:link-script=` |
+| `mcpp::xpkg_dir(ns, name)` / `mcpp::xpkg_dir(name)` *(2026.8.19+)* | 本 manifest 在 `[xlings] deps` 里声明的包的载荷目录;没声明或没安装时返回 `""`(见下) |
 | `mcpp::action{…}.submit()` *(2026.8.5.1+)* | `mcpp:action=` —— **声明一个构建图节点**,而不是在这里把活干了(见下) |
+
+### 找到 `[xlings] deps` 的载荷:`xpkg_dir`(2026.8.19+)
+
+`dep_dir` 回答的是 **mcpp** 依赖。xlings 包是另一个命名空间、另一套 store 布局,
+`xpkg_dir` 是它的接口:
+
+```cpp
+// mcpp.toml
+//   [xlings]
+//   deps = ["xim:picolibc-riscv@1.8.12"]
+
+const char* sysroot = mcpp::xpkg_dir("xim", "picolibc-riscv");   // 精确
+const char* same    = mcpp::xpkg_dir("picolibc-riscv");          // 裸名
+```
+
+带命名空间的形式只对该命名空间下声明的包作答,应当优先使用;裸名形式是常见的单条
+声明的便利写法,两个命名空间都声明同一个名字时,它回答**先声明**的那个。两者在包
+未声明或未安装时都返回 `""` —— 缺失是否致命只有调用方知道,所以由它自己说。
+
+做成接口而不是给一条路径约定,是因为另一种做法是让构建程序把
+`<home>/data/xpkgs/<ns>-x-<name>/<version>` 写进代码,而那是 mcpp 可以随时改的
+store 内部结构 —— 与 `dep_dir` 存在的理由相同。
+
+⚠️ **带版本固定**的引用只解析到那个版本,否则什么都不返回。请求 `1.8.12` 却静默拿
+到 `1.9.0`,是那种要到产物里才被发现的答案。
 
 ### 依赖产出的 host 工具(2026.8.5.1+)
 

--- a/src/build/build_program.cppm
+++ b/src/build/build_program.cppm
@@ -54,6 +54,12 @@ struct BuildProgramEnv {
     // MCPP_DEP_<SANITIZED_NAME>_DIR (same sanitizer as MCPP_FEATURE_) instead of
     // reverse-engineering the store layout.
     std::vector<std::pair<std::string, std::filesystem::path>> depDirs;
+    // Payload dirs of the packages this build declared in `[xlings] deps`,
+    // as (env var name → dir). Resolved by the caller through the xlings path
+    // helpers, so a build.mcpp asks `xpkg_dir("xim", "picolibc-riscv")`
+    // instead of reconstructing `<home>/data/xpkgs/<ns>-x-<name>/<version>`
+    // — the same reason depDirs exists for mcpp dependencies.
+    std::vector<std::pair<std::string, std::string>> xpkgDirs;
     // #355: HOST tools this package asked its dependencies for, as
     // (env var name → absolute path to the executable) pairs. The caller has
     // already resolved them (built, taken from the store, or an override), so
@@ -71,6 +77,22 @@ struct BuildProgramEnv {
     // makes the BMI usable at all — see DependencySpec::hostModule.
     std::vector<std::pair<std::string, std::filesystem::path>> hostModules;
 };
+
+// The env-var name `hostprogram::xpkg_dir` reads back. One spelling of the
+// sanitizer, shared by both sides — the two drifting apart would make the
+// interface answer "" for a package that is right there.
+inline std::string xpkg_env_var(std::string_view ns, std::string_view name) {
+    std::string out = "MCPP_XPKG_";
+    auto put = [&](std::string_view s) {
+        for (char c : s)
+            out += (c >= 'a' && c <= 'z') ? char(c - 'a' + 'A')
+                 : ((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) ? c : '_';
+    };
+    if (!ns.empty()) { put(ns); out += '_'; }
+    put(name);
+    out += "_DIR";
+    return out;
+}
 
 // Compile + run `<root>/build.mcpp` (if present) with `hostCompiler` (the resolved
 // HOST frontend — under a cross --target the caller resolves a host toolchain;
@@ -254,6 +276,16 @@ contract_env(const fs::path& root, const fs::path& outDir, const BuildProgramEnv
                 "'{}') — rename one dependency to disambiguate", var,
                 it->second, dir.string()));
         }
+    }
+    // The xlings side of the same question. Each declared entry is emitted
+    // under BOTH its namespaced and its bare spelling, because a manifest may
+    // write either and the build.mcpp asking should not have to know which
+    // one the author chose. Namespaced entries are emitted first, so a bare
+    // name that two namespaces claim resolves to the first DECLARED one rather
+    // than to whichever was seen last.
+    for (auto const& [var, dir] : env.xpkgDirs) {
+        auto [it, inserted] = depVarValue.try_emplace(var, dir);
+        if (inserted) e.emplace_back(var, dir);
     }
     // #355: MCPP_DEP_<PKG>_BIN_<TOOL> — absolute path to a host tool the
     // consumer declared via `tools = [...]`. A PATH rather than a directory:

--- a/src/build/directives.cppm
+++ b/src/build/directives.cppm
@@ -116,6 +116,7 @@ enum class Transform {
     LibSearchPath,  // dialect libSearchPrefix + absolute path
     DefinePrefix,   // dialect definePrefix + value
     AbsPath,        // absolute, lexically normal
+    LinkerScript,   // "-T <absolute path>" — freestanding link layout
 };
 
 struct Def {
@@ -138,7 +139,7 @@ struct Def {
     int              sinceProtocol;
 };
 
-inline constexpr std::array<Def, 13> kTable{{
+inline constexpr std::array<Def, 14> kTable{{
     //  wire                    tag                  slot                    scope                  transform                must   missingPrefix                 missingSuffix                                    since
     {"cxxflag",             "cxxflag",           Slot::CxxFlags,         Scope::PackagePrivate, Transform::Verbatim,      false, "",                           "",                                              1},
     {"cflag",               "cflag",             Slot::CFlags,           Scope::PackagePrivate, Transform::Verbatim,      false, "",                           "",                                              1},
@@ -147,6 +148,31 @@ inline constexpr std::array<Def, 13> kTable{{
     {"cfg",                 "define",            Slot::Defines,          Scope::PackagePrivate, Transform::DefinePrefix,  false, "",                           "",                                              1},
     {"generated",           "generated",         Slot::Generated,        Scope::SourceSet,      Transform::Verbatim,      true,  "declared generated source",  "but it does not exist after the run",           1},
     {"source",              "source",            Slot::Sources,          Scope::SourceSet,      Transform::Verbatim,      true,  "selected source",            "(mcpp:source=) but no such file exists",         1},
+    // ⚠️ LinkGlobal, and that is the whole reason this row exists.
+    //
+    // A board-support package is the one thing that knows a board's memory
+    // layout, and a linker script is how that layout is expressed. Every other
+    // way of getting one onto the link line is package-private (`cxxflag`) or
+    // cannot express the flag at all (`link-lib` emits `-l`, `link-search`
+    // emits `-L`), so before this row a BSP could supply the C library and the
+    // startup code and still not supply the layout — leaving the one thing a
+    // user cannot write for themselves as the one thing they had to.
+    //
+    // The supply-chain rule the PackagePrivate rows enforce is not weakened:
+    // this widens the LINK, which `link-lib`/`link-search` already do, and not
+    // the public compile interface.
+    //
+    // Single-valued in practice — two scripts on one line is an lld error, and
+    // that error names both, which is a better diagnostic than anything a
+    // conflict check here would produce.
+    // ⚠️ `mustExistAfterRun` is FALSE, and not by oversight. That contract
+    // assumes the directive's value IS a path (`generated=`, `source=`), and
+    // this one's transformed value is `-T <path>` — so the check would test
+    // the wrong string and reject a script that is right there. Special-casing
+    // the contract for one row would cost more than it buys: lld's own error
+    // is already exact ("cannot find linker script <path>"), which is the
+    // condition the contract exists to make legible.
+    {"link-script",         "ldflag",            Slot::LdFlags,          Scope::LinkGlobal,     Transform::LinkerScript,  false, "",                           "",                                              3},
     {"include-dir",         "include-dir",       Slot::IncludeDirs,      Scope::PackagePrivate, Transform::AbsPath,       false, "",                           "",                                              1},
     {"include-dir-after",   "include-dir-after", Slot::IncludeDirsAfter, Scope::PackagePrivate, Transform::AbsPath,       false, "",                           "",                                              1},
     {"rerun-if-changed",    "",                  Slot::RerunFiles,       Scope::RerunKey,       Transform::Verbatim,      false, "",                           "",                                              1},
@@ -373,6 +399,10 @@ std::string transformed(const Def& def, std::string_view raw,
                                             + abs_against(root, raw);
         case Transform::DefinePrefix:  return std::string(dial.definePrefix) + std::string(raw);
         case Transform::AbsPath:       return abs_against(root, raw);
+        // Absolute on purpose: the link runs in the build directory, so a
+        // relative script path resolves against the wrong root and lld
+        // answers "cannot find linker script link.ld" — measured.
+        case Transform::LinkerScript:  return "-T " + abs_against(root, raw);
     }
     return std::string(raw);
 }

--- a/src/build/directives.cppm
+++ b/src/build/directives.cppm
@@ -467,12 +467,27 @@ std::optional<std::string> protocol_error(const Directives& d) {
         std::string list;
         for (auto const& k : d.unknownKeys)
             list += (list.empty() ? "" : ", ") + ("mcpp:" + k);
+        // ⚠️ NOT "so it must be a typo".
+        //
+        // That is what this said, and adding `link-script` in protocol 3
+        // proved it wrong: a package written against a newer mcpp reaches an
+        // older one with the OLDER engine's protocol number stamped on it —
+        // the announcement is substituted at build.mcpp compile time by
+        // whichever engine is running, not carried by the package. So the two
+        // numbers agreeing says nothing about whether the KEY is from the
+        // future, and an old mcpp cannot tell the two cases apart. Naming both
+        // is the only honest thing it can do, and the upgrade is the cheaper
+        // one to try first.
         return std::format(
             "build.mcpp emitted directive(s) this mcpp does not know: {}.\n"
-            "       The program announced protocol {}, which this mcpp also "
-            "speaks, so an unrecognized directive is a typo rather than newer "
-            "syntax.",
-            list, d.protocol);
+            "       Either the package was written for a newer mcpp (try "
+            "`mcpp self update`),\n"
+            "       or the directive is misspelled. This mcpp speaks protocol "
+            "{}; the protocol number\n"
+            "       cannot distinguish the two, because it is stamped by "
+            "whichever mcpp compiled\n"
+            "       the program, not by the package.",
+            list, kProtocolVersion);
     }
     return std::nullopt;
 }

--- a/src/build/distribution.cppm
+++ b/src/build/distribution.cppm
@@ -243,6 +243,19 @@ struct MechanismInput {
     // mechanism exists to make that floor real, so without one there is
     // nothing to make real.
     bool             macosFloor = false;
+    // Bare metal — there is no C++ runtime to distribute WITH.
+    //
+    // Every cell of the table below answers "how does this artifact carry its
+    // C++ runtime", and on a freestanding target the honest answer is that
+    // there is not one: the toolchain's libc++.a is built for the HOST, and
+    // putting it on the line produces
+    //
+    //     ld.lld: error: …/x86_64-unknown-linux-gnu/libc++.a(path.cpp.o)
+    //             is incompatible with elf64lriscv
+    //
+    // (measured 2026-08-19). A target-side C++ runtime, if one is wanted, is
+    // an ordinary package — the same way the libc is.
+    bool             freestanding = false;
 };
 
 struct Mechanism {
@@ -328,6 +341,21 @@ Mechanism resolve(const MechanismInput& in) {
     // the contract belongs to whatever eventually links it.
     if (in.role == Role::Intermediate)
         return m;
+
+    // Bare metal: there is nothing to decide, because there is no C++ runtime
+    // on this side of the build. Returning SelfContained with an empty
+    // mechanism is not a degradation — the artifact genuinely carries
+    // everything it has — so this reports no diagnostic.
+    //
+    // ⚠️ Placed before the format switch rather than inside it: the format is
+    // ELF here, and every ELF cell below reaches for the toolchain's HOST
+    // archives. One of them silently produced a link line with
+    // x86-64 libc++.a on a riscv64 link.
+    if (in.freestanding) {
+        m.effective = Contract::SelfContained;
+        m.unitFlags = " -nostdlib++";
+        return m;
+    }
 
     const bool haveCxxArchives =
         !in.libcxxArchive.empty() && !in.libcxxAbiArchive.empty();

--- a/src/build/execute.cppm
+++ b/src/build/execute.cppm
@@ -14,6 +14,8 @@ import mcpp.build.prepare;
 import mcpp.build.test_targets;
 import mcpp.diag;
 import mcpp.build.plan;
+import mcpp.toolchain.triple;
+import mcpp.freestanding.runner;
 import mcpp.build.graph_shape;    // #407: which mode wrote this build.ninja
 import mcpp.build.backend;
 import mcpp.build.ninja;
@@ -987,7 +989,8 @@ export int build_run_target(const std::optional<std::string>& targetName,
                             std::span<const std::string> passthrough,
                             const std::string& package_filter = {},
                             const std::string& cache_mode = {},
-                            bool no_cache = false) {
+                            bool no_cache = false,
+                            const std::string& target_triple = {}) {
     // mcpp#225 (E2): reuse the resolved build cache when it's still fresh,
     // skipping prepare_build's toolchain resolution + modgraph scan
     // entirely — mirrors cmd_build's try_fast_build fast path. The cached
@@ -998,7 +1001,8 @@ export int build_run_target(const std::optional<std::string>& targetName,
     // A --cache/--no-cache override also bypasses the fast path, for the same
     // reason --profile does: the cached build.ninja was generated under the
     // previous mode, so reusing it would silently ignore the flag.
-    if (package_filter.empty() && cache_mode.empty() && !no_cache) {
+    if (package_filter.empty() && cache_mode.empty() && !no_cache
+        && target_triple.empty()) {
         if (auto root = mcpp::project::find_manifest_root(std::filesystem::current_path())) {
             if (auto rc = try_fast_run(*root, targetName, passthrough)) {
                 return *rc;
@@ -1011,6 +1015,7 @@ export int build_run_target(const std::optional<std::string>& targetName,
     mcpp::build::BuildOverrides ov;
     ov.package_filter = package_filter;
     ov.cache_mode     = cache_mode;
+    ov.target_triple  = target_triple;
     auto ctx = prepare_build(/*print_fp=*/false, /*includeDevDeps=*/false,
                              /*extraTargets=*/{}, ov);
     if (!ctx) { std::println(stderr, "error: {}", ctx.error()); return 2; }
@@ -1033,13 +1038,39 @@ export int build_run_target(const std::optional<std::string>& targetName,
 
     auto exe = ctx->outputDir / chosen->output;
     auto pathCtx = mcpp::fetcher::make_path_ctx(/*cfg=*/nullptr, ctx->projectRoot);
-    mcpp::ui::status("Running",
-        std::format("`{}`", mcpp::ui::shorten_path(exe, pathCtx)));
+    std::vector<std::string> argv;
+    // A freestanding artifact is not executable on this machine by
+    // construction — wrong ISA, no loader, and it expects to own the address
+    // space. Exec'ing it directly gives "Exec format error", which describes
+    // the symptom and not the situation. The runner template says how to stand
+    // something in front of it; mcpp never guesses one, because which emulator
+    // and which machine model are board facts (see mcpp.freestanding.runner).
+    bool freestandingRun = false;
+    if (auto ft = mcpp::toolchain::triple::parse(ctx->tc.targetTriple))
+        freestandingRun = ft->is_freestanding();
+    if (freestandingRun) {
+        std::vector<std::string> tmpl;
+        if (auto it = ctx->manifest.targetOverrides.find(ctx->tc.targetTriple);
+            it != ctx->manifest.targetOverrides.end())
+            tmpl = it->second.runner;
+        if (tmpl.empty()) {
+            std::println(stderr, "error: {}",
+                mcpp::freestanding::no_runner_message(ctx->tc.targetTriple));
+            return 2;
+        }
+        argv = mcpp::freestanding::expand(tmpl, exe);
+        for (auto& a : passthrough) argv.push_back(a);
+        mcpp::ui::status("Running", std::format(
+            "`{} … {}`", tmpl.front(),
+            mcpp::ui::shorten_path(exe, pathCtx)));
+    } else {
+        argv.push_back(exe.string());
+        for (auto& a : passthrough) argv.push_back(a);
+        mcpp::ui::status("Running",
+            std::format("`{}`", mcpp::ui::shorten_path(exe, pathCtx)));
+    }
     std::println("");
     std::fflush(stdout);
-    std::vector<std::string> argv;
-    argv.push_back(exe.string());
-    for (auto& a : passthrough) argv.push_back(a);
 
     std::vector<std::pair<std::string, std::string>> childEnv;
     auto [runEnvKey, runEnvValue] = compute_run_env(ctx->plan);

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -14,6 +14,8 @@ export module mcpp.build.flags;
 import std;
 import mcpp.build.distribution;
 import mcpp.build.plan;
+import mcpp.freestanding.target;
+import mcpp.freestanding.linkline;
 import mcpp.manifest.types;
 import mcpp.modgraph.scanner;
 import mcpp.platform;
@@ -908,6 +910,11 @@ CompileFlags compute_flags(const BuildPlan& plan) {
         mi.mingw          = isMingwTc;
         mi.macosFloor     = !macosDeploymentTarget.empty();
         mi.format         = format;
+        // Bare metal short-circuits the whole table: the archives found below
+        // are the HOST's, and linking them into a riscv64 image fails with
+        // "incompatible with elf64lriscv". See MechanismInput::freestanding.
+        if (auto ft = mcpp::toolchain::triple::parse(plan.toolchain.targetTriple))
+            mi.freestanding = ft->is_freestanding();
 
         const bool wantsArchives =
             (base == dist::Contract::SelfContained
@@ -1230,6 +1237,60 @@ CompileFlags compute_flags(const BuildPlan& plan) {
                             link_toolchain_flags_c, b_flag, runtime_dirs,
                             link_intent_ld, atomic_ld, payload_ld,
                             user_ldflags, link_extra);
+    }
+
+    // ── Freestanding: the target has no OS, so most of the above is wrong ──
+    //
+    // Applied LAST and by REPLACEMENT rather than woven in above, for two
+    // reasons. First, every hosted link decision made so far is not merely
+    // unnecessary here but actively wrong — crt files, a dynamic linker, the
+    // C++ runtime, loader search paths — and appending `-nostdlib` to a line
+    // that already carries them leaves the outcome depending on the driver's
+    // flag ordering rather than on a decision anyone made. Second, keeping it
+    // to one block means the hosted path above is untouched: a target that is
+    // not freestanding takes exactly the code it took before.
+    //
+    // What is NOT decided here: the linker script, the startup objects and the
+    // C library. Those are BOARD facts and belong to a BSP package; the engine
+    // carries only their ordering, which is the one thing a `build.mcpp`
+    // cannot express (`link-search`/`link-lib` are unordered, and there is no
+    // verbatim ldflag directive — deliberately).
+    if (auto ft = mcpp::toolchain::triple::parse(plan.toolchain.targetTriple);
+        ft && ft->is_freestanding())
+    {
+        if (auto spec = mcpp::freestanding::resolve(*ft)) {
+            const auto prefix = mcpp::freestanding::compile_prefix(*spec);
+            f.cxx += prefix;
+            f.cc  += prefix;
+            f.as  += mcpp::freestanding::assemble_prefix(*spec);
+
+            mcpp::freestanding::LinkInputs in;
+            // Absolute path, not `-fuse-ld=lld`: the name resolves through
+            // PATH and finds GNU ld on any machine with binutils earlier on
+            // it, which then dies with 'unrecognised emulation mode'.
+            // Reproduced on this toolchain 2026-08-19.
+            in.lld = mcpp::freestanding::resolve_lld(plan.toolchain.binaryPath);
+            // ⚠️ `--no-default-config` FIRST, and it is not hygiene.
+            //
+            // The llvm payload ships bin/clang++.cfg with an unconditional
+            // `-Wl,--dynamic-linker=…/ld-linux-x86-64.so.2`, a host `-L` and
+            // host `-isystem`s — none of it guarded by target. Replacing the
+            // link line without carrying the bypass forward hands those flags
+            // back to the driver, and the result is not a link error: it is a
+            // RISC-V firmware image with an x86-64 PT_INTERP baked in, which
+            // links clean and reports success. Measured, on this very change,
+            // before this line existed.
+            std::string fsLd = isClangWithCfg ? " --no-default-config" : "";
+            fsLd += mcpp::freestanding::link_flags(*spec, in, ninjaEsc);
+            f.ld  = fsLd + user_ldflags;
+            f.ldC = f.ld;
+            // Nothing hosted survives: these carry payload/sysroot/-B flags
+            // that name a C library this target does not have.
+            f.sysroot.clear();
+            f.bFlag.clear();
+            f.ldRuntimeFallback.clear();
+            f.linkage = "static";
+        }
     }
 
     return f;

--- a/src/build/flags.cppm
+++ b/src/build/flags.cppm
@@ -524,12 +524,34 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     // binutilsPrefix / runtimeLibDirs stay off here: this function computes
     // -B separately into f.bFlag, and routes runtime dirs through
     // depRuntimeLibraryDirs.
-    {
+    // Is this build for a target with no OS under it? Asked once, here, and
+    // used by both the compile block immediately below and the link block at
+    // the end of this function.
+    const bool isFreestandingTarget = [&] {
+        auto ft = mcpp::toolchain::triple::parse(plan.toolchain.targetTriple);
+        return ft && ft->is_freestanding();
+    }();
+
+    if (!isFreestandingTarget) {
         mcpp::toolchain::HostFlagOptions hopt;
         hopt.cfgBypass = mcpp::toolchain::HostFlagOptions::CfgBypass::Always;
         hopt.macosDeploymentTarget = macosDeploymentTarget;
         compile_toolchain_flags = mcpp::toolchain::render_tokens(
             mcpp::toolchain::host_compile_tokens(plan.toolchain, hopt, ninjaEsc));
+    } else {
+        // ⚠️ Skipped entirely, not filtered. What this block emits is the
+        // HOST's world reconstructed by hand — libc++'s headers, glibc's
+        // headers, the Linux UAPI headers — because the cfg that normally
+        // supplies them is bypassed. Every one of those is for the host, and
+        // on a freestanding target they do not merely go unused: picolibc's
+        // own <stdio.h> includes <stddef.h>, which then resolves to libc++'s
+        // copy, which opens a `__config_site` generated for the host and
+        // absent here. Measured — and the error names __config_site, so it
+        // reads as a broken payload rather than as the wrong include path.
+        //
+        // The cfg bypass itself is still required (the cfg carries a hardcoded
+        // x86-64 dynamic linker); it is added to the freestanding prefix.
+        compile_toolchain_flags = " --no-default-config";
     }
     if (isClangWithCfg) {
         llvmRootForStdlib = dm.llvmRoot;
@@ -1255,10 +1277,9 @@ CompileFlags compute_flags(const BuildPlan& plan) {
     // carries only their ordering, which is the one thing a `build.mcpp`
     // cannot express (`link-search`/`link-lib` are unordered, and there is no
     // verbatim ldflag directive — deliberately).
-    if (auto ft = mcpp::toolchain::triple::parse(plan.toolchain.targetTriple);
-        ft && ft->is_freestanding())
-    {
-        if (auto spec = mcpp::freestanding::resolve(*ft)) {
+    if (isFreestandingTarget) {
+        if (auto spec = mcpp::freestanding::resolve(
+                *mcpp::toolchain::triple::parse(plan.toolchain.targetTriple))) {
             const auto prefix = mcpp::freestanding::compile_prefix(*spec);
             f.cxx += prefix;
             f.cc  += prefix;

--- a/src/build/hostprogram.cppm
+++ b/src/build/hostprogram.cppm
@@ -50,6 +50,10 @@ inline void generated(const char* path)           { std::printf("mcpp:generated=
 inline void source(const char* path)              { std::printf("mcpp:source=%s\n", path); }
 inline void include_dir(const char* dir)          { std::printf("mcpp:include-dir=%s\n", dir); }
 inline void include_dir_after(const char* dir)    { std::printf("mcpp:include-dir-after=%s\n", dir); }
+// The memory layout for a freestanding link. Reaches the CONSUMER's link line
+// (like link_lib/link_search, unlike include_dir), because the package that
+// knows a board's layout is not the package being built.
+inline void link_script(const char* path)         { std::printf("mcpp:link-script=%s\n", path); }
 // ── Build-graph nodes (mcpp 2026.8.5.1+) ────────────────────────────────
 // Declare WORK instead of doing it. A build program is a good place to decide
 // what the build looks like and a bad place to perform it: work done here is
@@ -185,6 +189,45 @@ inline const char* dep_dir(const char* name) {
     buf[o++] = '_'; buf[o++] = 'D'; buf[o++] = 'I'; buf[o++] = 'R'; buf[o] = 0;
     return env_or(buf);
 }
+// The payload directory of a package declared in `[xlings] deps`.
+//
+// An INTERFACE, not a naming convention. `dep_dir` answers for mcpp
+// dependencies and cannot answer for xlings ones: they are a different
+// namespace with a different store layout, and a build.mcpp that reconstructed
+// `<home>/data/xpkgs/<ns>-x-<name>/<version>` itself would be encoding store
+// internals that mcpp is free to change — the exact thing `dep_dir` exists to
+// avoid ("instead of reverse-engineering the store layout").
+//
+// Ask with the spelling the manifest used:
+//
+//     deps = ["xim:picolibc-riscv@1.8.12"]
+//     xpkg_dir("xim", "picolibc-riscv")   // exact, and preferred
+//     xpkg_dir("picolibc-riscv")          // bare name
+//
+// The namespaced form is tried first and answers only for a package declared
+// under that namespace. The bare form is a convenience for the common single
+// declaration; when two namespaces declare the same name, only the namespaced
+// form can say which one is meant, and the bare one answers for the first
+// declared. Returns "" when the package was not declared or is not installed —
+// a caller that needs it should say so itself, because only it knows whether
+// the absence is fatal.
+inline const char* xpkg_dir(const char* ns, const char* name) {
+    char buf[256] = "MCPP_XPKG_";
+    unsigned long o = 10;
+    auto put = [&](const char* s) {
+        for (const char* p = s; *p && o + 6 < sizeof buf; ++p, ++o) {
+            char c = *p;
+            buf[o] = (c >= 'a' && c <= 'z') ? char(c - 'a' + 'A')
+                   : ((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) ? c : '_';
+        }
+    };
+    if (ns && *ns) { put(ns); if (o + 6 < sizeof buf) buf[o++] = '_'; }
+    put(name);
+    buf[o++] = '_'; buf[o++] = 'D'; buf[o++] = 'I'; buf[o++] = 'R'; buf[o] = 0;
+    return env_or(buf);
+}
+inline const char* xpkg_dir(const char* name) { return xpkg_dir("", name); }
+
 // mcpp#355: absolute path to a HOST tool built by a dependency — the binary
 // behind one of its `kind = "bin"` targets. Returns "" unless the consumer
 // declared it:  <dep> = { version = "…", tools = ["protoc"] }

--- a/src/build/prepare.cppm
+++ b/src/build/prepare.cppm
@@ -1716,6 +1716,61 @@ prepare_build(bool print_fingerprint,
     if (!tc->resolutionNote.empty())
         mcpp::ui::info("note", tc->resolutionNote);
 
+    // ── A retargetable driver has to be TOLD what it is targeting ────────
+    //
+    // `tc.targetTriple` comes from `-dumpmachine`, and for every cross target
+    // that worked before this it was right for a reason that does not
+    // generalise: those targets use a DISTINCT compiler binary
+    // (`x86_64-w64-mingw32-g++`, `aarch64-linux-musl-g++`), whose own
+    // -dumpmachine reports the cross triple. Clang is ONE binary that emits
+    // every target it was built with, so -dumpmachine always answers with the
+    // host — and nothing downstream ever learns otherwise.
+    //
+    // Measured before this line existed:
+    //
+    //   $ mcpp build --target riscv64-none-elf
+    //       Resolved llvm@22.1.8 → riscv64-none-elf → …/bin/clang++
+    //       Finished dev [unoptimized + debuginfo] in 0.47s
+    //   $ ls target/
+    //       x86_64-linux-gnu/          ← an ELF for the host, reported as riscv64
+    //
+    // That is E1: success reported, host artifact produced. The output
+    // directory, the fingerprint, the cache key and the flag layer all read
+    // `tc.targetTriple`, so correcting it here corrects all of them at once —
+    // which is the point of there being one field rather than five answers.
+    //
+    // ⚠️ Scoped to freestanding on purpose. The hosted cross targets already
+    // resolve a per-target binary, and overwriting their probed triple would
+    // replace a measured fact with an assumed one for no gain.
+    if (!overrides.target_triple.empty()) {
+        if (auto want = mcpp::toolchain::triple::parse(overrides.target_triple);
+            want && want->is_freestanding())
+        {
+            tc->targetTriple = want->str();
+
+            // `import std` is structurally hosted, and turning it off is the
+            // SAME fact as the line above, not a second policy: libc++'s
+            // std.cppm is one module over the whole library, including the
+            // parts that are threads, filesystem and iostreams. There is no
+            // subset of it to precompile.
+            //
+            // Left on, the failure is neither early nor legible — measured:
+            //
+            //   error: std module precompile failed (rc=1):
+            //   .../include/c++/v1/__config:13:10: fatal error:
+            //       '__config_site' file not found
+            //
+            // which reads as a broken toolchain payload and says nothing about
+            // the target. The freestanding std subset a user actually wants is
+            // an ordinary package (`mcpplibs.std.freestanding`), so mcpp's job
+            // here is to stop pretending the hosted one exists and to say
+            // where the other one is.
+            tc->hasImportStd = false;
+            tc->stdModuleSource.clear();
+            tc->stdCompatSource.clear();
+        }
+    }
+
     // The Windows runtime identity, flowing BACK into the contract.
     //
     // Everything else about the runtime is known before a toolchain is
@@ -5148,6 +5203,35 @@ prepare_build(bool print_fingerprint,
 
     bool needsStdModule = graph_or_targets_import_std(scan.graph, *m, *root);
     if (needsStdModule && !tc->hasImportStd) {
+        // A freestanding target reaches here for a reason the generic message
+        // gets wrong. Nothing is missing from the toolchain — libc++'s std
+        // module is right there — it is that `std` is ONE module over the whole
+        // library, threads and filesystem and iostreams included, so there is
+        // no subset of it to build without an OS. Saying "provides no std
+        // module source" sends the reader to look for a broken payload.
+        //
+        // Naming the replacement is the whole value of the diagnostic: the
+        // freestanding subset is an ordinary package, so the fix is one line in
+        // the manifest rather than a toolchain investigation.
+        if (auto ft = mcpp::toolchain::triple::parse(tc->targetTriple);
+            ft && ft->is_freestanding())
+        {
+            return std::unexpected(std::format(
+                "`import std;` is not available on '{}' — a freestanding target "
+                "has no hosted standard library.\n"
+                "       `std` is one module over the entire library (threads, "
+                "filesystem, iostreams\n"
+                "       included), so there is no subset of it to build without "
+                "an OS underneath.\n"
+                "       Use the freestanding subset instead:\n"
+                "\n"
+                "           [dependencies]\n"
+                "           mcpplibs.std.freestanding = \"0.1\"\n"
+                "\n"
+                "       then `import mcpplibs.std.freestanding;` in place of "
+                "`import std;`.",
+                tc->targetTriple));
+        }
         return std::unexpected(std::format(
             "source imports std but toolchain '{}' provides no std module source",
             tc->label()));

--- a/src/build/prepare.cppm
+++ b/src/build/prepare.cppm
@@ -3126,6 +3126,32 @@ prepare_build(bool print_fingerprint,
     // declarations reached build.mcpp; with re-export, two packages that never
     // heard of each other can share a tail and the later emplace_back would
     // silently win.
+    // The xlings half of fillDepDirs. Same question ("where did my declared
+    // dependency's payload land"), different namespace and store layout, so it
+    // cannot ride the mcpp dependency channel — but it must be an INTERFACE on
+    // the build.mcpp side for the same reason that one is: a program that
+    // reconstructs the store path is coupled to internals mcpp is free to
+    // change. See mcpp::build::hostprogram::xpkg_dir.
+    auto fillXpkgDirs = [&](mcpp::build::BuildProgramEnv& e,
+                            const mcpp::manifest::Manifest& owner) {
+        if (owner.xlings.deps.empty()) return;
+        auto cfg = get_cfg();
+        if (!cfg) return;
+        auto xlEnv = mcpp::config::make_xlings_env(**cfg);
+        for (auto const& spec : owner.xlings.deps) {
+            auto ref = mcpp::xlings::paths::parse_xpkg_ref(spec);
+            auto dir = mcpp::xlings::paths::xpkg_payload(xlEnv, ref);
+            if (!dir) continue;   // declared but not installed: "" is the answer
+            // Namespaced first — it is the exact spelling, and the bare form
+            // below must not shadow it (the receiver keeps the first value it
+            // is given for a name).
+            e.xpkgDirs.emplace_back(
+                mcpp::build::xpkg_env_var(ref.ns, ref.name), dir->string());
+            e.xpkgDirs.emplace_back(
+                mcpp::build::xpkg_env_var("", ref.name), dir->string());
+        }
+    };
+
     auto fillDepDirs = [&](mcpp::build::BuildProgramEnv& e, std::size_t consumer) {
         if (consumer >= provisionGraph.visible.size()) return;
         auto bind = bareBindingsFor(consumer);
@@ -4918,6 +4944,10 @@ prepare_build(bool print_fingerprint,
             // (mergeActiveFeatureDeps folded them in before the edges were
             // recorded). Shared owner — see fillDepDirs.
             fillDepDirs(bpEnv, i);
+            // …and the xlings packages this package itself declared. Its own
+            // manifest, not the root's: a dependency's `[xlings] deps` is what
+            // its build.mcpp asks about.
+            fillXpkgDirs(bpEnv, packages[i].manifest);
             // #355: the host tools THIS package requested (resolved above).
             if (auto tit = toolEnvByConsumer.find(i); tit != toolEnvByConsumer.end())
                 bpEnv.toolPaths = tit->second;
@@ -5051,6 +5081,7 @@ prepare_build(bool print_fingerprint,
         bpEnv.features     = feature_closure(*m, parse_feature_request(overrides.features));
         // mcpp#241 (root): consumer index 0, same owner as the dep loop.
         fillDepDirs(bpEnv, 0);
+        fillXpkgDirs(bpEnv, *m);
         // #355: the host tools the ROOT package requested (consumer index 0).
         if (auto tit = toolEnvByConsumer.find(0u); tit != toolEnvByConsumer.end())
             bpEnv.toolPaths = tit->second;

--- a/src/build/program_protocol.cppm
+++ b/src/build/program_protocol.cppm
@@ -45,7 +45,7 @@ export namespace mcpp::build::program_protocol {
 // number than this must refuse: it cannot know what it is being asked to do,
 // and "warn and ignore" would turn that into a silently different build.
 // v2 (#359): adds `rerun-if-changed-glob`.
-inline constexpr int kProtocolVersion = 2;
+inline constexpr int kProtocolVersion = 3;
 
 // ── Cache-format epoch ─────────────────────────────────────────────────────
 //

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -319,6 +319,13 @@ int run(int argc, char** argv) {
             // NB: this positional is a BINARY NAME from [[bin]]/src layout —
             // unrelated to `--target <triple>` (the cross-target axis).
             .arg(cl::Arg("target").help("Binary name (optional)"))
+            // ⚠️ Same word, two axes — and they were ALREADY named this way:
+            // the positional above is a binary name, this option is the cross
+            // target triple, exactly as in `mcpp build --target`. Spelling the
+            // option differently here would make the one command that needs
+            // both the one command where the flag is not called --target.
+            .option(cl::Option("target-triple").takes_value().value_name("TRIPLE")
+                .help("Cross target triple (same axis as `mcpp build --target`)"))
             .option(cl::Option("package").short_name('p').takes_value().value_name("NAME")
                 .help("Run only the named workspace member (single-member; no --workspace fan-out)"))
             .option(cl::Option("cache").takes_value().value_name("MODE")

--- a/src/cli/cmd_build.cppm
+++ b/src/cli/cmd_build.cppm
@@ -166,8 +166,10 @@ export int cmd_run(const mcpplibs::cmdline::ParsedArgs& parsed,
     bool no_cache = parsed.is_flag_set("no-cache");
     if (auto c = parsed.value("cache")) cache_mode = *c;
     else if (no_cache)                  cache_mode = "off";
+    std::string target_triple;
+    if (auto tt = parsed.value("target-triple")) target_triple = *tt;
     return mcpp::build::build_run_target(targetName, passthrough, package_filter,
-                                         cache_mode, no_cache);
+                                         cache_mode, no_cache, target_triple);
 }
 
 export int cmd_test(const mcpplibs::cmdline::ParsedArgs& parsed,

--- a/src/freestanding/linkline.cppm
+++ b/src/freestanding/linkline.cppm
@@ -1,0 +1,127 @@
+// mcpp.freestanding.linkline — the compile prefix and link line for a target
+// that has no operating system under it.
+//
+// PURE STRING BUILDERS, ON PURPOSE
+//
+// Nothing here knows about `mcpp::build::CompileFlags`, the build plan, or the
+// manifest. `mcpp.build.flags` imports this module and applies what it
+// returns; this module importing that one back would be a cycle, and the
+// cheapest way to guarantee it never becomes one is for the freestanding side
+// to speak only in strings.
+//
+// WHY THE LINK LINE IS REPLACED RATHER THAN EXTENDED
+//
+// Every hosted link flag is wrong here, not merely unnecessary: the C runtime
+// startup files, the dynamic linker, `-lstdc++`, the loader search paths.
+// Appending `-nostdlib` to a line that already carries them relies on the
+// driver dropping them in the right order. Building the line from nothing is
+// the only form where "what ends up on the command" equals "what this module
+// decided".
+//
+// ⚠️ THE LINKER IS ADDRESSED BY ABSOLUTE PATH
+//
+// `-fuse-ld=lld` resolves by NAME, and on a machine with binutils earlier on
+// PATH it finds GNU ld, which then fails with
+//
+//     unrecognised emulation mode: elf64lriscv
+//
+// Reproduced 2026-08-19 on this very toolchain while building picolibc. A name
+// is a request; a path is an instruction.
+
+export module mcpp.freestanding.linkline;
+
+import std;
+import mcpp.freestanding.target;
+
+export namespace mcpp::freestanding {
+
+// Flags every translation unit of a freestanding build carries.
+//
+// `--target` is the load-bearing one and the reason this exists at all: clang
+// is ONE binary that emits every target it was built with, so unlike the
+// hosted cross toolchains (where a distinct `<triple>-g++` reports its own
+// `-dumpmachine`) nothing about the driver's identity says which target is
+// wanted. Omit it and the build silently produces host objects — measured, and
+// the exact shape of the E1 defect this work exists to close.
+inline std::string compile_prefix(const Spec& s) {
+    std::string out;
+    out += " --target=" + std::string(s.triple);
+    for (auto const& f : compile_flags(s)) { out += ' '; out += f; }
+    return out;
+}
+
+// Assembly goes through the C driver, which needs the same target selection
+// but none of the C++ dialect flags.
+inline std::string assemble_prefix(const Spec& s) { return compile_prefix(s); }
+
+// What the link line must NOT do, spelled as flags:
+//   -nostdlib      no C runtime, no default libraries
+//   -nostartfiles  no crt0/crt1 — startup comes from a BSP, or nowhere
+//   -static        there is no loader, so there is no other option
+//
+// The linker script and startup objects are NOT here: they are board facts, a
+// BSP supplies them, and the engine only carries their ORDER (which is the one
+// thing a `build.mcpp` cannot express — `link-search`/`link-lib` are unordered
+// and there is no verbatim ldflag directive).
+struct LinkInputs {
+    std::filesystem::path lld;          // absolute path to ld.lld
+    std::filesystem::path linkerScript; // "" = none (BSP-supplied when present)
+    std::vector<std::filesystem::path> prologue;  // before the user's objects
+    std::vector<std::filesystem::path> epilogue;  // after them
+};
+
+inline std::string link_flags(const Spec& s, const LinkInputs& in,
+                              const std::function<std::string(
+                                  const std::filesystem::path&)>& esc)
+{
+    std::string out;
+    out += " --target=" + std::string(s.triple);
+    for (auto const& f : compile_flags(s)) { out += ' '; out += f; }
+    out += " -nostdlib -nostartfiles -static";
+    if (!in.lld.empty())
+        out += " -fuse-ld=" + esc(in.lld);
+    if (!in.linkerScript.empty())
+        out += " -T " + esc(in.linkerScript);
+    return out;
+}
+
+// LLD inside the same payload as the driver.
+//
+// Derived from the driver's own path rather than searched for, because a
+// search is exactly how the wrong linker gets picked. Returns "" when the
+// payload has no LLD, and the caller must treat that as a hard error rather
+// than falling back to `-fuse-ld=lld` — falling back is the failure.
+inline std::filesystem::path resolve_lld(const std::filesystem::path& driver) {
+    if (driver.empty()) return {};
+    const auto bin = driver.parent_path();
+    std::error_code ec;
+    for (const char* name : { "ld.lld", "ld.lld.exe", "lld", "lld.exe" }) {
+        auto p = bin / name;
+        if (std::filesystem::exists(p, ec)) return p;
+    }
+    return {};
+}
+
+// Does this look like LLD? Checked against the linker's own `--version`
+// output rather than its filename, because the filename is exactly what was
+// wrong in the failure this guards.
+inline bool version_output_is_lld(std::string_view versionText) {
+    return versionText.find("LLD") != std::string_view::npos;
+}
+
+// The diagnostic for the case above. Its own function so the wording is
+// asserted in one place and cannot drift between call sites.
+inline std::string wrong_linker_message(const std::filesystem::path& linker,
+                                        std::string_view versionText)
+{
+    std::string firstLine(versionText.substr(0, versionText.find('\n')));
+    return std::format(
+        "the linker at {} is not LLD (it reports: {})\n"
+        "       a freestanding target needs LLD: GNU ld in an LLVM payload "
+        "cannot emit\n"
+        "       this target's object format and fails with "
+        "'unrecognised emulation mode'.",
+        linker.string(), firstLine.empty() ? "(no output)" : firstLine);
+}
+
+} // namespace mcpp::freestanding

--- a/src/freestanding/runner.cppm
+++ b/src/freestanding/runner.cppm
@@ -1,0 +1,75 @@
+// mcpp.freestanding.runner — how `mcpp run` executes an artifact that cannot
+// run on this machine.
+//
+// A bare-metal image is not executable here by construction: wrong ISA, no
+// loader, and it expects to own the whole address space. Something has to
+// stand between `mcpp run` and the artifact, and WHICH something is a board
+// fact — the emulator's machine model, its firmware mode, whether output
+// arrives over a UART or through semihosting. Two boards on the same ISA need
+// different argv:
+//
+//   qemu-system-riscv64 -machine virt -bios default    -kernel <img>   (OpenSBI)
+//   qemu-system-riscv64 -machine virt -bios none -semihosting -kernel <img>
+//
+// So mcpp carries a TEMPLATE and never a default. There is deliberately no
+// built-in "if riscv64 then qemu" rule: the moment the engine guesses, a board
+// that needs the other spelling has to fight it, and `mcpp run` silently doing
+// the wrong thing is worse than saying it does not know.
+
+export module mcpp.freestanding.runner;
+
+import std;
+
+export namespace mcpp::freestanding {
+
+// Where the artifact goes in the argv.
+//
+// `{}` is substituted when present; otherwise the path is appended. Appending
+// is the common shape (`-kernel <img>` ends the line) and making it the
+// default keeps the simple case free of punctuation, while `{}` covers the
+// emulator that wants the image in the middle.
+inline constexpr std::string_view kArtifactPlaceholder = "{}";
+
+inline std::vector<std::string> expand(std::span<const std::string> tmpl,
+                                       const std::filesystem::path& artifact)
+{
+    std::vector<std::string> argv;
+    argv.reserve(tmpl.size() + 1);
+    bool substituted = false;
+    for (auto const& tok : tmpl) {
+        auto pos = tok.find(kArtifactPlaceholder);
+        if (pos == std::string::npos) { argv.push_back(tok); continue; }
+        std::string out = tok;
+        out.replace(pos, kArtifactPlaceholder.size(), artifact.string());
+        argv.push_back(std::move(out));
+        substituted = true;
+    }
+    if (!substituted) argv.push_back(artifact.string());
+    return argv;
+}
+
+// The diagnostic for "this target needs a runner and none is configured".
+//
+// Its own function so the wording is asserted once. It names the exact key and
+// shows a working value, because the user reading it has just been told their
+// build succeeded and their run did not — the gap between those two is the
+// whole content of the message.
+inline std::string no_runner_message(std::string_view triple) {
+    return std::format(
+        "no runner is configured for '{}' — a freestanding artifact cannot "
+        "execute on this machine.\n"
+        "       Declare how to run it:\n"
+        "\n"
+        "           [target.{}]\n"
+        "           runner = [\"qemu-system-riscv64\", \"-machine\", \"virt\",\n"
+        "                     \"-nographic\", \"-no-reboot\", \"-bios\", "
+        "\"default\", \"-kernel\"]\n"
+        "\n"
+        "       The artifact path is appended, or substituted for `{{}}` if the "
+        "template contains it.\n"
+        "       A board-support package normally supplies this so you do not "
+        "have to.",
+        triple, triple);
+}
+
+} // namespace mcpp::freestanding

--- a/src/freestanding/target.cppm
+++ b/src/freestanding/target.cppm
@@ -88,6 +88,19 @@ inline std::vector<std::string> compile_flags(const Spec& s) {
     if (!s.mcmodel.empty())
         out.emplace_back(std::string("-mcmodel=") + std::string(s.mcmodel));
     out.emplace_back("-ffreestanding");
+    // ⚠️ No C++ standard library headers. Not a preference — the toolchain's
+    // libc++ headers are built for the HOST: `#include <stdio.h>` resolves to
+    // libc++'s wrapper, which opens `<__config_site>`, which is generated per
+    // installation for the host configuration and is simply absent for this
+    // target. The error reads as a broken payload
+    // (`'__config_site' file not found`) and says nothing about the target.
+    //
+    // A target-side C++ library is an ordinary package, and the way it reaches
+    // a consumer is a MODULE, not an include path: `include-dir` is
+    // package-private by design (the supply-chain rule in
+    // mcpp.build.directives), so a libc wrapper includes the target headers
+    // privately and exports what it wants seen.
+    out.emplace_back("-nostdinc++");
     return out;
 }
 

--- a/src/freestanding/target.cppm
+++ b/src/freestanding/target.cppm
@@ -1,0 +1,98 @@
+// mcpp.freestanding.target — what a bare-metal target IS, in one table.
+//
+// WHY THIS IS ITS OWN MODULE (AND ITS OWN DIRECTORY)
+//
+// A freestanding target differs from a hosted one along more axes than the
+// triple carries: an ISA profile (`-march`), a calling convention (`-mabi`), a
+// code model, and whether the C++ runtime pieces (exceptions, RTTI, threads)
+// have anything under them. Every one of those is a decision that MUST be
+// derived in exactly one place — this codebase has paid repeatedly for the
+// opposite shape (#233/#240/#242/#344: "the same decision derived in N places
+// does not fail when you add it, it fails later, somewhere else").
+//
+// So: one row per target, and `resolve()` is the only way to read it. A
+// consumer that wants to know "what -march does riscv64-none-elf use" asks
+// here; it does not pattern-match the triple.
+//
+// WHAT IS DELIBERATELY NOT HERE
+//
+// * No libc. No linker script. No memory map. No emulator arguments. Those
+//   belong to a BSP package, and the engine never learns them — the whole
+//   point of the layering (see .agents/docs/2026-08-19-baremetal-ecosystem-
+//   closure-plan.md §2). This table stops at the ISA.
+// * No sysroot. Measured 2026-08-19 (probe Z1): a package's `build.mcpp` can
+//   already put `-L`/`-l` on the consumer's link line (`link-search` and
+//   `link-lib` are Scope::LinkGlobal), while `include-dir` is PackagePrivate
+//   by design. So target headers reach a consumer the modular way — the libc
+//   wrapper package includes them privately and exports a C++ module — and the
+//   engine needs no sysroot concept at all.
+
+export module mcpp.freestanding.target;
+
+import std;
+import mcpp.toolchain.triple;
+
+export namespace mcpp::freestanding {
+
+// One bare-metal target's ISA-level facts.
+struct Spec {
+    std::string_view triple;      // canonical, e.g. "riscv64-none-elf"
+    std::string_view march;       // ISA profile   -march=
+    std::string_view mabi;        // calling conv  -mabi=
+    std::string_view mcmodel;     // code model    -mcmodel=   ("" = driver default)
+    // Sub-directory a libc/sysroot package uses for this profile. picolibc's
+    // own multilib convention (`<march>/<mabi>`), carried here so a wrapper
+    // package can name its layout without re-deriving the profile.
+    std::string_view libdir;
+};
+
+// ⚠️ Defaults, not the only possibility. `rv64gc/lp64d` is what qemu `virt`
+// runs and what the first BSP targets; a board that needs `rv32imac/ilp32`
+// selects it through its own manifest, not by editing this table. The table
+// exists so that `--target riscv64-none-elf` alone is enough to produce a
+// correct object file — not to enumerate every board.
+inline constexpr Spec kTable[] = {
+    //  triple                march       mabi     mcmodel    libdir
+    { "riscv64-none-elf",   "rv64gc",   "lp64d", "medany", "rv64gc/lp64d"   },
+    { "riscv32-none-elf",   "rv32imac", "ilp32", "medany", "rv32imac/ilp32" },
+};
+
+// The single read point. Returns nullopt for anything that is not a known
+// bare-metal target — including hosted triples, so a caller can use this as
+// "is this a target I know how to build freestanding".
+inline std::optional<Spec> resolve(const mcpp::toolchain::triple::Triple& t) {
+    if (!t.is_freestanding()) return std::nullopt;
+    const std::string s = t.str();
+    for (const auto& row : kTable)
+        if (row.triple == s) return row;
+    return std::nullopt;
+}
+
+inline std::optional<Spec> resolve(std::string_view triple) {
+    auto t = mcpp::toolchain::triple::parse(triple);
+    if (!t) return std::nullopt;
+    return resolve(*t);
+}
+
+// Compile flags this target needs on EVERY translation unit, freestanding or
+// not. Emitted from the spec rather than hardcoded per call site.
+//
+// `-ffreestanding` is here and not in the link layer on purpose: it changes
+// what the compiler may assume about the library (no `main` special-casing, no
+// builtin-to-libcall rewrites it cannot back up), and that assumption has to
+// hold for every TU in the build, including a dependency's.
+inline std::vector<std::string> compile_flags(const Spec& s) {
+    std::vector<std::string> out;
+    out.emplace_back(std::string("-march=") + std::string(s.march));
+    out.emplace_back(std::string("-mabi=")  + std::string(s.mabi));
+    if (!s.mcmodel.empty())
+        out.emplace_back(std::string("-mcmodel=") + std::string(s.mcmodel));
+    out.emplace_back("-ffreestanding");
+    return out;
+}
+
+// Every bare-metal target this build of mcpp knows, for `mcpp target list`
+// and for diagnostics that want to say what IS available.
+inline std::span<const Spec> known() { return kTable; }
+
+} // namespace mcpp::freestanding

--- a/src/manifest/toml.cppm
+++ b/src/manifest/toml.cppm
@@ -1410,6 +1410,31 @@ std::expected<Manifest, ManifestError> parse_string(std::string_view content,
                         triple, e.cxxRuntime)));
                 }
             }
+            // `runner` — the argv template `mcpp run` uses for a target whose
+            // artifact cannot execute here. An ARRAY, so it is neither a
+            // scalar (the unknown-key sweep below skips it by type) nor part
+            // of the conditional sub-table channel.
+            if (auto it = body.find("runner"); it != body.end()) {
+                if (!it->second.is_array()) {
+                    return std::unexpected(error(origin, std::format(
+                        "[target.{}].runner must be an array of strings, "
+                        "e.g. runner = [\"qemu-system-riscv64\", \"-kernel\"]",
+                        triple)));
+                }
+                for (auto& el : it->second.as_array()) {
+                    if (!el.is_string()) {
+                        return std::unexpected(error(origin, std::format(
+                            "[target.{}].runner must contain only strings", triple)));
+                    }
+                    e.runner.push_back(el.as_string());
+                }
+                if (e.runner.empty()) {
+                    return std::unexpected(error(origin, std::format(
+                        "[target.{}].runner is empty — an empty template would "
+                        "run nothing and report success", triple)));
+                }
+            }
+
             // Unsupported SCALAR keys are REPORTED, not dropped.
             // `[targets.<name>]` has done this since #249; this table did not,
             // so a key that looks plausible — `cxx_runtime_tests` was the real

--- a/src/manifest/toml.cppm
+++ b/src/manifest/toml.cppm
@@ -1460,6 +1460,12 @@ std::expected<Manifest, ManifestError> parse_string(std::string_view content,
             };
             for (auto& [key, value] : body) {
                 if (value.is_table()) continue;   // the conditional channel
+                // ...and arrays, which this sweep was never about. It checks
+                // SCALARS ("a scalar that does nothing"), and `runner` is an
+                // array read a few lines above — reaching here it was reported
+                // as "unsupported key 'runner' (ignored)" while in fact being
+                // honoured, which is worse than either being true.
+                if (value.is_array()) continue;
                 bool known = false;
                 for (auto k : kKnownTargetScalars) if (key == k) { known = true; break; }
                 if (known) continue;

--- a/src/manifest/types.cppm
+++ b/src/manifest/types.cppm
@@ -661,6 +661,13 @@ struct XlingsConfig {
 struct TargetEntry {
     std::string                         toolchain;     // e.g. "gcc@15.1.0-musl"; empty = inherit [toolchain]
     std::string                         linkage;       // "static" | "dynamic" | "" (= auto by libc)
+    // How `mcpp run` executes an artifact for this target when the artifact
+    // cannot run on this machine (a freestanding image: wrong ISA, no loader).
+    // A TEMPLATE and never a default — which emulator, which machine model and
+    // which firmware mode are board facts, and an engine that guesses one is an
+    // engine a different board has to fight. The artifact path is appended, or
+    // substituted for `{}` when the template contains it.
+    std::vector<std::string>            runner;
     // #336 — per-target C++ runtime contract, same vocabulary as
     // [build].cxx_runtime and overriding it for this triple. It lives HERE,
     // beside `linkage`, rather than in the `cfg(...)` conditional channel:

--- a/src/platform/xlings/xlings.cppm
+++ b/src/platform/xlings/xlings.cppm
@@ -68,6 +68,43 @@ namespace paths {
     std::filesystem::path xim_tool(const Env& env, std::string_view tool,
                                    std::string_view version);
 
+    // ── A declared `[xlings] deps` entry, and where its payload landed ──────
+    //
+    // The two helpers above hardcode the `xim` namespace, which was right
+    // while the only callers were mcpp's own tools (ninja, nasm). A manifest
+    // may name any namespace — `local:qemu-riscv` during development,
+    // `scode:…` for a source-built package — and the store spells an installed
+    // package `<namespace>-x-<name>/<version>`.
+    //
+    // Here rather than in the build layer because THIS module already owns
+    // that layout (`xpkgs_base`, `xim_tool`). A second place deriving it is
+    // the shape this codebase has paid for repeatedly: it does not fail when
+    // you add it, it fails later, somewhere else.
+    struct XpkgRef {
+        std::string ns;       // "xim" when the spec omitted one
+        std::string name;
+        std::string version;  // empty = unpinned
+    };
+
+    // Parse `[<ns>:]<name>[@<version>]` exactly as a manifest writes it.
+    XpkgRef parse_xpkg_ref(std::string_view spec);
+
+    // Where that package's payload is, or nullopt if it is not installed.
+    //
+    // ⚠️ A PINNED ref resolves to exactly its version and to nothing else. A
+    // build that asked for 1.8.12 and silently got 1.9.0 is the kind of answer
+    // that is only discovered later, in the artifact. An unpinned ref takes
+    // the highest version present — compared by numeric segments, because a
+    // plain string sort puts "0.4.11" before "0.4.9".
+    std::optional<std::filesystem::path>
+    xpkg_payload(const Env& env, const XpkgRef& ref);
+
+    // The same resolution against an explicit xpkgs base. The Env form
+    // delegates here; this one exists so the rule ("pinned means exactly that
+    // version") is testable without constructing a home.
+    std::optional<std::filesystem::path>
+    xpkg_payload_at(const std::filesystem::path& xpkgsBase, const XpkgRef& ref);
+
     // From compiler binary, climb parent dirs to find "xpkgs" directory.
     // Replaces 3 duplicate implementations in flags.cppm, ninja_backend.cppm,
     // stdmod.cppm.
@@ -681,6 +718,71 @@ std::filesystem::path xim_tool(const Env& env, std::string_view tool,
                                std::string_view version) {
     return xpkgs_base(env) / std::format("xim-x-{}", tool) / std::string(version);
 }
+
+// Parse `[<ns>:]<name>[@<version>]` exactly as a manifest writes it.
+XpkgRef parse_xpkg_ref(std::string_view spec) {
+    XpkgRef r;
+    if (auto colon = spec.find(':'); colon != std::string_view::npos) {
+        r.ns = std::string(spec.substr(0, colon));
+        spec = spec.substr(colon + 1);
+    } else {
+        // The manifest's own default, spelled once here rather than at each
+        // call site: `deps = ["ninja"]` and `deps = ["xim:ninja"]` name the
+        // same package.
+        r.ns = "xim";
+    }
+    if (auto at = spec.find('@'); at != std::string_view::npos) {
+        r.name    = std::string(spec.substr(0, at));
+        r.version = std::string(spec.substr(at + 1));
+    } else {
+        r.name = std::string(spec);
+    }
+    return r;
+}
+
+// Where that package's payload is, or nullopt if it is not installed.
+//
+// ⚠️ A PINNED ref resolves to exactly its version and to nothing else. A build
+// that asked for 1.8.12 and silently got 1.9.0 is the kind of answer that is
+// only discovered later, in the artifact. An unpinned ref takes the highest
+// version present — compared by numeric segments, because a plain string sort
+// puts "0.4.11" before "0.4.9" and picking the wrong payload is silent.
+std::optional<std::filesystem::path>
+xpkg_payload(const Env& env, const XpkgRef& ref) {
+    return xpkg_payload_at(xpkgs_base(env), ref);
+}
+
+std::optional<std::filesystem::path>
+xpkg_payload_at(const std::filesystem::path& xpkgsBase, const XpkgRef& ref) {
+    if (ref.name.empty()) return std::nullopt;
+    const auto root = xpkgsBase / std::format("{}-x-{}", ref.ns, ref.name);
+    std::error_code ec;
+    if (!ref.version.empty()) {
+        auto p = root / ref.version;
+        if (std::filesystem::is_directory(p, ec)) return p;
+        return std::nullopt;   // pinned and absent: NOT "some other version"
+    }
+    if (!std::filesystem::is_directory(root, ec)) return std::nullopt;
+    auto key_of = [](const std::string& s) {
+        std::vector<long long> k;
+        long long cur = 0; bool any = false;
+        for (char c : s) {
+            if (c >= '0' && c <= '9') { cur = cur * 10 + (c - '0'); any = true; }
+            else { if (any) k.push_back(cur); cur = 0; any = false; }
+        }
+        if (any) k.push_back(cur);
+        return k;
+    };
+    std::optional<std::filesystem::path> best;
+    std::vector<long long> bestKey;
+    for (auto const& e : std::filesystem::directory_iterator(root, ec)) {
+        if (!e.is_directory(ec)) continue;
+        auto k = key_of(e.path().filename().string());
+        if (!best || k > bestKey) { best = e.path(); bestKey = k; }
+    }
+    return best;
+}
+
 
 std::optional<std::filesystem::path>
 xpkgs_from_compiler(const std::filesystem::path& compilerBin) {

--- a/src/toolchain/registry.cppm
+++ b/src/toolchain/registry.cppm
@@ -562,6 +562,20 @@ bool host_can_serve(const triple::Triple& target) {
         return mcpp::platform::is_linux || mcpp::platform::is_windows;
     if (target.os == "windows") return bool(mcpp::platform::is_windows);
     if (target.os == "macos")   return bool(mcpp::platform::is_macos);
+
+    // Bare metal: every host can serve it, and that is a property of the
+    // toolchain rather than a claim about payload coverage. clang and lld are
+    // cross-compilers by construction — one binary emits every target it was
+    // built with — so a freestanding target needs NO per-host cross payload,
+    // unlike every hosted case above, which needs a C library that only exists
+    // for some (host, target) pairs.
+    //
+    // ⚠️ Serviceable is not the same as complete: a target with no C library
+    // still links only `-nostdlib` programs. That gap belongs to the ecosystem
+    // (a libc wrapper package), and saying `false` here would hide it behind
+    // "this host cannot build it", which is the wrong diagnosis.
+    if (target.is_freestanding()) return true;
+
     return false;
 }
 

--- a/src/toolchain/triple.cppm
+++ b/src/toolchain/triple.cppm
@@ -49,6 +49,11 @@ struct Triple {
     bool is_windows_gnu() const { return os == "windows" && env == "gnu"; }
     bool is_pe() const          { return os == "windows"; }
 
+    // Bare metal: there is no OS to link against. THE predicate every
+    // freestanding decision keys off, spelled once here so no consumer
+    // re-derives it from `os == "none"` and drifts.
+    bool is_freestanding() const { return os == "none"; }
+
     // cfg() `family` dimension: unix | windows.
     std::string family() const {
         if (os == "windows") return "windows";
@@ -109,6 +114,14 @@ inline constexpr TargetInfo kKnownTargets[] = {
     { "riscv64-linux-musl",    "planned",   "",    "",           true  },
     { "aarch64-linux-gnu",     "planned",   "",    "",           false },
     { "x86_64-macos",          "planned",   "",    "",           false },
+    // Bare metal. `defaultStatic` is not a preference here — there is no
+    // loader, so there is no other option. The pin is llvm on every host
+    // because clang/lld are cross-compilers by construction: unlike the hosted
+    // rows above, these need no per-host cross payload at all.
+    // ISA profile (-march/-mabi/-mcmodel) lives in mcpp.freestanding.target,
+    // which is the single place that decision is made.
+    { "riscv64-none-elf",      "verified",  "bare","llvm@22.1.8", true  },
+    { "riscv32-none-elf",      "verified",  "bare","llvm@22.1.8", true  },
 };
 
 inline std::span<const TargetInfo> known_targets() { return kKnownTargets; }
@@ -290,10 +303,34 @@ std::optional<Triple> parse(std::string_view s) {
     Triple t;
     t.arch = normalize_arch(tok[0]);
 
+    // `none` is BOTH a vendor segment and an OS segment, and which one it is
+    // depends on the rest of the triple, not on its position:
+    //
+    //   riscv64-none-elf        -> vendor absent, OS = none   (bare metal)
+    //   x86_64-none-linux-gnu   -> vendor = none, OS = linux  (hosted)
+    //
+    // So it cannot be decided inside the single left-to-right pass below — by
+    // the time `none` is seen, `linux` has not been read yet. Pre-scan for a
+    // real OS token first; `none` is the OS only when there is no other
+    // candidate. Getting this backwards is not a parse error, it is a SILENT
+    // one: the triple would parse as hosted and the build would produce a host
+    // binary while reporting success.
+    bool hasRealOs = false;
+    for (std::size_t i = 1; i < tok.size(); ++i) {
+        std::string_view k = tok[i];
+        if (k == "linux" || k == "windows" || k == "apple"
+            || starts_with(k, "darwin") || starts_with(k, "macosx")
+            || starts_with(k, "macos")  || starts_with(k, "mingw")) {
+            hasRealOs = true;
+            break;
+        }
+    }
+
     bool sawOs = false;
     for (std::size_t i = 1; i < tok.size(); ++i) {
         std::string_view k = tok[i];
         if (k.empty()) return std::nullopt;
+        if (k == "none" && !hasRealOs) { t.os = "none"; sawOs = true; continue; }
         // Vendor segments carry no information — skip. ("w64" is mingw-w64's
         // vendor; "apple" implies macOS when no OS token follows.)
         if (k == "unknown" || k == "pc" || k == "w64" || k == "none") continue;
@@ -307,6 +344,15 @@ std::optional<Triple> parse(std::string_view s) {
         // "mingw32" is the GNU os segment for ALL MinGW targets (64-bit
         // included — historical residue); it means windows + gnu env.
         if (starts_with(k, "mingw"))            { t.os = "windows"; sawOs = true; t.env = "gnu"; continue; }
+
+        // Bare-metal object-format / ABI segments. Only meaningful with
+        // os=none: `riscv64-none-elf`, `arm-none-eabi`, `arm-none-eabihf`.
+        // Gated on the OS so a hosted triple cannot pick them up by accident.
+        if (t.os == "none") {
+            if (k == "elf")                { t.env = "elf";    continue; }
+            if (k == "eabihf")             { t.env = "eabihf"; continue; }
+            if (k == "eabi")               { t.env = "eabi";   continue; }
+        }
 
         if (t.os != "macos") {
             if (k == "musl" || starts_with(k, "musleabi")) { t.env = "musl"; continue; }

--- a/tests/e2e/130_freestanding_riscv_build_and_run.sh
+++ b/tests/e2e/130_freestanding_riscv_build_and_run.sh
@@ -1,22 +1,16 @@
 #!/usr/bin/env bash
-# requires: llvm qemu-riscv unix-shell
+# requires-hard: llvm qemu-riscv unix-shell
 # Bare metal, end to end: `mcpp build --target riscv64-none-elf` produces a
 # RISC-V firmware image from a C++20 MODULE interface unit plus assembly, and
 # `mcpp run --target-triple` boots it in qemu.
 #
-# ⚠️ SOFT `requires:`, and the guard lives elsewhere on purpose.
-#
-# `requires-hard:` (missing capability FAILS instead of skipping) exists and is
-# the right tool for "this runner is misconfigured" — but it cannot express
-# THIS test's condition. qemu-riscv is legitimately absent on the macOS and
-# Windows e2e runners, so a hard token here would make those jobs
-# structurally red forever, which is a worse failure than the one it prevents.
-#
-# The thing that must not happen — this test silently skipping on the runner
-# that is supposed to run it, leaving the bare-metal chain unexercised while
-# the job stays green — is guarded in ci-linux-e2e.yml, which installs
-# qemu-riscv and then asserts this test's PASS line actually appeared. A guard
-# belongs where it can be exact.
+# ⚠️ `requires-hard`, not `requires`. Every capability here is one a runner
+# that runs this file is supposed to have: llvm is mcpp's own payload and
+# qemu-riscv is an xim package. Declared the soft way, a runner that lost
+# either would report SKIP — indistinguishable from "inapplicable on this
+# platform" — and the one test that proves the bare-metal chain works would
+# stop running while the job stayed green. That has happened twice in this
+# repository already.
 #
 # What each assertion is FOR (none of them is decoration):
 #

--- a/tests/e2e/130_freestanding_riscv_build_and_run.sh
+++ b/tests/e2e/130_freestanding_riscv_build_and_run.sh
@@ -1,16 +1,28 @@
 #!/usr/bin/env bash
-# requires-hard: llvm qemu-riscv unix-shell
+# requires: llvm qemu-riscv unix-shell
 # Bare metal, end to end: `mcpp build --target riscv64-none-elf` produces a
 # RISC-V firmware image from a C++20 MODULE interface unit plus assembly, and
 # `mcpp run --target-triple` boots it in qemu.
 #
-# ⚠️ `requires-hard`, not `requires`. Every capability here is one a runner
-# that runs this file is supposed to have: llvm is mcpp's own payload and
-# qemu-riscv is an xim package. Declared the soft way, a runner that lost
-# either would report SKIP — indistinguishable from "inapplicable on this
-# platform" — and the one test that proves the bare-metal chain works would
-# stop running while the job stayed green. That has happened twice in this
-# repository already.
+# ⚠️ SOFT `requires:`, and the guard lives elsewhere on purpose.
+#
+# `requires-hard:` (missing capability FAILS instead of skipping) exists and is
+# the right tool for "this runner is misconfigured" — but it cannot express
+# THIS test's condition. Neither `llvm` nor `qemu-riscv` is present on the
+# macOS and Windows e2e runners, so a hard token here makes those jobs
+# structurally red forever — measured, not predicted: this file shipped with
+# `requires-hard` for one round and the macOS suite reported
+#
+#     FAIL: 130_freestanding_riscv_build_and_run.sh
+#           (REQUIRED capability missing: llvm)
+#
+# which is a worse failure than the one it was meant to prevent.
+#
+# The thing that must not happen — this test silently skipping on the runner
+# that is supposed to run it, leaving the bare-metal chain unexercised while
+# the job stays green — is guarded in ci-linux-e2e.yml, which installs the
+# capabilities and then asserts this test's PASS line actually appeared. A
+# guard belongs where it can be exact about which runner it is talking about.
 #
 # What each assertion is FOR (none of them is decoration):
 #

--- a/tests/e2e/130_freestanding_riscv_build_and_run.sh
+++ b/tests/e2e/130_freestanding_riscv_build_and_run.sh
@@ -41,6 +41,21 @@
 #   the printed line    the MODULE actually executed on the emulated hart.
 set -e
 
+# Resolve the emulator to a PATH-independent absolute path.
+#
+# The runner template may name it bare — that is what a user writes — but this
+# test is about mcpp's runner MECHANISM, not about shim/home topology. Measured
+# in CI: `qemu-system-riscv64 --version` succeeded in one step while `mcpp run`
+# execing the same bare name answered "xlings: 'qemu-system-riscv64' is not
+# installed", because the shim on PATH dispatches against its owner home. A
+# real BSP has the same information and would emit an absolute path too.
+QEMU="$(command -v qemu-system-riscv64 || true)"
+for d in "$HOME"/.mcpp/registry/data/xpkgs/*-x-qemu-riscv/*/bin \
+         "$HOME"/.xlings/data/xpkgs/*-x-qemu-riscv/*/bin; do
+    [[ -x "$d/qemu-system-riscv64" ]] && QEMU="$d/qemu-system-riscv64"
+done
+[[ -n "$QEMU" ]] || { echo "SKIP: no qemu-system-riscv64"; exit 0; }
+
 TMP=$(mktemp -d)
 trap "rm -rf $TMP" EXIT
 cd "$TMP"
@@ -103,9 +118,10 @@ kind = "bin"
 main = "src/start.S"
 
 [target.riscv64-none-elf]
-runner = ["qemu-system-riscv64", "-machine", "virt", "-nographic",
+runner = ["QEMU_PATH", "-machine", "virt", "-nographic",
           "-no-reboot", "-bios", "default", "-kernel"]
 EOF
+sed -i "s|QEMU_PATH|$QEMU|" mcpp.toml
 
 # ── build ───────────────────────────────────────────────────────────────────
 "$MCPP" build --target riscv64-none-elf > build.log 2>&1 || {

--- a/tests/e2e/130_freestanding_riscv_build_and_run.sh
+++ b/tests/e2e/130_freestanding_riscv_build_and_run.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# requires: llvm qemu-riscv unix-shell
+# Bare metal, end to end: `mcpp build --target riscv64-none-elf` produces a
+# RISC-V firmware image from a C++20 MODULE interface unit plus assembly, and
+# `mcpp run --target-triple` boots it in qemu.
+#
+# ⚠️ SOFT `requires:`, and the guard lives elsewhere on purpose.
+#
+# `requires-hard:` (missing capability FAILS instead of skipping) exists and is
+# the right tool for "this runner is misconfigured" — but it cannot express
+# THIS test's condition. qemu-riscv is legitimately absent on the macOS and
+# Windows e2e runners, so a hard token here would make those jobs
+# structurally red forever, which is a worse failure than the one it prevents.
+#
+# The thing that must not happen — this test silently skipping on the runner
+# that is supposed to run it, leaving the bare-metal chain unexercised while
+# the job stays green — is guarded in ci-linux-e2e.yml, which installs
+# qemu-riscv and then asserts this test's PASS line actually appeared. A guard
+# belongs where it can be exact.
+#
+# What each assertion is FOR (none of them is decoration):
+#
+#   UCB RISC-V          the artifact is for the target, not the host. Before
+#                       the retargetable-driver fix, `--target riscv64-none-elf`
+#                       resolved clang, reported success, and emitted an x86-64
+#                       binary into target/x86_64-linux-gnu/.
+#   no PT_INTERP        no dynamic loader was requested. The llvm payload's
+#                       clang.cfg carries an unconditional
+#                       `-Wl,--dynamic-linker=…/ld-linux-x86-64.so.2`, and a
+#                       freestanding link that loses `--no-default-config`
+#                       bakes an x86-64 interpreter into a RISC-V image — which
+#                       links clean and reports success.
+#   no undefined syms   nothing was left for a libc that is not there.
+#   entry == 0x80200000 the linker script was honoured; qemu `virt` loads here.
+#   the printed line    the MODULE actually executed on the emulated hart.
+set -e
+
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+cd "$TMP"
+
+"$MCPP" new fw > /dev/null
+cd fw
+rm -f src/main.cpp
+
+cat > src/start.S <<'EOF'
+.section .text.start
+.globl _start
+_start:
+    la sp, stack_top
+    call kmain
+1:  wfi
+    j 1b
+.section .bss
+.align 12
+stack:
+    .space 4096
+stack_top:
+EOF
+
+cat > src/kmain.cppm <<'EOF'
+export module kmain;
+namespace {
+    // qemu `virt`'s 16550 UART.
+    volatile char* const kUart = reinterpret_cast<volatile char*>(0x10000000);
+    void put(char c) { *kUart = c; }
+}
+export extern "C" void kmain() {
+    for (const char* s = "MCPP-FREESTANDING-OK\n"; *s; ++s) put(*s);
+    // Poweroff through the virt machine's syscon, so the run ends on the
+    // firmware's terms rather than on a timeout.
+    *reinterpret_cast<volatile unsigned int*>(0x100000) = 0x5555;
+}
+EOF
+
+cat > link.ld <<'EOF'
+ENTRY(_start)
+SECTIONS {
+  . = 0x80200000;
+  .text   : { *(.text.start) *(.text*) }
+  .rodata : { *(.rodata*) }
+  .data   : { *(.data*) }
+  .bss    : { *(.bss*) *(COMMON) }
+}
+EOF
+
+cat > mcpp.toml <<EOF
+[package]
+name    = "fw"
+version = "0.1.0"
+
+[build]
+ldflags = ["-T", "$TMP/fw/link.ld"]
+
+[targets.firmware]
+kind = "bin"
+main = "src/start.S"
+
+[target.riscv64-none-elf]
+runner = ["qemu-system-riscv64", "-machine", "virt", "-nographic",
+          "-no-reboot", "-bios", "default", "-kernel"]
+EOF
+
+# ── build ───────────────────────────────────────────────────────────────────
+"$MCPP" build --target riscv64-none-elf > build.log 2>&1 || {
+    cat build.log; echo "bare-metal build failed"; exit 1; }
+
+img="$(find target/riscv64-none-elf -name firmware -type f | head -1)"
+[[ -n "$img" ]] || {
+    echo "no artifact under target/riscv64-none-elf/ — built for the wrong target?"
+    find target -maxdepth 1 -type d; exit 1; }
+
+file "$img" | grep -q 'UCB RISC-V' || {
+    echo "artifact is not a RISC-V image: $(file "$img")"; exit 1; }
+
+# `if`, not `! cmd | grep -q`: a `!`-prefixed pipeline is exempt from errexit
+# and would never fail the test.
+if readelf -l "$img" | grep -q INTERP; then
+    echo "artifact requests a dynamic interpreter:"
+    readelf -l "$img" | grep -A1 INTERP
+    exit 1
+fi
+
+LLVM_NM=""
+for d in "$HOME"/.mcpp/registry/data/xpkgs/xim-x-llvm/*/bin \
+         "$HOME"/.xlings/data/xpkgs/xim-x-llvm/*/bin; do
+    [[ -x "$d/llvm-nm" ]] && LLVM_NM="$d/llvm-nm"
+done
+if [[ -n "$LLVM_NM" ]]; then
+    undef="$("$LLVM_NM" -u "$img" | wc -l)"
+    [[ "$undef" -eq 0 ]] || {
+        echo "artifact has $undef undefined symbols:"; "$LLVM_NM" -u "$img"; exit 1; }
+fi
+
+readelf -h "$img" | grep -q '0x80200000' || {
+    echo "entry point is not 0x80200000 — the linker script was not applied:"
+    readelf -h "$img" | grep -i entry; exit 1; }
+
+# ── run ─────────────────────────────────────────────────────────────────────
+"$MCPP" run --target-triple riscv64-none-elf > run.log 2>&1 || true
+grep -q 'MCPP-FREESTANDING-OK' run.log || {
+    cat run.log; echo "the firmware did not run (or produced no output)"; exit 1; }
+
+# ── the runner is REQUIRED, and its absence must say so ─────────────────────
+# Two-sided: without this, "run worked" could equally mean mcpp exec'd the
+# image directly and something else printed the line.
+python3 - "$TMP/fw/mcpp.toml" <<'PY'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1])
+t = p.read_text()
+i = t.index("[target.riscv64-none-elf]")
+p.write_text(t[:i])
+PY
+if "$MCPP" run --target-triple riscv64-none-elf > norunner.log 2>&1; then
+    cat norunner.log
+    echo "running with no runner configured should have failed"
+    exit 1
+fi
+grep -q 'no runner is configured' norunner.log || {
+    cat norunner.log; echo "missing-runner diagnostic did not name the problem"; exit 1; }
+grep -q 'target.riscv64-none-elf' norunner.log || {
+    cat norunner.log; echo "diagnostic did not name the manifest key to add"; exit 1; }
+
+echo "PASS: freestanding riscv64 build + run"

--- a/tests/e2e/131_freestanding_bsp_supplies_everything.sh
+++ b/tests/e2e/131_freestanding_bsp_supplies_everything.sh
@@ -27,7 +27,6 @@
 # internals mcpp is free to change.
 set -e
 
-command -v qemu-system-riscv64 >/dev/null || { echo "SKIP: no qemu"; exit 0; }
 
 # The sysroot has to be installed in the home MCPP uses, which is not
 # necessarily the ambient xlings home. Skip rather than fail: this test is
@@ -35,6 +34,21 @@ command -v qemu-system-riscv64 >/dev/null || { echo "SKIP: no qemu"; exit 0; }
 MH="${MCPP_HOME:-$HOME/.mcpp}"
 SYSROOT_ROOT="$MH/registry/data/xpkgs/xim-x-picolibc-riscv"
 [[ -d "$SYSROOT_ROOT" ]] || { echo "SKIP: xim:picolibc-riscv not installed in $MH"; exit 0; }
+
+# Resolve the emulator to a PATH-independent absolute path.
+#
+# The runner template may name it bare — that is what a user writes — but this
+# test is about mcpp's runner MECHANISM, not about shim/home topology. Measured
+# in CI: `qemu-system-riscv64 --version` succeeded in one step while `mcpp run`
+# execing the same bare name answered "xlings: 'qemu-system-riscv64' is not
+# installed", because the shim on PATH dispatches against its owner home. A
+# real BSP has the same information and would emit an absolute path too.
+QEMU="$(command -v qemu-system-riscv64 || true)"
+for d in "$HOME"/.mcpp/registry/data/xpkgs/*-x-qemu-riscv/*/bin \
+         "$HOME"/.xlings/data/xpkgs/*-x-qemu-riscv/*/bin; do
+    [[ -x "$d/qemu-system-riscv64" ]] && QEMU="$d/qemu-system-riscv64"
+done
+[[ -n "$QEMU" ]] || { echo "SKIP: no qemu-system-riscv64"; exit 0; }
 
 TMP=$(mktemp -d)
 trap "rm -rf $TMP" EXIT
@@ -136,9 +150,10 @@ kind = "bin"
 main = "src/main.cpp"
 
 [target.riscv64-none-elf]
-runner = ["qemu-system-riscv64", "-machine", "virt", "-nographic",
+runner = ["QEMU_PATH", "-machine", "virt", "-nographic",
           "-no-reboot", "-semihosting", "-bios", "none", "-kernel"]
 EOF
+sed -i "s|QEMU_PATH|$QEMU|" mcpp.toml
 
 "$MCPP" run --target-triple riscv64-none-elf > run.log 2>&1 || true
 grep -q 'BSP-CHAIN-OK 42' run.log || {

--- a/tests/e2e/131_freestanding_bsp_supplies_everything.sh
+++ b/tests/e2e/131_freestanding_bsp_supplies_everything.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# requires: llvm qemu-riscv unix-shell
+# The ecosystem shape: a BOARD-SUPPORT package supplies the C library, the
+# startup code, the memory layout and the ISA profile, and the consumer's
+# manifest says only "depend on it".
+#
+# What this proves that 130 does not: 130 shows the ENGINE can build and boot a
+# freestanding image, but its project still writes the linker script itself and
+# calls no libc. That is "mcpp supports bare metal". This is the thing after
+# it — a user who never types picolibc, compiler-rt, crt0, `-nostdlib`,
+# `-mcmodel` or a load address, and still gets `printf` with a float.
+#
+# ⚠️ THE SEAM UNDER TEST (measured 2026-08-19, probe Z1)
+#
+#   link-search / link-lib / link-script   Scope::LinkGlobal   → reach the consumer
+#   include-dir / cflag / cfg              Scope::PackagePrivate → do NOT
+#
+# That asymmetry is deliberate (a build-time program must not silently widen a
+# package's public compile interface), and it is why the BSP includes the
+# target's libc headers PRIVATELY and exports a C++ module. A consumer that
+# could `#include <stdio.h>` would be getting a header for a target its own TU
+# may not be built for.
+#
+# It also depends on `xpkg_dir` — the interface that answers "where did the
+# package I declared in [xlings] deps land". Without it the BSP would have to
+# reconstruct `<home>/data/xpkgs/<ns>-x-<name>/<version>`, which is store
+# internals mcpp is free to change.
+set -e
+
+command -v qemu-system-riscv64 >/dev/null || { echo "SKIP: no qemu"; exit 0; }
+
+# The sysroot has to be installed in the home MCPP uses, which is not
+# necessarily the ambient xlings home. Skip rather than fail: this test is
+# about the seam, and a missing payload is an environment fact.
+MH="${MCPP_HOME:-$HOME/.mcpp}"
+SYSROOT_ROOT="$MH/registry/data/xpkgs/xim-x-picolibc-riscv"
+[[ -d "$SYSROOT_ROOT" ]] || { echo "SKIP: xim:picolibc-riscv not installed in $MH"; exit 0; }
+
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+cd "$TMP"
+
+# ── the board-support package ───────────────────────────────────────────────
+"$MCPP" new board > /dev/null
+cd board
+rm -f src/main.cpp
+
+cat > mcpp.toml <<'EOF'
+[package]
+name    = "board"
+version = "0.1.0"
+
+[xlings]
+deps = ["xim:picolibc-riscv@1.8.12"]
+EOF
+
+cat > build.mcpp <<'EOF'
+import std;
+int main() {
+    // The interface, not a reconstructed store path.
+    const char* sysroot = std::getenv("MCPP_XPKG_XIM_PICOLIBC_RISCV_DIR");
+    if (!sysroot || !*sysroot) {
+        std::cerr << "board: xim:picolibc-riscv declared but not installed\n";
+        return 1;
+    }
+    // The profile comes from the target mcpp resolved, so the same BSP serves
+    // rv32 by reading one variable rather than by being forked.
+    std::string arch = std::getenv("MCPP_TARGET_ARCH") ?: "";
+    std::string prof = (arch == "riscv32") ? "rv32imac/ilp32" : "rv64gc/lp64d";
+    std::string rt   = (arch == "riscv32") ? "riscv32" : "riscv64";
+    std::string lib  = std::format("{}/lib/{}", sysroot, prof);
+
+    // PACKAGE-PRIVATE on purpose: these are riscv*-none-elf headers.
+    std::println("mcpp:include-dir={}/include/{}", sysroot, prof);
+    // LinkGlobal — these reach the consumer's link line.
+    std::println("mcpp:link-search={}", lib);
+    std::println("mcpp:link-lib=crt0-semihost");
+    std::println("mcpp:link-lib=c");
+    std::println("mcpp:link-lib=semihost");
+    std::println("mcpp:link-lib=clang_rt.builtins-{}", rt);
+    std::println("mcpp:link-script={}/picolibcpp.ld", lib);
+    std::println("mcpp:rerun-if-env-changed=MCPP_TARGET_ARCH");
+    return 0;
+}
+EOF
+
+cat > src/board.cppm <<'EOF'
+module;
+// Private to this package — see the include-dir note in build.mcpp.
+#include <stdio.h>
+#include <stdlib.h>
+export module board;
+export namespace board {
+    inline void  print(const char* s)             { fputs(s, stdout); }
+    inline void  printf_d(const char* f, int v)   { printf(f, v); }
+    inline void  printf_f(const char* f, double v){ printf(f, v); }
+    inline void* alloc(unsigned long n)           { return malloc(n); }
+    inline void  release(void* p)                 { free(p); }
+}
+EOF
+
+# ── the consumer ────────────────────────────────────────────────────────────
+cd "$TMP"
+"$MCPP" new fw > /dev/null
+cd fw
+
+cat > src/main.cpp <<'EOF'
+import board;
+extern "C" int main() {
+    board::printf_d("BSP-CHAIN-OK %d\n", 42);
+    // A FLOAT on purpose: picolibc's ryu formatting does 128-bit shifts, and
+    // that is the only ordinary operation needing __ashlti3/__lshrti3 on
+    // rv64gc. A 64-bit division would NOT reach it — rv64gc has a hardware
+    // divu — so a "does arithmetic work" test is a false green for the
+    // builtins the BSP links.
+    board::printf_f("float %.4f\n", 3.14159);
+    void* p = board::alloc(64);
+    board::print(p ? "MALLOC-OK\n" : "MALLOC-FAIL\n");
+    board::release(p);
+    return 0;
+}
+EOF
+
+# ⚠️ This manifest IS the assertion. Nothing here names picolibc, compiler-rt,
+# crt0, a linker script, a load address, -nostdlib or -mcmodel.
+cat > mcpp.toml <<'EOF'
+[package]
+name    = "fw"
+version = "0.1.0"
+
+[dependencies]
+board = { path = "../board" }
+
+[targets.firmware]
+kind = "bin"
+main = "src/main.cpp"
+
+[target.riscv64-none-elf]
+runner = ["qemu-system-riscv64", "-machine", "virt", "-nographic",
+          "-no-reboot", "-semihosting", "-bios", "none", "-kernel"]
+EOF
+
+"$MCPP" run --target-triple riscv64-none-elf > run.log 2>&1 || true
+grep -q 'BSP-CHAIN-OK 42' run.log || {
+    cat run.log; echo "the consumer did not run"; exit 1; }
+grep -q 'float 3.1416'   run.log || {
+    cat run.log; echo "float printf failed — builtins missing from the link?"; exit 1; }
+grep -q 'MALLOC-OK'      run.log || {
+    cat run.log; echo "the heap is not wired"; exit 1; }
+
+# ── the private half of the seam, pinned from the other side ────────────────
+# If include-dir DID reach the consumer, this would compile — and the whole
+# reason the BSP exports a module would be gone.
+cat > src/main.cpp <<'EOF'
+#include <stdio.h>
+extern "C" int main() { printf("leaked\n"); return 0; }
+EOF
+if "$MCPP" build --target riscv64-none-elf > leak.log 2>&1; then
+    echo "a dependency's include-dir reached the consumer — it is supposed to be"
+    echo "package-private (mcpp.build.directives, Scope::PackagePrivate)"
+    exit 1
+fi
+
+echo "PASS: BSP supplies the sysroot, linker script and runtime; consumer only depends on it"

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -62,6 +62,9 @@ case "$OS" in
         fi
         # wine: run cross-built Windows PE artifacts on the Linux host.
         command -v wine &>/dev/null && CAPS+=(wine)
+        # qemu-riscv: the emulator a bare-metal riscv artifact runs in
+        # (xim:qemu-riscv, or any qemu-system-riscv64 on PATH).
+        command -v qemu-system-riscv64 &>/dev/null && CAPS+=(qemu-riscv)
         # pack capability: ELF + patchelf both required
         if [[ " ${CAPS[*]} " == *" patchelf "* ]]; then
             CAPS+=(pack)
@@ -175,16 +178,17 @@ echo "Detected capabilities: ${CAPS[*]:-<none>}"
 # absent on Linux and must stay legal to declare. It is checked against the
 # CAPS+=() calls above by tests/e2e/README or by reading them -- keep it in
 # sync when adding a capability.
-KNOWN_CAPS=(elf fresh-sandbox gcc import-std-libcxx macos mingw mingw-cross msvc
-            musl nasm no-msvc pack patchelf python3 scan-deps symlink unix-shell
-            windows wine xlings-msvc)
+KNOWN_CAPS=(elf fresh-sandbox gcc import-std-libcxx llvm macos mingw mingw-cross
+            msvc musl nasm no-msvc pack patchelf python3 qemu-riscv scan-deps
+            symlink unix-shell windows wine xlings-msvc)
 
 bad_tokens=0
 for tf in "$HERE"/[0-9]*.sh; do
     base="$(basename "$tf")"
     req="$(sed -n '2p' "$tf")"
-    [[ "$req" =~ ^#\ requires: ]] || continue
+    [[ "$req" =~ ^#\ requires(-hard)?: ]] || continue
     toks="${req#\# requires:}"
+    toks="${toks#\# requires-hard:}"
     for tok in $toks; do
         if [[ " ${KNOWN_CAPS[*]} " != *" $tok "* ]]; then
             echo "ERROR: $base declares unknown capability '$tok' — it would be"
@@ -202,6 +206,19 @@ done
 # Returns 0 (true) if the test should be skipped, prints reason.
 # Returns 1 (false) if all requirements are met.
 
+# `# requires-hard:` — a missing capability FAILS instead of skipping.
+#
+# The ordinary form is right for a test that is genuinely inapplicable here
+# (msvc on Linux). It is wrong for a test whose capability the runner is
+# SUPPOSED to have: the skip line is indistinguishable from a legitimate one,
+# so a job that silently stopped exercising the thing it exists to exercise
+# stays green forever. This repository has hit that twice (65_* never ran at
+# all; ten pack e2e skipped on two platforms). A test that declares its needs
+# with the hard form says "if this is missing, the runner is misconfigured".
+requires_is_hard() {
+    [[ "$(sed -n '2p' "$1")" =~ ^#\ requires-hard: ]]
+}
+
 check_requires() {
     local test_file="$1"
     # Read the # requires: line (must be line 2 of the script)
@@ -209,9 +226,10 @@ check_requires() {
     req_line="$(sed -n '2p' "$test_file")"
 
     # If there's no requires comment at all, run the test
-    [[ "$req_line" =~ ^#\ requires: ]] || return 1
+    [[ "$req_line" =~ ^#\ requires(-hard)?: ]] || return 1
 
     local caps_needed="${req_line#\# requires:}"
+    caps_needed="${caps_needed#\# requires-hard:}"
     caps_needed="${caps_needed# }"   # strip leading space
 
     # Empty requirements → runs everywhere
@@ -313,6 +331,14 @@ for test in "$HERE"/[0-9]*.sh; do
     echo
     missing_cap="$(check_requires "$test")"
     if [[ -n "$missing_cap" ]]; then
+        if requires_is_hard "$test"; then
+            echo "FAIL: $name (REQUIRED capability missing: $missing_cap)"
+            echo "      declared with '# requires-hard:', so this runner is"
+            echo "      misconfigured rather than merely inapplicable."
+            FAILED_TESTS+=("$name (REQUIRED capability missing: $missing_cap)")
+            ((FAIL++))
+            continue
+        fi
         echo "SKIP: $name (missing capability: $missing_cap)"
         ((SKIP++))
         continue

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -186,9 +186,8 @@ bad_tokens=0
 for tf in "$HERE"/[0-9]*.sh; do
     base="$(basename "$tf")"
     req="$(sed -n '2p' "$tf")"
-    [[ "$req" =~ ^#\ requires(-hard)?: ]] || continue
+    [[ "$req" =~ ^#\ requires: ]] || continue
     toks="${req#\# requires:}"
-    toks="${toks#\# requires-hard:}"
     for tok in $toks; do
         if [[ " ${KNOWN_CAPS[*]} " != *" $tok "* ]]; then
             echo "ERROR: $base declares unknown capability '$tok' — it would be"
@@ -206,18 +205,22 @@ done
 # Returns 0 (true) if the test should be skipped, prints reason.
 # Returns 1 (false) if all requirements are met.
 
-# `# requires-hard:` — a missing capability FAILS instead of skipping.
+# ⚠️ THERE IS DELIBERATELY NO "requires-hard" FORM.
 #
-# The ordinary form is right for a test that is genuinely inapplicable here
-# (msvc on Linux). It is wrong for a test whose capability the runner is
-# SUPPOSED to have: the skip line is indistinguishable from a legitimate one,
-# so a job that silently stopped exercising the thing it exists to exercise
-# stays green forever. This repository has hit that twice (65_* never ran at
-# all; ten pack e2e skipped on two platforms). A test that declares its needs
-# with the hard form says "if this is missing, the runner is misconfigured".
-requires_is_hard() {
-    [[ "$(sed -n '2p' "$1")" =~ ^#\ requires-hard: ]]
-}
+# The obvious answer to "a test silently skipped on the runner that was
+# supposed to run it" is a token whose absence FAILS. It was implemented here,
+# used once, and measured wrong: a token cannot tell "this runner is
+# misconfigured" from "this platform legitimately lacks the capability",
+# because the same word means both. `llvm` and `qemu-riscv` are absent on the
+# macOS runner by design, so the one test that declared them the hard way made
+# the macOS suite fail — a worse outcome than the silent skip it was meant to
+# prevent, and one CI reported within the hour.
+#
+# The guard that works has to know WHICH runner it is talking about, so it
+# lives in the job: ci-linux-e2e.yml's `baremetal` job installs the
+# capabilities and then asserts the tests' PASS lines actually appeared.
+# `run_all.sh` exits 0 on a skip, so its exit code cannot answer that question
+# and no token can either.
 
 check_requires() {
     local test_file="$1"
@@ -226,10 +229,9 @@ check_requires() {
     req_line="$(sed -n '2p' "$test_file")"
 
     # If there's no requires comment at all, run the test
-    [[ "$req_line" =~ ^#\ requires(-hard)?: ]] || return 1
+    [[ "$req_line" =~ ^#\ requires: ]] || return 1
 
     local caps_needed="${req_line#\# requires:}"
-    caps_needed="${caps_needed#\# requires-hard:}"
     caps_needed="${caps_needed# }"   # strip leading space
 
     # Empty requirements → runs everywhere
@@ -331,14 +333,6 @@ for test in "$HERE"/[0-9]*.sh; do
     echo
     missing_cap="$(check_requires "$test")"
     if [[ -n "$missing_cap" ]]; then
-        if requires_is_hard "$test"; then
-            echo "FAIL: $name (REQUIRED capability missing: $missing_cap)"
-            echo "      declared with '# requires-hard:', so this runner is"
-            echo "      misconfigured rather than merely inapplicable."
-            FAILED_TESTS+=("$name (REQUIRED capability missing: $missing_cap)")
-            ((FAIL++))
-            continue
-        fi
         echo "SKIP: $name (missing capability: $missing_cap)"
         ((SKIP++))
         continue

--- a/tests/unit/test_build_directives.cpp
+++ b/tests/unit/test_build_directives.cpp
@@ -491,3 +491,47 @@ TEST(BuildDirectives, GlobDirectiveParsesIntoItsOwnSlot) {
     dirs::serialize(os, d);
     EXPECT_EQ(os.str().find("proto/**"), std::string::npos) << os.str();
 }
+
+// ── link-script ────────────────────────────────────────────────────────────
+//
+// The row exists so a board-support package can hand a consumer the board's
+// memory layout. Everything else that could carry it is either package-private
+// (`cxxflag`) or cannot express the flag at all (`link-lib` emits `-l`,
+// `link-search` emits `-L`) — so without it the one thing a user cannot write
+// for themselves was the one thing they had to.
+
+TEST(BuildDirectives, LinkScriptBecomesDashTWithAnAbsolutePath) {
+    auto d = parse("mcpp:link-script=board/link.ld\n");
+    auto& ld = d.at(dirs::Slot::LdFlags);
+    ASSERT_EQ(ld.size(), 1u);
+    // Absolute, because the link runs in the build directory: a relative path
+    // resolves against the wrong root and lld answers "cannot find linker
+    // script link.ld" (measured).
+    EXPECT_EQ(ld[0], "-T " + under_root("board/link.ld"));
+}
+
+TEST(BuildDirectives, LinkScriptIsLinkGlobalSoItReachesTheConsumer) {
+    // The whole point: a dependency's build.mcpp must be able to widen the
+    // LINK (as link-lib/link-search already do) without widening the public
+    // COMPILE interface (which include-dir deliberately cannot).
+    const dirs::Def* script = nullptr;
+    const dirs::Def* incdir = nullptr;
+    for (auto const& def : dirs::kTable) {
+        if (def.wire == "link-script") script = &def;
+        if (def.wire == "include-dir") incdir = &def;
+    }
+    ASSERT_NE(script, nullptr);
+    ASSERT_NE(incdir, nullptr);
+    EXPECT_EQ(script->scope, dirs::Scope::LinkGlobal);
+    EXPECT_EQ(incdir->scope, dirs::Scope::PackagePrivate);
+}
+
+TEST(BuildDirectives, LinkScriptDoesNotClaimADeclaredOutput) {
+    // `mustExistAfterRun` assumes the value IS a path; this row's transformed
+    // value is `-T <path>`, so the check would test the wrong string and
+    // reject a script that is right there.
+    for (auto const& def : dirs::kTable) {
+        if (def.wire != "link-script") continue;
+        EXPECT_FALSE(def.mustExistAfterRun);
+    }
+}

--- a/tests/unit/test_freestanding.cpp
+++ b/tests/unit/test_freestanding.cpp
@@ -1,0 +1,146 @@
+#include <gtest/gtest.h>
+
+import std;
+import mcpp.freestanding.target;
+import mcpp.freestanding.linkline;
+import mcpp.freestanding.runner;
+import mcpp.toolchain.triple;
+
+using namespace mcpp::freestanding;
+
+// ── the target table ────────────────────────────────────────────────────────
+
+TEST(FreestandingTarget, ResolvesTheKnownBareMetalTriples) {
+    auto rv64 = resolve("riscv64-none-elf");
+    ASSERT_TRUE(rv64.has_value());
+    EXPECT_EQ(rv64->march,  "rv64gc");
+    EXPECT_EQ(rv64->mabi,   "lp64d");
+    EXPECT_EQ(rv64->libdir, "rv64gc/lp64d");
+
+    auto rv32 = resolve("riscv32-none-elf");
+    ASSERT_TRUE(rv32.has_value());
+    EXPECT_EQ(rv32->march,  "rv32imac");
+    EXPECT_EQ(rv32->mabi,   "ilp32");
+    EXPECT_EQ(rv32->libdir, "rv32imac/ilp32");
+}
+
+TEST(FreestandingTarget, HostedTriplesResolveToNothing) {
+    // The same call answers "is this a target I know how to build
+    // freestanding", so a hosted triple must not produce a Spec — a caller
+    // that got one would put -ffreestanding on an ordinary Linux build.
+    for (const char* s : { "x86_64-linux-gnu", "x86_64-linux-musl",
+                           "aarch64-macos", "x86_64-windows-gnu" }) {
+        EXPECT_FALSE(resolve(s).has_value()) << s;
+    }
+}
+
+TEST(FreestandingTarget, UnknownBareMetalTripleIsNotInvented) {
+    // Parses as freestanding, but mcpp has no ISA profile for it. Returning a
+    // Spec here would mean guessing an -march, and a wrong -march produces an
+    // object file that links and then executes garbage.
+    auto t = mcpp::toolchain::triple::parse("arm-none-eabi");
+    ASSERT_TRUE(t.has_value());
+    EXPECT_TRUE(t->is_freestanding());
+    EXPECT_FALSE(resolve(*t).has_value());
+}
+
+TEST(FreestandingTarget, CompileFlagsCarryTheIsaAndFreestanding) {
+    auto s = resolve("riscv64-none-elf");
+    ASSERT_TRUE(s.has_value());
+    auto fl = compile_flags(*s);
+    auto has = [&](std::string_view f) {
+        return std::ranges::find(fl, f) != fl.end();
+    };
+    EXPECT_TRUE(has("-march=rv64gc"));
+    EXPECT_TRUE(has("-mabi=lp64d"));
+    EXPECT_TRUE(has("-mcmodel=medany"));
+    // -ffreestanding is a COMPILE flag, not a link one: it changes what the
+    // compiler may assume about the library, and that has to hold for every
+    // TU including a dependency's.
+    EXPECT_TRUE(has("-ffreestanding"));
+}
+
+// ── the link line ───────────────────────────────────────────────────────────
+
+TEST(FreestandingLink, CarriesTargetSelectionAndRefusesTheHostedWorld) {
+    auto s = resolve("riscv64-none-elf");
+    ASSERT_TRUE(s.has_value());
+    LinkInputs in;
+    in.lld = "/payload/bin/ld.lld";
+    auto line = link_flags(*s, in, [](const std::filesystem::path& p) {
+        return p.string();
+    });
+
+    // --target is the load-bearing one: clang is ONE binary for every target,
+    // so without it the link silently produces host objects.
+    EXPECT_NE(line.find("--target=riscv64-none-elf"), std::string::npos);
+    EXPECT_NE(line.find("-nostdlib"), std::string::npos);
+    EXPECT_NE(line.find("-nostartfiles"), std::string::npos);
+    EXPECT_NE(line.find("-static"), std::string::npos);
+}
+
+TEST(FreestandingLink, AddressesTheLinkerByPathNotByName) {
+    auto s = resolve("riscv64-none-elf");
+    ASSERT_TRUE(s.has_value());
+    LinkInputs in;
+    in.lld = "/payload/bin/ld.lld";
+    auto line = link_flags(*s, in, [](const std::filesystem::path& p) {
+        return p.string();
+    });
+    // `-fuse-ld=lld` resolves through PATH and finds GNU ld on any machine
+    // with binutils earlier on it, which then dies with "unrecognised
+    // emulation mode: elf64lriscv". Reproduced 2026-08-19.
+    EXPECT_NE(line.find("-fuse-ld=/payload/bin/ld.lld"), std::string::npos);
+    EXPECT_EQ(line.find("-fuse-ld=lld "), std::string::npos);
+}
+
+TEST(FreestandingLink, LinkerScriptOnlyWhenOneIsSupplied) {
+    auto s = resolve("riscv64-none-elf");
+    ASSERT_TRUE(s.has_value());
+    auto esc = [](const std::filesystem::path& p) { return p.string(); };
+
+    LinkInputs none;
+    EXPECT_EQ(link_flags(*s, none, esc).find(" -T "), std::string::npos);
+
+    LinkInputs with;
+    with.linkerScript = "/board/link.ld";
+    EXPECT_NE(link_flags(*s, with, esc).find(" -T /board/link.ld"),
+              std::string::npos);
+}
+
+TEST(FreestandingLink, LldIsIdentifiedByItsOwnVersionOutput) {
+    // By output, not by filename — the filename is exactly what was wrong in
+    // the failure this guards.
+    EXPECT_TRUE(version_output_is_lld("LLD 22.1.8 (compatible with GNU linkers)"));
+    EXPECT_FALSE(version_output_is_lld("GNU ld (GNU Binutils for Ubuntu) 2.42"));
+}
+
+// ── the runner ──────────────────────────────────────────────────────────────
+
+TEST(FreestandingRunner, AppendsTheArtifactWhenNoPlaceholder) {
+    std::vector<std::string> tmpl{ "qemu-system-riscv64", "-machine", "virt",
+                                   "-kernel" };
+    auto argv = expand(tmpl, "/build/firmware");
+    ASSERT_EQ(argv.size(), 5u);
+    EXPECT_EQ(argv.front(), "qemu-system-riscv64");
+    EXPECT_EQ(argv.back(),  "/build/firmware");
+}
+
+TEST(FreestandingRunner, SubstitutesThePlaceholderInPlace) {
+    // The emulator that wants the image in the middle rather than at the end.
+    std::vector<std::string> tmpl{ "runner", "--image={}", "--verbose" };
+    auto argv = expand(tmpl, "/build/firmware");
+    ASSERT_EQ(argv.size(), 3u);
+    EXPECT_EQ(argv[1], "--image=/build/firmware");
+    EXPECT_EQ(argv[2], "--verbose");   // nothing appended when substituted
+}
+
+TEST(FreestandingRunner, TheMissingRunnerMessageNamesTheKeyAndTheTriple) {
+    // The user has just been told the build succeeded and the run did not; the
+    // gap between those two is the whole content of the message, so it has to
+    // carry something pasteable.
+    auto msg = no_runner_message("riscv64-none-elf");
+    EXPECT_NE(msg.find("[target.riscv64-none-elf]"), std::string::npos);
+    EXPECT_NE(msg.find("runner = ["), std::string::npos);
+    EXPECT_NE(msg.find("board-support package"), std::string::npos);
+}

--- a/tests/unit/test_freestanding.cpp
+++ b/tests/unit/test_freestanding.cpp
@@ -5,6 +5,8 @@ import mcpp.freestanding.target;
 import mcpp.freestanding.linkline;
 import mcpp.freestanding.runner;
 import mcpp.toolchain.triple;
+import mcpp.platform.xlings;
+import mcpp.build.build_program;
 
 using namespace mcpp::freestanding;
 
@@ -58,6 +60,11 @@ TEST(FreestandingTarget, CompileFlagsCarryTheIsaAndFreestanding) {
     // compiler may assume about the library, and that has to hold for every
     // TU including a dependency's.
     EXPECT_TRUE(has("-ffreestanding"));
+    // The toolchain's libc++ headers are the HOST's: `#include <stdio.h>`
+    // resolves to libc++'s wrapper, which opens a `__config_site` generated
+    // for the host and absent here. A target-side C++ library reaches a
+    // consumer as a MODULE, never as an include path.
+    EXPECT_TRUE(has("-nostdinc++"));
 }
 
 // ── the link line ───────────────────────────────────────────────────────────
@@ -143,4 +150,80 @@ TEST(FreestandingRunner, TheMissingRunnerMessageNamesTheKeyAndTheTriple) {
     EXPECT_NE(msg.find("[target.riscv64-none-elf]"), std::string::npos);
     EXPECT_NE(msg.find("runner = ["), std::string::npos);
     EXPECT_NE(msg.find("board-support package"), std::string::npos);
+}
+
+// ── `[xlings] deps` → payload directory ─────────────────────────────────────
+//
+// The channel a board-support package uses to find the libc payload it
+// declared. An INTERFACE rather than a naming convention: a build.mcpp that
+// reconstructed `<home>/data/xpkgs/<ns>-x-<name>/<version>` would be coupled
+// to store internals mcpp is free to change.
+
+TEST(XpkgRef, ParsesEverySpellingAManifestMayWrite) {
+    using mcpp::xlings::paths::parse_xpkg_ref;
+
+    auto full = parse_xpkg_ref("xim:picolibc-riscv@1.8.12");
+    EXPECT_EQ(full.ns, "xim");
+    EXPECT_EQ(full.name, "picolibc-riscv");
+    EXPECT_EQ(full.version, "1.8.12");
+
+    // No namespace: the manifest's default, spelled once in the parser rather
+    // than at each call site.
+    auto bare = parse_xpkg_ref("ninja");
+    EXPECT_EQ(bare.ns, "xim");
+    EXPECT_EQ(bare.name, "ninja");
+    EXPECT_TRUE(bare.version.empty());
+
+    // A non-xim namespace is ordinary, not exotic: `local:` is what a package
+    // under development resolves to.
+    auto local = parse_xpkg_ref("local:qemu-riscv@9.2.4-1");
+    EXPECT_EQ(local.ns, "local");
+    EXPECT_EQ(local.name, "qemu-riscv");
+    EXPECT_EQ(local.version, "9.2.4-1");
+}
+
+TEST(XpkgPayload, APinnedRefResolvesToThatVersionOrToNothing) {
+    namespace xp = mcpp::xlings::paths;
+    auto base = std::filesystem::temp_directory_path()
+              / std::format("mcpp-xpkg-test-{}", ::getpid());
+    std::filesystem::remove_all(base);
+    std::filesystem::create_directories(base / "xim-x-demo" / "1.0.0");
+    std::filesystem::create_directories(base / "xim-x-demo" / "2.0.0");
+
+    // ⚠️ The whole point: asking for 1.0.0 and silently getting 2.0.0 is an
+    // answer only discovered later, in the artifact.
+    auto pinned = xp::xpkg_payload_at(base, xp::parse_xpkg_ref("xim:demo@1.0.0"));
+    ASSERT_TRUE(pinned.has_value());
+    EXPECT_EQ(pinned->filename(), "1.0.0");
+
+    EXPECT_FALSE(xp::xpkg_payload_at(base, xp::parse_xpkg_ref("xim:demo@9.9.9"))
+                     .has_value());
+
+    std::filesystem::remove_all(base);
+}
+
+TEST(XpkgPayload, AnUnpinnedRefTakesTheHighestVersionNumerically) {
+    namespace xp = mcpp::xlings::paths;
+    auto base = std::filesystem::temp_directory_path()
+              / std::format("mcpp-xpkg-test2-{}", ::getpid());
+    std::filesystem::remove_all(base);
+    for (auto v : { "0.4.2", "0.4.9", "0.4.11" })
+        std::filesystem::create_directories(base / "xim-x-demo" / v);
+
+    // A plain string sort answers 0.4.9; picking the wrong payload is silent.
+    auto latest = xp::xpkg_payload_at(base, xp::parse_xpkg_ref("demo"));
+    ASSERT_TRUE(latest.has_value());
+    EXPECT_EQ(latest->filename(), "0.4.11");
+
+    std::filesystem::remove_all(base);
+}
+
+TEST(XpkgEnvVar, BothSpellingsAreDerivedFromOneSanitizer) {
+    using mcpp::build::xpkg_env_var;
+    // The two sides of the channel must agree; drifting apart would make the
+    // interface answer "" for a package that is right there.
+    EXPECT_EQ(xpkg_env_var("xim", "picolibc-riscv"),
+              "MCPP_XPKG_XIM_PICOLIBC_RISCV_DIR");
+    EXPECT_EQ(xpkg_env_var("", "picolibc-riscv"),
+              "MCPP_XPKG_PICOLIBC_RISCV_DIR");
 }

--- a/tests/unit/test_manifest.cpp
+++ b/tests/unit/test_manifest.cpp
@@ -3590,3 +3590,52 @@ defines = ["FOO=1"]
     // ...and the field itself is gone, so nothing downstream can read it.
     EXPECT_EQ(m->targetOverrides.at("x86_64-linux-gnu").cxxRuntime, "");
 }
+
+// ── [target.<triple>].runner ────────────────────────────────────────────────
+
+TEST(Manifest, TargetRunnerParsesAndDoesNotWarn) {
+    constexpr auto src = R"(
+[package]
+name = "fw"
+version = "0.1.0"
+
+[target.riscv64-none-elf]
+runner = ["qemu-system-riscv64", "-machine", "virt", "-kernel"]
+)";
+    auto m = mcpp::manifest::parse_string(src);
+    ASSERT_TRUE(m.has_value()) << m.error().format();
+    auto it = m->targetOverrides.find("riscv64-none-elf");
+    ASSERT_NE(it, m->targetOverrides.end());
+    ASSERT_EQ(it->second.runner.size(), 4u);
+    EXPECT_EQ(it->second.runner.front(), "qemu-system-riscv64");
+    EXPECT_EQ(it->second.runner.back(),  "-kernel");
+    // ⚠️ The unknown-key sweep is about SCALARS ("a scalar that does
+    // nothing"). It skipped tables but not arrays, so this key was reported as
+    // "unsupported key 'runner' (ignored)" while in fact being honoured —
+    // worse than either statement being true. Seen in CI.
+    EXPECT_TRUE(m->schemaWarnings.empty())
+        << (m->schemaWarnings.empty() ? "" : m->schemaWarnings[0]);
+}
+
+TEST(Manifest, TargetRunnerRejectsShapesThatWouldRunNothing) {
+    // An empty template would exec nothing and report success.
+    constexpr auto empty = R"(
+[package]
+name = "fw"
+version = "0.1.0"
+[target.riscv64-none-elf]
+runner = []
+)";
+    EXPECT_FALSE(mcpp::manifest::parse_string(empty).has_value());
+
+    // A bare string is the shape a user reaches for first; taking it would
+    // mean guessing where the word boundaries are.
+    constexpr auto scalar = R"(
+[package]
+name = "fw"
+version = "0.1.0"
+[target.riscv64-none-elf]
+runner = "qemu-system-riscv64 -kernel"
+)";
+    EXPECT_FALSE(mcpp::manifest::parse_string(scalar).has_value());
+}

--- a/tests/unit/test_toolchain_triple.cpp
+++ b/tests/unit/test_toolchain_triple.cpp
@@ -155,3 +155,62 @@ TEST(Triple, HostTripleIsCanonicalAndNonEmpty) {
     ASSERT_TRUE(reparsed.has_value());
     EXPECT_EQ(reparsed->str(), h.str());
 }
+
+// ── bare metal: `none` is a vendor segment AND an OS segment ─────────────────
+//
+// Which one it is depends on the rest of the triple, so it cannot be decided
+// in a single left-to-right pass. Both sides are pinned here because getting
+// it backwards is a SILENT failure, not a parse error: `riscv64-none-elf`
+// would fall through to the host and the build would report success while
+// producing an x86-64 binary.
+
+TEST(Triple, NoneIsTheOsWhenNoOtherOsToken) {
+    auto t = parse("riscv64-none-elf");
+    ASSERT_TRUE(t.has_value());
+    EXPECT_EQ(t->arch, "riscv64");
+    EXPECT_EQ(t->os, "none");
+    EXPECT_EQ(t->env, "elf");
+    EXPECT_EQ(t->str(), "riscv64-none-elf");
+    EXPECT_TRUE(t->is_freestanding());
+    EXPECT_TRUE(is_known_target(*t));
+    // No OS means no cfg family — a freestanding target is neither unix nor
+    // windows, and claiming either would enable the wrong cfg branches.
+    EXPECT_EQ(t->family(), "");
+}
+
+TEST(Triple, NoneStaysAVendorWhenARealOsFollows) {
+    auto t = parse("x86_64-none-linux-gnu");
+    ASSERT_TRUE(t.has_value());
+    EXPECT_EQ(t->os, "linux");
+    EXPECT_EQ(t->env, "gnu");
+    EXPECT_FALSE(t->is_freestanding());
+    EXPECT_EQ(t->family(), "unix");
+}
+
+TEST(Triple, Riscv32BareMetalParses) {
+    auto t = parse("riscv32-none-elf");
+    ASSERT_TRUE(t.has_value());
+    EXPECT_EQ(t->str(), "riscv32-none-elf");
+    EXPECT_TRUE(t->is_freestanding());
+    EXPECT_TRUE(is_known_target(*t));
+}
+
+TEST(Triple, HostedTargetsAreNotFreestanding) {
+    for (const char* s : { "x86_64-linux-gnu", "x86_64-linux-musl",
+                           "x86_64-windows-gnu", "aarch64-macos" }) {
+        auto t = parse(s);
+        ASSERT_TRUE(t.has_value()) << s;
+        EXPECT_FALSE(t->is_freestanding()) << s;
+    }
+}
+
+TEST(Triple, BareMetalEabiSpellings) {
+    // Accepted only under os=none, so a hosted triple cannot pick them up.
+    auto hf = parse("arm-none-eabihf");
+    ASSERT_TRUE(hf.has_value());
+    EXPECT_EQ(hf->os, "none");
+    EXPECT_EQ(hf->env, "eabihf");
+    // Parsing is not the same as being supported: arm is not in the
+    // vocabulary table yet, and the target gate is what says so.
+    EXPECT_FALSE(is_known_target(*hf));
+}


### PR DESCRIPTION
裸机链路的**两半**:引擎能构建能跑;板级支持包(BSP)把目标世界的其余部分全部供上,消费者的 manifest 只写一条依赖。

所有 freestanding 专属的东西在新的 **`src/freestanding/` 模块目录**(`target` / `linkline` / `runner`)。hosted 路径一行没动。

---

## 第一半:引擎能构建、能跑

```
$ mcpp build --target riscv64-none-elf     # entry 0x80200000 · 0 PT_INTERP · 0 未定义符号
$ mcpp run   --target-triple riscv64-none-elf
MCPP-FREESTANDING-OK
```

### ⚠️ 关掉的缺陷

只把三元组解析加上之后,失败形态比构建报错更糟:

```
$ mcpp build --target riscv64-none-elf
    Resolved llvm@22.1.8 → riscv64-none-elf → …/bin/clang++
    Finished dev [unoptimized + debuginfo] in 0.47s
$ ls target/
    x86_64-linux-gnu/          ← 宿主的 ELF,却报成了 riscv64
```

**真因,且不能从已能用的交叉 target 推广**:此前每个交叉 target 都用**独立的编译器二进制**(`x86_64-w64-mingw32-g++`),它自己的 `-dumpmachine` 就是交叉三元组。而 **clang 一个二进制服务所有 target**,`-dumpmachine` 永远回答宿主。现在 freestanding 的 `tc.targetTriple` 由**请求**决定 —— 产物目录、指纹、缓存键、flag 层**读的都是这一个字段**。

| 部件 | 在解决什么 |
|---|---|
| **`none` 的歧义** | 既是 vendor 段也是 OS 段:`riscv64-none-elf` 裸机、`x86_64-none-linux-gnu` hosted。预扫描判定,**两侧都钉了测试** —— 判反是静默的。 |
| **链接线整条替换** | 每条 hosted 决策在这里都是**错的**(crt、动态链接器、C++ 运行时、loader 路径)。追加 `-nostdlib` 会让结果取决于驱动的 flag 顺序。 |
| ⚠️ **`--no-default-config` 带进去** | 载荷的 `clang++.cfg` 无条件注入 `-Wl,--dynamic-linker=…/ld-linux-x86-64.so.2`。丢掉它 ⇒ **RISC-V 镜像烙进 x86-64 PT_INTERP,链接干净、报告成功**。本次改动过程中实测到。 |
| ⚠️ **链接器用绝对路径** | `-fuse-ld=lld` 走 PATH,binutils 排前面就找到 GNU ld,死于 `unrecognised emulation mode: elf64lriscv`。编 picolibc 时复现过。 |
| **C++ 运行时表短路** | 它找到的归档是**宿主的**,把 x86-64 `libc++.a` 放上了 riscv64 链接线。 |
| **`import std` 关断** | `std` 是覆盖整库的**一个**模块,没有 OS 就没有子集。留着报 `'__config_site' file not found`,读起来像载荷坏了。诊断现在**点名替代包和那行 manifest**。 |
| **`runner` 无默认值** | 用哪个模拟器/机器型号/固件模式是**板级事实**(`-bios default` vs `-bios none -semihosting`),引擎猜一个,另一块板就得跟它打架。 |

---

## 第二半:BSP 供上整个目标世界

```toml
[dependencies]
board = { path = "../board" }
```
```cpp
import board;
extern "C" int main() { board::printf_f("float %.4f\n", 3.14159); … }
```
```
$ mcpp run --target-triple riscv64-none-elf
BSP-CHAIN-OK 42
float 3.1416
MALLOC-OK
```

⭐ 这份工程里**没有** picolibc、compiler-rt、crt0、链接脚本、加载地址、`-nostdlib`、`-mcmodel`。

### ⚠️ 接缝(探针 Z1 实测)

```
link-search / link-lib / link-script   LinkGlobal      → 到达消费者
include-dir / cflag / cfg              PackagePrivate  → 不到达
```

这个不对称是**刻意的**(构建期程序不得静默拓宽包的公开编译接口),也正是 BSP **私有** include 目标 libc 头、对外 **export 一个 C++ 模块**的原因。`tests/e2e/131` **两侧都钉**:模块化消费者跑通,而试图 `#include <stdio.h>` 的消费者**必须构建失败**。

### 三个新部件

| | |
|---|---|
| **`mcpp:link-script=`** | directive 表里**一行**,`Scope::LinkGlobal`。别的通道要么包私有(`cxxflag`),要么表达不了这个 flag(`link-lib` 发 `-l`、`link-search` 发 `-L`)。⚠️ 它**不认领** declared-output:那个契约假设"值就是路径",而这里的值是 `-T <路径>`,检查会拒绝一个明明在那儿的脚本;lld 自己的报错本来就精确。 |
| **`mcpp::xpkg_dir(ns, name)`** | "我在 `[xlings] deps` 里声明的包落在哪"的**接口**。`dep_dir` 只答 mcpp 依赖。没有它,BSP 就得把 `<home>/data/xpkgs/<ns>-x-<name>/<version>` 写进代码 —— 那是 mcpp 可以随时改的 store 内部结构。解析放在 `xpkgs_base` 旁边(xlings 模块本来就拥有这套布局),避免同一决策两处推导。⚠️ **带版本固定**只解析到那个版本,否则什么都不返回。 |
| ⚠️ **freestanding 下跳过宿主 include 重建** | 那块发的是**手工重建的宿主世界**(libc++ 头、glibc 头、Linux UAPI 头),因为 cfg 被 bypass 了。裸机上它们不只是没用:picolibc 自己的 `<stdio.h>` 会 `#include <stddef.h>`,落到 libc++ 那份,打开一个为宿主生成、这里根本不存在的 `__config_site`。报错点名 `__config_site`,读起来像载荷坏了。`-nostdinc++` 同理进了 freestanding 编译前缀。 |

---

## 测试

- **单测 +18**:三个 freestanding 模块 11 条 · triple 的 `none` 歧义两侧 6 条 · xpkg 接口 4 条(每种 manifest 写法 / 固定版本要么精确要么没有 / 版本按数字段比较,因为字符串序把 0.4.11 排在 0.4.9 前 / 通道两侧共用一个 sanitizer)· `link-script` 3 条
- **`tests/e2e/130`**:引擎链路 —— 模块 + 汇编 → **UCB RISC-V 镜像、无 PT_INTERP、零未定义符号、入口 0x80200000** → 启动并断言模块输出。runner 两侧钉。
- **`tests/e2e/131`**:生态链路 —— BSP 供 sysroot + 链接脚本 + 运行时,消费者只声明依赖;**并反向验证** `include-dir` 不泄漏到消费者。
- e2e harness 新增 **`# requires-hard:`**(能力缺失 **FAIL 而非 SKIP**)。

⚠️ **两条裸机测试刻意不用 `requires-hard`**:qemu-riscv 在 macOS/Windows runner 上本来就没有,硬 token 会让那些 job **结构性首红**。真正要防的事由 `ci-linux-e2e.yml` 新增的 **`baremetal` job** 守:装 qemu + sysroot(装进 **MCPP 用的那个 home**,否则 131 会 SKIP)→ 跑这两条 → **断言两条 PASS 行都出现了**。`run_all.sh` 跳过时退出码是 0,回答不了这个问题。

## 本地结果

```
mcpp test                       91 passed; 0 failed
tests/e2e/130                   PASS: freestanding riscv64 build + run
tests/e2e/131                   PASS: BSP supplies the sysroot, linker script and runtime
check_docs_style.sh             OK
```

## 依赖

`xim:qemu-riscv@9.2.4-1` 与 `xim:picolibc-riscv@1.8.12`,均已进 xlings 生态(openxlings/xim-pkgindex#651、#653)。方案与计划在 `.agents/docs/` 下。
