### PR TITLE
chore(release): 2026.8.19.1

### DIFF
--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version = "2026.8.18.3"
+version = "2026.8.19.1"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/version.cppm
+++ b/src/version.cppm
@@ -31,6 +31,6 @@ import std;
 
 export namespace mcpp {
 
-inline constexpr std::string_view MCPP_VERSION = "2026.8.18.3";
+inline constexpr std::string_view MCPP_VERSION = "2026.8.19.1";
 
 } // namespace mcpp


### PR DESCRIPTION
版本号两处同提交(`mcpp.toml` + `src/version.cppm`),bootstrap pin 不动 —— `check_version_pins.sh` 通过:

```
building=2026.8.19.1 (src/version.cppm=2026.8.19.1)  bootstrap pin=2026.8.17.1
OK: xlings pins all at 2026.8.17.2
```

内容见 #455(裸机 target + BSP 供整个目标世界)。