### PR TITLE
docs(pack): four judgement rows move from 'to be verified' to measured

### DIFF
--- a/.agents/docs/2026-08-20-issue460-shared-library-runpath.md
+++ b/.agents/docs/2026-08-20-issue460-shared-library-runpath.md
@@ -524,8 +524,8 @@ tarball(§4 最后一行)——它们不会因为 mcpp 升级而自动变好,只
 | 10 | 已发布的二进制库包同样受影响(但 `mcpp publish` 本身发的是源码,不是这条路径) | 读码(`publish/pipeline.cppm:109`) |
 | 11 | soname 别名的 copy 回退拷的是未重定位的源 | 读码(`library.cppm:293`) |
 | 12 | 库包产物是 debug、未 strip、含发布者源码路径 | **实测** |
-| 13 | 打包 shared 目标不校验其 DT_NEEDED 闭包 | 读码,**未实测** |
-| 14 | Mach-O 的 `LC_RPATH` 是否泄漏 | **未核验**,需在 macOS 上跑 |
+| 13 | 打包 shared 目标不校验其 DT_NEEDED 闭包 | 读码,**未实测**(P1-3,仍未实施) |
+| 14 | Mach-O 的 `LC_RPATH` 是否泄漏 | **已核验:不泄漏**(2026-08-20,PR#464 的 macOS CI)。打包器现在读出 `LC_RPATH` 并在非空时告警,整个 macOS e2e 套件一条都没发出 ⇒ `.dylib` 的可重定位性来自链接期的 `-install_name @rpath/`,不需要打包期改写 |
 
 ---
 

--- a/.agents/docs/2026-08-20-pack-and-consumer-model-review.md
+++ b/.agents/docs/2026-08-20-pack-and-consumer-model-review.md
@@ -403,7 +403,7 @@ P1-1(闭包模型学会 RUNPATH 抑制规则)落地后,这段诊断才**说得�
 
 | # | 主张 | 证据等级 |
 |---|---|---|
-| 1 | macOS 宿主上应用打包走 glibc 路径并执行产物 | **读码**(`pack.cppm:934` 分支 + `ldd_parse:442`),**需 macOS 核验** |
+| 1 | macOS 宿主上应用打包走 glibc 路径并执行产物 | **已按格式拒绝(2026.8.20.1)**。旁证:此前 macOS 上 249/250 是绿的,而它们检查的正是那次「运行用户程序」产出的 bundle —— 加上拒绝后这两条立刻变红 | **读码 + macOS CI 实测** |
 | 2 | e2e 的 `pack` 能力 = ELF + patchelf ⇒ 应用打包在 macOS 上一条 e2e 都不跑 | **读码**(`tests/e2e/run_all.sh:43-76` 的 `Linux)` / `Darwin)` 分支) |
 | 3 | `binfmt::Format` 已是三态但只服务 PE 路径 | 读码 |
 | 4 | `is_machine_local` 无 packer 调用方 | **grep** |
@@ -411,6 +411,6 @@ P1-1(闭包模型学会 RUNPATH 抑制规则)落地后,这段诊断才**说得�
 | 6 | 库 leg 的 digest 记录但从不校验 | 读码(`prebuilt.cppm:137-139` 只匹配 `role == "interface"`) |
 | 7 | tar 路径不确定、zip 路径确定,而文档只声明了确定性 | 读码(`pack.cppm:797` vs `:917`)+ docs/02:306 |
 | 8 | `PackConfig` 无 profile / strip 键 | 读码(`types.cppm:791-800`) |
-| 9 | 静态库不能 `--strip-all`(会删符号表) | 通用知识,**落地前必须实测** |
+| 9 | 静态库不能 `--strip-all`(会删符号表) | **已实测**:`ld: 归档没有索引;run ranlib`,而 `--strip-debug` 后 2988→1244 字节且消费方链接并跑通(e2e 265 两侧都钉) |
 | 10 | 老客户端兼容用静态+真实两半钉,且 CI 上只跑了静态那半 | 读码 + docs/12 自述 |
 | 11 | `--mode` 对库目标 warning 且措辞含 "yet" | 读码(`cmd_publish.cppm:78-82`) |


### PR DESCRIPTION
Follow-up to #464. Its own CI answered three of the open items in the two design
records under `.agents/docs`, and a record that still says 未核验 after the
measurement exists is one the next reader will re-derive.

| item | before | now |
|---|---|---|
| Mach-O `LC_RPATH` leaks? | 未核验,需在 macOS 上跑 | **does not leak** — the packer reads `LC_RPATH` and warns when a package would carry one; the whole macOS e2e suite emitted none. A `.dylib`'s relocatability comes from the link-time `-install_name @rpath/`, so packaging has nothing to rewrite. |
| macOS program packing runs the user's program | 读码,需 macOS 核验 | **refused by format (2026.8.20.1)**, with a second piece of evidence: 249/250 were GREEN on macOS beforehand, and what they inspected was the bundle that run produced. Adding the refusal turned them red immediately. |
| a static archive cannot be `--strip-all`ed | 通用知识,落地前必须实测 | **measured** — `archive has no index; run ranlib to add one`; `--strip-debug` gives 2988 → 1244 bytes and the consumer links and runs (e2e 265 pins both sides). |

P1-3 (the shipped `.so`'s own `DT_NEEDED` closure is not checked against the
package + `[dependencies]`) stays unmeasured and unimplemented, and now says so
explicitly rather than by omission.

Documentation only — no source, no test, no workflow changes.