### PR TITLE
2026.8.21.3 —— 补上 aarch64/x86_64 的 multilib 目录

### DIFF
--- a/docs/13-baremetal.md
+++ b/docs/13-baremetal.md
@@ -19,17 +19,25 @@ at `src/toolchain/triple.cppm` carries four of them:
 |---|---|---|
 | `riscv64-none-elf` | verified | `xim:picolibc-riscv` |
 | `riscv32-none-elf` | verified | `xim:picolibc-riscv` |
-| `aarch64-none-elf` | preview | none — the zero-libc tier |
-| `x86_64-none-elf` | preview | none — the zero-libc tier |
+| `aarch64-none-elf` | preview | none by default — the zero-libc tier; `xim:picolibc-aarch64` is declarable |
+| `x86_64-none-elf` | preview | none by default — the zero-libc tier; `xim:picolibc-x86` is declarable |
 
 `verified` means an image has been built **and run** for the row. `preview`
 means it builds and has been observed to run, but is not yet covered by the
 engine's own emulator jobs.
 
-⚠️ The last two rows' C library column is empty, and that is a statement rather
-than an omission: no aarch64 or x86_64 build of picolibc exists in the package
-index, and the first consumer of both rows — the `openarch` layer of machine
-mechanism — references no C library symbol. An empty column means exactly what
+⚠️ The last two rows default to no C library, and that is a statement rather
+than an omission: the first consumer of both rows — the `openarch` layer of
+machine mechanism — references no C library symbol, and if no row defaulted to
+this tier there would be nothing demonstrating the tier works.
+⭐ **A build for those rows is declarable, not absent** (mcpp 2026.8.21.3+).
+`xim:picolibc-aarch64` and `xim:picolibc-x86` are in the index; a project that
+wants one names it the same way it would choose a different one:
+
+```toml
+[target.aarch64-none-elf]
+sysroot = "xim:picolibc-aarch64@1.8.12"
+``` An empty column means exactly what
 `[target.<triple>].sysroot = ""` means in a manifest, so a project targeting one
 begins on the zero-libc tier without asking. A project that wants a C library on
 those targets declares one, which is also how it would choose a different one.

--- a/docs/zh/13-baremetal.md
+++ b/docs/zh/13-baremetal.md
@@ -17,17 +17,25 @@ freestanding 目标是 `os` 字段为 `none` 的目标。`src/toolchain/triple.c
 |---|---|---|
 | `riscv64-none-elf` | verified | `xim:picolibc-riscv` |
 | `riscv32-none-elf` | verified | `xim:picolibc-riscv` |
-| `aarch64-none-elf` | preview | 无 —— 零 libc 档 |
-| `x86_64-none-elf` | preview | 无 —— 零 libc 档 |
+| `aarch64-none-elf` | preview | 默认无 —— 零 libc 层;`xim:picolibc-aarch64` 可声明 |
+| `x86_64-none-elf` | preview | 默认无 —— 零 libc 层;`xim:picolibc-x86` 可声明 |
 
 `verified` 意味着该行的镜像被构建**并被运行**过。`preview` 意味着它构建得出、
 也被观察到能运行,但尚未纳入引擎自己的模拟器作业。
 
-⚠️ 后两行的 C 库列为空,这是声明而非遗漏:包索引里不存在 aarch64 与 x86_64 的
-picolibc 构建,而这两行的第一个消费者 —— 机器机制层 `openarch` —— 一个 C 库符号
-都不引用。空列在这里的含义与清单里 `[target.<triple>].sysroot = ""` 完全一致,
-因此面向它们的工程无需声明即处在零 libc 档。想要 C 库的工程自行声明一个,而那也
-正是它换用另一份 C 库的做法。
+⚠️ 后两行**默认**没有 C 库,这是声明而非遗漏:这两行的第一个消费者 —— 机器机制层
+`openarch` —— 一个 C 库符号都不引用,而**如果四行里没有一行默认在这一层,就没有
+任何东西在证明这一层可用**。空列在这里的含义与清单里
+`[target.<triple>].sysroot = ""` 完全一致。
+
+⭐ **这两行的 C 库是可声明的,不是不存在的**(mcpp 2026.8.21.3+)。
+`xim:picolibc-aarch64` 与 `xim:picolibc-x86` 已在索引里;想要它的工程自行声明,
+而那与它换用另一份 C 库是同一个动作:
+
+```toml
+[target.aarch64-none-elf]
+sysroot = "xim:picolibc-aarch64@1.8.12"
+```
 
 这类目标不需要逐宿主的交叉工具链。clang 与 lld 在构造上就是交叉编译器 ——
 一个二进制发射它构建时支持的全部目标 —— 因此目标表在每个宿主上都钉

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version = "2026.8.21.2"
+version = "2026.8.21.3"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/freestanding/target.cppm
+++ b/src/freestanding/target.cppm
@@ -108,6 +108,25 @@ inline constexpr std::string_view kX86_64NoneExtra[] = {
     "-mno-red-zone",
 };
 
+// ⚠️ THE `libdir` COLUMN WAS EMPTY ON THE LAST TWO ROWS UNTIL 2026-08-21, AND
+// THAT WAS CORRECT UNTIL THE DAY IT WAS NOT.
+//
+// It names the sub-directory of a multilib C library — picolibc's own
+// convention, `<march>/<mabi>` — and those two rows had no C library in the
+// index to point into, so an empty column said something true.
+//
+// `xim:picolibc-aarch64` and `xim:picolibc-x86` now exist. Measured with the
+// column still empty: a project that declares
+// `[target.aarch64-none-elf] sysroot = "xim:picolibc-aarch64@1.8.12"` gets
+// `'stdio.h' file not found` — the package is installed and correct, and the
+// engine cannot find the profile inside it.
+//
+// ⚠️ Filling this does NOT give those targets a C library by default. The
+// column is consulted only when a sysroot has been resolved, and the target
+// TABLE still binds none for these two rows — the zero-libc tier stays the
+// default and the package stays opt-in. This makes the opt-in work; it does not
+// take the opt-out away.
+//
 // ⚠️ Defaults, not the only possibility. `rv64gc/lp64d` is what qemu `virt`
 // runs and what the first BSP targets; a board that needs `rv32imac/ilp32`
 // selects it through its own manifest, not by editing this table. The table
@@ -139,7 +158,7 @@ inline constexpr Spec kTable[] = {
     // table resolves no C library: `aarch64-none-elf` is the zero-libc tier.
     // The engine reads this column only when a sysroot exists, so an invented
     // value would be a value nothing could ever check.
-    { "aarch64-none-elf",   "armv8-a",  "aapcs", "small",  ""               },
+    { "aarch64-none-elf",   "armv8-a",  "aapcs", "small",  "armv8-a/aapcs"  },
     // ⚠️ `x86-64` WITH A HYPHEN, WHICH IS THE ONE PLACE THIS TRIPLE'S TWO
     // SPELLINGS DIVERGE. The triple segment is `x86_64` with an underscore and
     // the `-march` value is `x86-64` with a hyphen; deriving one from the other
@@ -163,7 +182,7 @@ inline constexpr Spec kTable[] = {
     //
     // ⚠️ THE LIBDIR IS EMPTY FOR THE SAME REASON aarch64's IS: this row
     // resolves no C library, so a value here could never be checked.
-    { "x86_64-none-elf",    "x86-64",   "sysv",  "small",  "", kX86_64NoneExtra,
+    { "x86_64-none-elf",    "x86-64",   "sysv",  "small",  "x86-64/sysv", kX86_64NoneExtra,
       "elf_x86_64" },
 };
 

--- a/src/version.cppm
+++ b/src/version.cppm
@@ -31,6 +31,6 @@ import std;
 
 export namespace mcpp {
 
-inline constexpr std::string_view MCPP_VERSION = "2026.8.21.2";
+inline constexpr std::string_view MCPP_VERSION = "2026.8.21.3";
 
 } // namespace mcpp

--- a/tests/unit/test_freestanding.cpp
+++ b/tests/unit/test_freestanding.cpp
@@ -391,16 +391,42 @@ TEST(FreestandingTarget, Aarch64ResolvesNoCLibrary) {
     EXPECT_EQ(mcpp::toolchain::triple::effective_sysroot(*t, &want), want);
 }
 
-// The libdir column is empty for the same reason, and a consumer that read it
-// would be reading a value nothing could ever check.
-TEST(FreestandingTarget, Aarch64HasNoMultilibDirectoryToName) {
-    auto s = mcpp::freestanding::resolve("aarch64-none-elf");
-    ASSERT_TRUE(s.has_value());
-    EXPECT_TRUE(s->libdir.empty());
+// ⚠️ THIS TEST USED TO ASSERT THE OPPOSITE, AND IT WAS RIGHT UNTIL 2026-08-21.
+//
+// The libdir column names the sub-directory of a MULTILIB C library, and the
+// aarch64 and x86_64 rows had none in the index to point into — so an empty
+// column asserted something true, and a consumer reading it would have been
+// reading a value nothing could check.
+//
+// `xim:picolibc-aarch64` and `xim:picolibc-x86` now exist, and their payloads
+// use picolibc's own `<march>/<mabi>` convention. Measured with the column
+// still empty: a project declaring
+// `[target.aarch64-none-elf] sysroot = "xim:picolibc-aarch64@1.8.12"` got
+// `'stdio.h' file not found` while the package sat installed and correct.
+//
+// ⭐ The values below are a CROSS-REPOSITORY fact: they must match the
+// directory layout those two packages ship. `xim-pkgindex`'s
+// `.agents/tools/build-baremetal-sysroot.sh` produces them from the same
+// march/mabi pair this table carries, so the two cannot drift silently — but
+// they are named here so a reader knows where the other half lives.
+TEST(FreestandingTarget, MultilibDirectoriesMatchTheIndexPayloads) {
+    auto a = mcpp::freestanding::resolve("aarch64-none-elf");
+    ASSERT_TRUE(a.has_value());
+    EXPECT_EQ(a->libdir, "armv8-a/aapcs");
+    // The directory is the march/mabi pair, so it cannot disagree with the
+    // flags the same row produces.
+    EXPECT_EQ(a->libdir, std::string(a->march) + "/" + std::string(a->mabi));
 
-    // The RISC-V rows do name one, so the emptiness above is this row's
-    // property rather than the field being unused everywhere.
-    auto r = mcpp::freestanding::resolve("riscv64-none-elf");
-    ASSERT_TRUE(r.has_value());
-    EXPECT_FALSE(r->libdir.empty());
+    auto x = mcpp::freestanding::resolve("x86_64-none-elf");
+    ASSERT_TRUE(x.has_value());
+    EXPECT_EQ(x->libdir, "x86-64/sysv");
+    EXPECT_EQ(x->libdir, std::string(x->march) + "/" + std::string(x->mabi));
+
+    // ⚠️ Filling this column does NOT give those targets a C library by
+    // default. It is consulted only once a sysroot has been RESOLVED, and the
+    // target table still binds none for these two rows — the zero-libc tier
+    // stays the default and the package stays opt-in.
+    auto t = mcpp::toolchain::triple::parse("aarch64-none-elf");
+    ASSERT_TRUE(t.has_value());
+    EXPECT_TRUE(mcpp::toolchain::triple::effective_sysroot(*t, nullptr).empty());
 }


### PR DESCRIPTION
`libdir` 列命名的是 **multilib C 库**的子目录(picolibc 自己的 `<march>/<mabi>` 约定)。那两行此前为空,而**在索引里没有对应 picolibc 之前,空是对的**。

`xim:picolibc-aarch64` 与 `xim:picolibc-x86` 现在存在了,列必须填。

## 实测 A/B

一个声明 `[target.aarch64-none-elf] sysroot = "xim:picolibc-aarch64@1.8.12"` 的工程:

| 引擎 | 结果 |
|---|---|
| 带修复 | `-isystem …/include/armv8-a/aapcs` —— **头解析成功** |
| 已发布的 2026.8.21.2 | `'stdio.h' file not found` |

**包装好了、是对的,而引擎找不到里面的 profile。**

(链接仍缺 `printf`,因为裸工程没有 crt0 —— riscv 在同样条件下同样如此,那是板级包的活。)

## ⚠️ 这不改变默认

`libdir` **只在 sysroot 已被解析后才被读**,而目标表对这两行仍不绑定任何 C 库 —— **零 libc 仍是默认,包仍是可选加入**。单元测试把这一点也断言了。

## ⚠️ 一条单元测试此前断言相反的事,而它当时是对的

`Aarch64HasNoMultilibDirectoryToName` 断言 libdir 为空。事实变了,测试跟着改,并在注释里写明它为什么曾经正确 —— **结论会被复查,理由不会**。
