### PR TITLE
fix(aur): 收敛轮询的窗口太短,而它产生的失败在说谎

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -127,7 +127,32 @@ jobs:
             --summary "$GITHUB_STEP_SUMMARY"
           )
           [[ -z "$REQUESTED_TAG" ]] || args+=(--tag "$REQUESTED_TAG")
+
+          # ⚠️ EXIT 75 IS "THE PUSH LANDED, THE AUR'S INDEX HAS NOT CAUGHT UP",
+          # AND FAILING ON IT MAKES THIS REPOSITORY'S CI RED FOR SOMEBODY ELSE'S
+          # REFRESH SCHEDULE.
+          #
+          # The reconciler already classifies that case as TRANSIENT and exits
+          # 75 (the conventional EX_TEMPFAIL) rather than 2. It is reached only
+          # AFTER the git push has succeeded, so the AUR holds the new version
+          # at that point; what has not happened is the AUR's own RPC metadata
+          # refresh, which runs on a schedule measured in minutes.
+          #
+          # Measured twice (2026.8.21.2 and 2026.8.21.3): this step reported
+          # `AUR RPC did not converge to <ver>` and the AUR RPC answered with
+          # that exact version when asked afterwards.
+          #
+          # ⚠️ EVERY OTHER NON-ZERO CODE STILL FAILS. A refused downgrade (3) and
+          # a permanent error (2) are this repository's problem and stay red.
+          set +e
           python3 scripts/aur/reconcile_mcpp_bin.py "${args[@]}"
+          rc=$?
+          set -e
+          if [[ "$rc" == "75" ]]; then
+              echo "::warning::The push to the AUR succeeded; its RPC metadata had not refreshed within the poll window. Verify with: curl -s 'https://aur.archlinux.org/rpc/v5/info?arg[]=mcpp-bin'"
+          elif [[ "$rc" != "0" ]]; then
+              exit "$rc"
+          fi
 
       - name: Preserve reconciliation reports
         if: always()

--- a/scripts/aur/reconcile_mcpp_bin.py
+++ b/scripts/aur/reconcile_mcpp_bin.py
@@ -1050,8 +1050,22 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--arch-image", default=ARCH_IMAGE)
     parser.add_argument("--push-attempts", type=int, default=4)
     parser.add_argument("--push-base-delay", type=float, default=5.0)
-    parser.add_argument("--rpc-poll-attempts", type=int, default=12)
-    parser.add_argument("--rpc-poll-delay", type=float, default=5.0)
+    # ⚠️ 12 x 5s = 60s WAS TOO SHORT, AND THE FAILURE IT PRODUCED WAS A LIE
+    # ABOUT WHOSE FAULT IT WAS.
+    #
+    # This poll runs AFTER the git push has succeeded, so by the time it starts
+    # the AUR already holds the new version — what it waits for is the AUR's own
+    # RPC metadata to catch up, which refreshes on a schedule measured in
+    # minutes, not seconds. Measured on 2026.8.21.2 and again on 2026.8.21.3:
+    # the workflow reported `AUR RPC did not converge` and the AUR RPC showed
+    # the new version when asked afterwards. Both were red for a third party's
+    # refresh interval.
+    #
+    # 40 x 15s = 10 minutes covers the observed lag with room. See also the
+    # workflow, which no longer treats a non-converged poll as a build failure —
+    # the push is the thing this repository is responsible for.
+    parser.add_argument("--rpc-poll-attempts", type=int, default=40)
+    parser.add_argument("--rpc-poll-delay", type=float, default=15.0)
     parser.add_argument("--report-json", type=Path)
     parser.add_argument("--summary", type=Path)
     args = parser.parse_args(argv)


### PR DESCRIPTION
`aur-publish` 在 2026.8.21.2 与 2026.8.21.3 两次发布上都报红:

```
mcpp-bin reconcile error: AUR RPC did not converge to 2026.8.21.3-1; last='2026.8.21.2-1'
```

⭐ **而发布是成功的。** 事后问 AUR:

```
mcpp-bin     2026.8.21.3-1
```

## 成因

那次轮询跑在 **git 推送成功之后** —— AUR 那时已经持有新版本,它等的是 **AUR 自己的 RPC 元数据刷新**,而那是分钟级的。默认 **12 × 5s = 60 秒**根本不够。

**两次红都红在第三方的刷新间隔上,而不是本仓的正确性上。**

## 改动

- 轮询窗口 `12×5s` → `40×15s`(10 分钟)
- 工作流不再把退出 **75**(脚本自己分类的 `TRANSIENT`,即 EX_TEMPFAIL)当作构建失败,改为警告 + 可粘贴的复核命令

⚠️ **其它非零码照旧让作业红**:拒绝降级(3)与永久错误(2)是本仓自己的问题。

## ⚠️ 测试覆盖不到的那部分

脚本的 13 个测试全过,但它们**覆盖不到工作流里那条新分支**。四条路径(0 / 75 / 2 / 3)因此是手工验证的:75 变警告并继续,2 与 3 **真的退出**(实测退出码 2)。
