### PR TITLE
chore: bundle xlings 2026.8.27.5, and release 2026.8.28.1

### DIFF
--- a/.github/actions/bootstrap-mcpp/action.yml
+++ b/.github/actions/bootstrap-mcpp/action.yml
@@ -25,7 +25,7 @@ inputs:
     # `package.name`, so one of the two was simply unreachable — and which one
     # depended on the machine, which is why CI failed on `compat:lua` on
     # Windows and `mcpplibs.capi:lua` on Linux. Never pin below that.
-    default: '2026.8.27.4'
+    default: '2026.8.27.5'
   cache-target:
     description: also restore/save target/ (build artifacts + BMIs)
     required: false

--- a/.github/actions/setup-macos-llvm/action.yml
+++ b/.github/actions/setup-macos-llvm/action.yml
@@ -15,7 +15,7 @@ inputs:
     # Floor imposed by the index, not a routine bump — see
     # .github/actions/bootstrap-mcpp/action.yml for why 0.4.69 is required
     # (two packages named `lua` in one repo need openxlings/xlings#381).
-    default: '2026.8.27.4'
+    default: '2026.8.27.5'
 
 runs:
   using: composite

--- a/.github/workflows/bootstrap-macos.yml
+++ b/.github/workflows/bootstrap-macos.yml
@@ -17,7 +17,7 @@ jobs:
       # Dormant (workflow_dispatch only), but kept in step with the rest —
       # check_version_pins.sh holds it there. Floor: 0.4.69, below which the
       # index cannot resolve two packages that share a short name.
-      XLINGS_VERSION: '2026.8.27.4'
+      XLINGS_VERSION: '2026.8.27.5'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-fresh-install.yml
+++ b/.github/workflows/ci-fresh-install.yml
@@ -152,7 +152,7 @@ jobs:
         env:
           XLINGS_NON_INTERACTIVE: '1'
         run: |
-          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash -s v2026.8.27.4
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash -s v2026.8.27.5
           echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
 
       - name: Install mcpp and config mirror
@@ -293,7 +293,7 @@ jobs:
 
       - name: Install xlings + mcpp
         run: |
-          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash -s v2026.8.27.4
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash -s v2026.8.27.5
           # Deliberately NOT writing to $GITHUB_PATH here. On container
           # images that declare no PATH in their config (opensuse/
           # tumbleweed), appending a single dir to GITHUB_PATH makes the
@@ -364,7 +364,7 @@ jobs:
           #             (older ones carry minos=15 and refuse to start).
           #   v0.4.51+: in-process sha256 — this image has no sha256sum
           #             binary, so pinned fetches failed before it.
-          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash -s v2026.8.27.4
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash -s v2026.8.27.5
           echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
 
       - name: Install mcpp and config mirror

--- a/.github/workflows/ci-linux-e2e.yml
+++ b/.github/workflows/ci-linux-e2e.yml
@@ -237,7 +237,7 @@ jobs:
 
       - name: Bootstrap xlings + released mcpp
         run: |
-          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash -s v2026.8.27.4
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash -s v2026.8.27.5
           export PATH="$HOME/.xlings/subos/current/bin:$PATH"
           xlings update
           xlings install mcpp -y -g

--- a/.github/workflows/cross-build-test.yml
+++ b/.github/workflows/cross-build-test.yml
@@ -122,7 +122,7 @@ jobs:
           # release assets were uploaded in a broken state (records present,
           # blobs missing → 404 on GET); re-uploaded clean. The stale-INDEX
           # half is handled by the marker-clear below.
-          XLINGS_VERSION: '2026.8.27.4'
+          XLINGS_VERSION: '2026.8.27.5'
         run: |
           tarball="xlings-${XLINGS_VERSION}-linux-x86_64.tar.gz"
           bash "$GITHUB_WORKSPACE/.github/tools/fetch_release.sh" \
@@ -263,7 +263,7 @@ jobs:
       - name: Bootstrap mcpp via xlings
         env:
           XLINGS_NON_INTERACTIVE: '1'
-          XLINGS_VERSION: '2026.8.27.4'
+          XLINGS_VERSION: '2026.8.27.5'
         run: |
           tarball="xlings-${XLINGS_VERSION}-linux-x86_64.tar.gz"
           bash "$GITHUB_WORKSPACE/.github/tools/fetch_release.sh" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           # Pin xlings to a known-good version. The upstream install
           # script always grabs `latest` (no version override), so we
           # download + self-install manually to avoid broken releases.
-          XLINGS_VERSION: '2026.8.27.4'
+          XLINGS_VERSION: '2026.8.27.5'
         run: |
           if [ ! -x "$HOME/.xlings/subos/default/bin/xlings" ]; then
             tarball="xlings-${XLINGS_VERSION}-linux-x86_64.tar.gz"
@@ -289,7 +289,7 @@ jobs:
       - name: Bootstrap mcpp via xlings
         env:
           XLINGS_NON_INTERACTIVE: '1'
-          XLINGS_VERSION: '2026.8.27.4'
+          XLINGS_VERSION: '2026.8.27.5'
         run: |
           tarball="xlings-${XLINGS_VERSION}-linux-x86_64.tar.gz"
           bash "$GITHUB_WORKSPACE/.github/tools/fetch_release.sh" \
@@ -360,7 +360,7 @@ jobs:
           # below are pinned to the same version as XLINGS_VERSION; they are
           # NOT interpolated from it, so check_version_pins.sh scans for them
           # explicitly (they were absent from the old lock-step comment).
-          XLA="xlings-2026.8.27.4-linux-aarch64.tar.gz"
+          XLA="xlings-2026.8.27.5-linux-aarch64.tar.gz"
           # NOT fetch_release.sh: this asset is OPTIONAL and the `if` is the
           # point — an arch with no prebuilt xlings must fall through quietly,
           # while the helper retries a 404 five times before giving up. The one
@@ -369,9 +369,9 @@ jobs:
           # cover it.
           if curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
                --connect-timeout 20 --max-time 600 -o "/tmp/$XLA" \
-               "https://github.com/openxlings/xlings/releases/download/v2026.8.27.4/$XLA"; then
+               "https://github.com/openxlings/xlings/releases/download/v2026.8.27.5/$XLA"; then
             tar -xzf "/tmp/$XLA" -C /tmp
-            XLBIN=$(find /tmp/xlings-2026.8.27.4-linux-aarch64 -path '*/bin/xlings' -type f | head -1)
+            XLBIN=$(find /tmp/xlings-2026.8.27.5-linux-aarch64 -path '*/bin/xlings' -type f | head -1)
             if [ -n "$XLBIN" ]; then
               mkdir -p "$STAGING/$WRAPPER/registry/bin"
               cp "$XLBIN" "$STAGING/$WRAPPER/registry/bin/xlings"
@@ -449,7 +449,7 @@ jobs:
       - name: Bootstrap mcpp via xlings
         env:
           XLINGS_NON_INTERACTIVE: '1'
-          XLINGS_VERSION: '2026.8.27.4'
+          XLINGS_VERSION: '2026.8.27.5'
         run: |
           if [ ! -x "$HOME/.xlings/subos/default/bin/xlings" ]; then
             WORK=$(mktemp -d)
@@ -632,7 +632,7 @@ jobs:
         shell: bash
         env:
           XLINGS_NON_INTERACTIVE: '1'
-          XLINGS_VERSION: '2026.8.27.4'
+          XLINGS_VERSION: '2026.8.27.5'
         run: |
           # Captured before the `cd` below, in POSIX form: this step never
           # returns to the workspace, and GITHUB_WORKSPACE is a backslash

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version = "2026.8.27.2"
+version = "2026.8.28.1"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/src/platform/xlings/xlings.cppm
+++ b/src/platform/xlings/xlings.cppm
@@ -45,7 +45,24 @@ namespace pinned {
     // in lock-step by hand; that list was already missing both composite
     // actions, which is how CI's sandbox sat on 0.4.30 unnoticed while
     // everything else had moved on. Don't reintroduce a hand-maintained list.
-    inline constexpr std::string_view kXlingsVersion   = "2026.8.27.4";
+    //
+    // ⚠️ 2026.8.27.5 is a FLOOR, not just the current pick. Below 2026.8.27.2
+    // the bundled xlings takes a subos's runtime binding from a compiled-in
+    // constant, so a home can declare one glibc and install another the
+    // moment the index publishes a packaging revision -- and mcpp is the
+    // party that notices, because select_glibc_payload_lib looks up the
+    // payload directory by the binding's exact version and refuses to fall
+    // back:
+    //
+    //   error: selected RuntimeBinding glibc@2.44 requires payload
+    //          '<store>/xim-x-glibc/2.44', but it is not installed
+    //
+    // Measured across four xlings versions against an index carrying both
+    // 2.44 and 2.44.2: every client whose binding is a constant mismatched;
+    // 2026.8.27.4 and .5, which read the index, stayed consistent. .5 also
+    // makes the declaration outrank the index during resolution, so it holds
+    // even when `latest` is not the highest entry in the table.
+    inline constexpr std::string_view kXlingsVersion   = "2026.8.27.5";
     inline constexpr std::string_view kNasmVersion     = "3.02";
 }
 

--- a/src/version.cppm
+++ b/src/version.cppm
@@ -31,6 +31,6 @@ import std;
 
 export namespace mcpp {
 
-inline constexpr std::string_view MCPP_VERSION = "2026.8.27.2";
+inline constexpr std::string_view MCPP_VERSION = "2026.8.28.1";
 
 } // namespace mcpp


### PR DESCRIPTION
The bundled xlings creates `<install>/registry/subos/default` and therefore decides that subos's runtime binding. Below `2026.8.27.2` it took that binding from a **compiled-in constant**, which stays true only while the index happens to agree with it.

mcpp is the party that notices when it stops agreeing — `select_glibc_payload_lib` looks the payload up by the binding's exact version and deliberately refuses to fall back (#392):

```
error: selected RuntimeBinding glibc@2.44 requires payload
       '<store>/xim-x-glibc/2.44', but it is not installed
```

## Measured

Four xlings versions against an index carrying glibc 2.44 **and** 2.44.2, `latest = 2.44.2`:

| xlings | binding source | declares | installs | |
|---|---|---|---|---|
| `v2026.8.8.1` | constant | 2.39 | 2.44.2 | mismatch |
| `v2026.8.10.1` | constant | 2.44 | 2.44.2 | mismatch |
| `2026.8.27.4` | reads index | 2.44.2 | 2.44.2 | ok |
| `2026.8.27.5` | index + declared-wins | 2.44.2 | 2.44.2 | ok |

**`2026.8.27.4` — what this repo bundles today — is already consistent**, so this is not a fix for a live defect. `.5` adds the part that holds when `latest` is *not* the highest entry in the table: resolution honours what the subos declares over what the index calls newest.

That shape exists right now — the index has `musl` at `latest = 1.2.5` with `1.2.6` in the table — so it is not hypothetical.

## What it unblocks

glibc **2.44.2**, the build that fixes the host `/etc/ld.so.preload` breach (#484), has been withdrawn from the index three times because consumers pinned the binding name and none of them moved together. This is mcpp's half of moving them; openxlings/xlings#574 is the other half. The index entry moves **last**.

## Also

The constant's comment now says **FLOOR** rather than just naming a version, and states the failure it floors against — so the next person can tell a routine bump from a load-bearing one.

Pin guard: `OK: xlings pins all at 2026.8.27.5` (17 pins across 8 files).