### PR TITLE
docs(examples): 09 —— 系统级图形栈,用推荐方式做完整条链 (#527)

### DIFF
--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -27,6 +27,7 @@ examples.
 | 02 | [`examples/02-with-deps`](../examples/02-with-deps/) | Adds the `mcpplibs.cmdline` dependency to parse command-line arguments | `[dependencies]`, SemVer, `mcpp.lock` |
 | 03 | [`examples/03-pack-static`](../examples/03-pack-static/) | Produces a fully static release package via `mcpp pack --mode static` | `[target.<triple>]` and `[pack]` configuration |
 | 08 | [`examples/08-build-rules`](../examples/08-build-rules/) | Two rule packages and a project that uses both | `host-module = true`, `[build-dependencies]`, `mcpp::action` with `role = "check"` |
+| 09 | [`examples/09-graphics-stack`](../examples/09-graphics-stack/) | KMS/DRM -> GBM -> EGL, plus Wayland, with nothing from the host | `compat.libgbm` / `libdrm` / `egl` / `wayland`, SubOS-supplied `GBM_BACKENDS_PATH` |
 
 ## Suggested Reading Order
 

--- a/docs/zh/01-examples.md
+++ b/docs/zh/01-examples.md
@@ -24,6 +24,7 @@ mcpp build && mcpp run
 | 02 | [`examples/02-with-deps`](../../examples/02-with-deps/) | 引入依赖 `mcpplibs.cmdline` 解析命令行参数 | `[dependencies]`、SemVer、`mcpp.lock` |
 | 03 | [`examples/03-pack-static`](../../examples/03-pack-static/) | 通过 `mcpp pack --mode static` 生成全静态发布包 | `[target.<triple>]` 与 `[pack]` 配置 |
 | 08 | [`examples/08-build-rules`](../../examples/08-build-rules/) | 两个规则包,以及同时用到它们的工程 | `host-module = true`、`[build-dependencies]`、`role = "check"` 的 `mcpp::action` |
+| 09 | [`examples/09-graphics-stack`](../../examples/09-graphics-stack/) | KMS/DRM -> GBM -> EGL 加 Wayland,不碰宿主的任何东西 | `compat.libgbm` / `libdrm` / `egl` / `wayland`、由 SubOS 提供的 `GBM_BACKENDS_PATH` |
 
 ## 推荐阅读顺序
 

--- a/examples/09-graphics-stack/README.md
+++ b/examples/09-graphics-stack/README.md
@@ -50,10 +50,13 @@ answer: the whole chain, done the recommended way, declaring dependencies.
 
 ```toml
 [target.'cfg(linux)'.dependencies.compat]
-libdrm  = "2.4.134"
-libgbm  = "25.0.7"
-egl     = "1.7.0"
-wayland = "2026.08.30"
+libdrm = "2.4.134"
+libgbm = "25.0.7"
+egl    = "1.7.0"
+
+[target.'cfg(linux)'.dependencies.freedesktop]
+wayland        = "1.26.0"
+wayland-server = "1.26.0"
 ```
 
 That is the entire configuration. `src/main.cpp` then includes `<gbm.h>`,
@@ -80,47 +83,49 @@ BIN=target/x86_64-linux-gnu/*/bin/graphics-stack
 ```
 
 ```
-<project>/target/.../bin/libdrm.so.2        <- built from source, by this build
+<project>/bin/libdrm.so.2                    <- built by this build
+<project>/bin/libwayland-client.so.0         <- built by this build
+<project>/bin/libwayland-server.so.0         <- built by this build
+<project>/bin/libffi.so.8                    <- built by this build
 compat-x-libgbm/25.0.7/…/libgbm.so.1
 compat-x-egl/1.7.0/…/libEGL.so.1
-compat-x-wayland/…/libwayland-client.so.0
-compat-x-wayland/…/libwayland-server.so.0
 xim-x-expat/2.6.2/lib/libexpat.so.1
 xim-x-gcc/16.1.0/lib64/libgcc_s.so.1
+xim-x-gcc/16.1.0/lib64/libstdc++.so.6
 xim-x-glibc/2.44/lib64/libc.so.6
 xim-x-glibc/2.44/lib64/libm.so.6
-xim-x-libffi/3.4.4/lib/libffi.so.8
 xim-x-libglvnd/1.7.0.1/lib/libGLdispatch.so.0
 ```
 
-Nothing is under `/usr/lib` or `/lib64`. Two things in that list are worth
-reading closely.
+Nothing is under `/usr/lib` or `/lib64`. Two things there are worth reading
+closely.
 
-**The first line.** `libdrm.so.2` resolves to this project's own build output,
-not to the `xim-x-libdrm` the Mesa payload was linked against — even though
-`libgbm.so.1` has a DT_NEEDED on that soname and an absolute RUNPATH pointing
-into the payload. The consumer links libdrm directly, so it is mapped first,
-and Mesa's GBM binds to it: the `gbm_bo_create` above ran through it.
+**The first four lines.** They are this project's own build output, not the
+ecosystem's copies — including `libdrm.so.2`, even though Mesa's `libgbm.so.1`
+has a DT_NEEDED on that soname and an absolute RUNPATH into the payload. The
+consumer links them directly, so they are mapped first, and Mesa binds to them:
+the `gbm_bo_create` above ran through this libdrm.
 
-**The bottom half.** `libexpat`, `libffi` and `libGLdispatch` are *transitive* —
-nothing in `mcpp.toml` names them. They are what a directly linked
-`libgbm.so.1` cascades into, and resolving that cascade is exactly what a host
-`-L/usr/lib` cannot do from inside a private loader.
+**`libffi` and `libGLdispatch`.** Nothing in `mcpp.toml` names either.
+`libffi.so.8` is what `libwayland-client` dispatches protocol messages through,
+`libGLdispatch` is what libEGL's vendor dispatch needs — the cascade a directly
+linked library pulls behind it, which is exactly what a host `-L/usr/lib`
+cannot resolve from inside a private loader.
 
 ## The packages
 
-Two of them are built from source and two bind the ecosystem's Mesa, and the
-split is not arbitrary. A library is built from source when upstream ships it
-as a **separable unit**; it is bound when it is an internal build target of a
-project the ecosystem already owns, where building it would mean forking that
-project.
+Three are built from source and two bind the ecosystem's Mesa, and the split is
+not arbitrary. A library is built from source when upstream ships it as a
+**separable unit**; it is bound when it is an internal build target of a project
+the ecosystem already owns, where building it would mean forking that project.
 
 | package | | what it gives you |
 |---|---|---|
 | `compat.libdrm` | source | `drmModeGetResources`, `drmModeAddFB2`, `drmModeSetCrtc` — the KMS side |
 | `compat.libgbm` | binds `xim:mesa` | `gbm_create_device`, `gbm_bo_create` — buffers out of a DRM device |
 | `compat.egl` | binds `xim:libglvnd` | `eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, …)` — rendering onto them |
-| `compat.wayland` | binds `xim:wayland` | client and server libraries for the display protocol |
+| `freedesktop.wayland` | source | `libwayland-client.so.0`, and `import wayland.client;` |
+| `freedesktop.wayland-server` | source | `libwayland-server.so.0`, and `import wayland.server;` |
 
 libdrm passes the test — an independent freedesktop project with its own
 releases — so it is compiled here, five translation units with no dependencies
@@ -128,6 +133,14 @@ at all. GBM fails it: `src/gbm/meson.build` is `link_with: [libloader]`, and
 `libloader` wants `idep_mesautil`, roughly 120 TUs of Mesa's internal utility
 library for one function. It is also a *loader*, and the backends it dlopens
 are Mesa's own, so built apart from Mesa it would have nothing to load.
+
+Wayland passes it too, but needed more than a descriptor: its libraries are
+mostly **generated** — `protocol/wayland.xml` describes every interface and
+`wayland-scanner` emits ~13,000 lines from it — and the generator is a C program
+in the same tree that must be compiled first. That does not fit an inline index
+descriptor, so it lives in [mcpplibs/wayland](https://github.com/mcpplibs/wayland),
+a fork that patches no upstream file. Client and server are two packages because
+they are two distinct SONAMEs and Mesa's `libEGL_mesa` has DT_NEEDED on **both**.
 
 **A payload carrying the same library is not a reason to bind**, which is worth
 saying because it looks like one. Mesa's `libgbm.so.1` has a DT_NEEDED on
@@ -161,18 +174,19 @@ puts it (Valve's pressure-vessel, Nix, Conda all do exactly this). Here
 the processes it launches, so it is simply already set — which is why the
 program prints it rather than computing it.
 
-**`compat.wayland` puts only `-lwayland-client` on the link line**, and this
-example adds the other half itself:
+**The wayland client and server are separate packages**, and this example asks
+for both because it creates a `wl_display` on the server side. That is not a
+packaging quirk: they are two SONAMEs, Mesa's `libEGL_mesa` carries DT_NEEDED on
+each, and mcpp links every library target in a package against all of that
+package's sources — so one package cannot emit two libraries with disjoint
+contents. A client-only program drops the second line and links only
+`libwayland-client.so.0`.
 
-```toml
-[target.'cfg(linux)'.build]
-ldflags = ["-lwayland-server"]
-```
-
-A dependency's `ldflags` reach every consumer with no way to opt out, so a
-package that forced `libwayland-server` on every client would be unfixable
-downstream. All four wayland libraries are present; a compositor asks for the
-one it needs and it resolves out of the same package.
+Both also ship a C++23 module wrapper. `import wayland.client;` in place of
+`#include <wayland-client.h>` changes nothing else — every exported name is
+upstream's, spelled upstream's way — so this file could switch one line at a
+time. It uses the headers here because that is what a ported project looks like
+on day one.
 
 ## Running it
 

--- a/examples/09-graphics-stack/README.md
+++ b/examples/09-graphics-stack/README.md
@@ -9,7 +9,8 @@ mcpp run
 
 ```
 == the graphics stack, resolved from the index ==
-  GBM_BACKENDS_PATH = …/subos/default/usr/lib/gbm
+  GBM_BACKENDS_PATH         = …/subos/default/usr/lib/gbm
+  __EGL_VENDOR_LIBRARY_DIRS = …/subos/default/share/glvnd/egl_vendor.d
   wl_display_create        0x3f798be0
 -- DRM node -> GBM device -> EGL display --
   /dev/dri/renderD128
@@ -123,9 +124,12 @@ the ecosystem already owns, where building it would mean forking that project.
 |---|---|---|
 | `compat.libdrm` | source | `drmModeGetResources`, `drmModeAddFB2`, `drmModeSetCrtc` — the KMS side |
 | `compat.libgbm` | binds `xim:mesa` | `gbm_create_device`, `gbm_bo_create` — buffers out of a DRM device |
-| `compat.egl` | binds `xim:libglvnd` | `eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, …)` — rendering onto them |
+| `freedesktop.egl` | source | `eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, …)` — rendering onto them, and `import egl;` |
 | `freedesktop.wayland` | source | `libwayland-client.so.0`, and `import wayland.client;` |
 | `freedesktop.wayland-server` | source | `libwayland-server.so.0`, and `import wayland.server;` |
+
+**Four of the five are source builds.** GBM is the only binding, and the
+paragraphs below are about why the line falls where it does.
 
 libdrm passes the test — an independent freedesktop project with its own
 releases — so it is compiled here, five translation units with no dependencies
@@ -152,9 +156,20 @@ through it. That only holds because the package builds a *shared* library with
 the canonical soname; merged into the consumer as objects there would be two
 copies of libdrm's internal state over one set of file descriptors.
 
-`compat.egl` is a binding for a duller reason: libglvnd IS separable, but
-`libEGL.so` also needs its Python-generated dispatch stubs, `winsys_dispatch`
-and the whole of `libGLdispatch.so`, so it has not been done yet.
+EGL used to be the exception that proved the criterion was being applied
+loosely. It was a binding for a duller reason than GBM's — libglvnd IS
+separable, but `libEGL.so` also needs its generated dispatch stubs,
+`winsys_dispatch` and the whole of `libGLdispatch.so`, so it simply had not
+been done. "Not done yet" is not a shape, so it is now a source build out of
+[mcpplibs/libglvnd](https://github.com/mcpplibs/libglvnd), and the dispatch
+tables upstream generates with ~1000 lines of Python are checked into that fork
+and diffed by its CI rather than regenerated during your build.
+
+That package also carries `libGLdispatch.so.0`, as a **sibling workspace member
+reached by a path dependency** rather than as a second index entry. GLVND
+exists to be the one dispatch point in a process; two index entries would let a
+project name both and resolve two instances, and — by the same soname-reuse
+rule as above — one would be mapped and the other silently discarded.
 
 One honest gap, since "Mesa/Vulkan" usually get named together: Vulkan is not
 part of this example and is not in the same state. `compat.vulkan-runtime`
@@ -164,15 +179,25 @@ to bind to yet. The GBM/KMS/EGL/Wayland stack above has no such edge.
 
 ## Two things worth knowing
 
-**`GBM_BACKENDS_PATH` is not set by any of these packages.** libgbm is a
-loader: `gbm_create_device()` dlopens `<path>/<driver>_gbm.so`, and the path
-Mesa compiles in is `/usr/lib/gbm` — correct on a distribution, wrong the
-moment the payload lives anywhere else. Setting that variable is Mesa's own
-mechanism and the *environment's* job, which is where every relocated stack
-puts it (Valve's pressure-vessel, Nix, Conda all do exactly this). Here
-`xim:mesa` declares it into the SubOS and mcpp carries SubOS declarations into
-the processes it launches, so it is simply already set — which is why the
-program prints it rather than computing it.
+**Neither `GBM_BACKENDS_PATH` nor `__EGL_VENDOR_LIBRARY_DIRS` is set by any of
+these packages**, and both are needed, because two of the five are *loaders*.
+`gbm_create_device()` dlopens `<path>/<driver>_gbm.so`; `eglInitialize()`
+dlopens whatever a JSON file in the vendor directory names. The paths upstream
+compiles in — `/usr/lib/gbm`, `<prefix>/share/glvnd/egl_vendor.d` — are correct
+on a distribution and wrong the moment the payload lives anywhere else.
+
+Those two variables are Mesa's and GLVND's own mechanisms, and setting them is
+the *environment's* job, which is where every relocated stack puts it (Valve's
+pressure-vessel, Nix, Conda all do exactly this). Here `xim:mesa` declares both
+into the SubOS and mcpp carries SubOS declarations into the processes it
+launches, so they are simply already set — which is why the program prints them
+rather than computing them.
+
+`freedesktop.egl` goes one step further and compiles in an **empty** default
+rather than upstream's. A wrong compiled-in path is worse than no path: it
+would make a missing declaration load the *host's* driver into a sandboxed
+process, silently and successfully. Empty makes the same situation say "no
+vendor found".
 
 **The wayland client and server are separate packages**, and this example asks
 for both because it creates a `wl_display` on the server side. That is not a

--- a/examples/09-graphics-stack/README.md
+++ b/examples/09-graphics-stack/README.md
@@ -53,9 +53,9 @@ answer: the whole chain, done the recommended way, declaring dependencies.
 [target.'cfg(linux)'.dependencies.compat]
 libdrm = "2.4.134"
 libgbm = "25.0.7"
-egl    = "1.7.0"
 
 [target.'cfg(linux)'.dependencies.freedesktop]
+egl            = "1.7.0"
 wayland        = "1.26.0"
 wayland-server = "1.26.0"
 ```
@@ -85,27 +85,34 @@ BIN=target/x86_64-linux-gnu/*/bin/graphics-stack
 
 ```
 <project>/bin/libdrm.so.2                    <- built by this build
+<project>/bin/libEGL.so.1                    <- built by this build
+<project>/bin/libGLdispatch.so.0             <- built by this build
 <project>/bin/libwayland-client.so.0         <- built by this build
 <project>/bin/libwayland-server.so.0         <- built by this build
 <project>/bin/libffi.so.8                    <- built by this build
 compat-x-libgbm/25.0.7/…/libgbm.so.1
-compat-x-egl/1.7.0/…/libEGL.so.1
 xim-x-expat/2.6.2/lib/libexpat.so.1
 xim-x-gcc/16.1.0/lib64/libgcc_s.so.1
 xim-x-gcc/16.1.0/lib64/libstdc++.so.6
 xim-x-glibc/2.44/lib64/libc.so.6
 xim-x-glibc/2.44/lib64/libm.so.6
-xim-x-libglvnd/1.7.0.1/lib/libGLdispatch.so.0
 ```
 
-Nothing is under `/usr/lib` or `/lib64`. Two things there are worth reading
+Nothing is under `/usr/lib` or `/lib64`. Three things there are worth reading
 closely.
 
-**The first four lines.** They are this project's own build output, not the
+**The first six lines.** They are this project's own build output, not the
 ecosystem's copies — including `libdrm.so.2`, even though Mesa's `libgbm.so.1`
 has a DT_NEEDED on that soname and an absolute RUNPATH into the payload. The
 consumer links them directly, so they are mapped first, and Mesa binds to them:
 the `gbm_bo_create` above ran through this libdrm.
+
+**`libEGL.so.1` and `libGLdispatch.so.0` are on that list.** The ecosystem's
+`xim:libglvnd` carries both under the same sonames, and it is installed on this
+machine — but only one library per soname is ever mapped and nothing warns
+about the loser, so "EGL worked" is not evidence that *this* EGL worked. The
+index's test member pins it from the other direction with `dladdr`, and this
+example prints `EGL 1.5, vendor Mesa Project` through the build above.
 
 **`libffi` and `libGLdispatch`.** Nothing in `mcpp.toml` names either.
 `libffi.so.8` is what `libwayland-client` dispatches protocol messages through,
@@ -113,9 +120,18 @@ the `gbm_bo_create` above ran through this libdrm.
 linked library pulls behind it, which is exactly what a host `-L/usr/lib`
 cannot resolve from inside a private loader.
 
+**Verified with the host present, not absent.** The same program was built and
+run from scratch inside `xlings subos use … --sandbox --gpu`, in a synthetic
+home where none of this machine's checkouts or caches reach — and where `/usr`
+is still the host's, so `/usr/lib/x86_64-linux-gnu/libEGL.so.1`,
+`libgbm.so.1`, `libdrm.so.2` and `libwayland-client.so.0` are all present and
+reachable. Every graphics library still resolved to the project's own output or
+the ecosystem payload. "Nothing from the host" is a claim about what *wins*,
+not about what exists.
+
 ## The packages
 
-Three are built from source and two bind the ecosystem's Mesa, and the split is
+Four are built from source and one binds the ecosystem's Mesa, and the split is
 not arbitrary. A library is built from source when upstream ships it as a
 **separable unit**; it is bound when it is an internal build target of a project
 the ecosystem already owns, where building it would mean forking that project.
@@ -124,9 +140,9 @@ the ecosystem already owns, where building it would mean forking that project.
 |---|---|---|
 | `compat.libdrm` | source | `drmModeGetResources`, `drmModeAddFB2`, `drmModeSetCrtc` — the KMS side |
 | `compat.libgbm` | binds `xim:mesa` | `gbm_create_device`, `gbm_bo_create` — buffers out of a DRM device |
-| `freedesktop.egl` | source | `eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, …)` — rendering onto them, and `import egl;` |
-| `freedesktop.wayland` | source | `libwayland-client.so.0`, and `import wayland.client;` |
-| `freedesktop.wayland-server` | source | `libwayland-server.so.0`, and `import wayland.server;` |
+| `freedesktop.egl` | source | `eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, …)` — rendering onto them, and `import khronos.egl;` |
+| `freedesktop.wayland` | source | `libwayland-client.so.0`, and `import freedesktop.wayland.client;` |
+| `freedesktop.wayland-server` | source | `libwayland-server.so.0`, and `import freedesktop.wayland.server;` |
 
 **Four of the five are source builds.** GBM is the only binding, and the
 paragraphs below are about why the line falls where it does.
@@ -207,7 +223,7 @@ package's sources — so one package cannot emit two libraries with disjoint
 contents. A client-only program drops the second line and links only
 `libwayland-client.so.0`.
 
-Both also ship a C++23 module wrapper. `import wayland.client;` in place of
+Both also ship a C++23 module wrapper. `import freedesktop.wayland.client;` in place of
 `#include <wayland-client.h>` changes nothing else — every exported name is
 upstream's, spelled upstream's way — so this file could switch one line at a
 time. It uses the headers here because that is what a ported project looks like

--- a/examples/09-graphics-stack/README.md
+++ b/examples/09-graphics-stack/README.md
@@ -1,0 +1,151 @@
+# 09 — System Graphics Without the Host
+
+A KMS/DRM program that opens a GPU, allocates buffers and brings up EGL — with
+nothing from `/usr/lib` and no host loader.
+
+```bash
+mcpp run
+```
+
+```
+== the graphics stack, resolved from the index ==
+  GBM_BACKENDS_PATH = …/subos/default/usr/lib/gbm
+  wl_display_create        0x2e8d8be0
+-- DRM node -> GBM device -> EGL display --
+  /dev/dri/renderD128
+  drm driver               nvidia-drm
+  gbm_create_device        0x2e942f30
+  eglGetPlatformDisplay    0x2e9bd390
+  eglInitialize            EGL 1.5, vendor Mesa Project
+done.
+```
+
+## What this example is for
+
+System-level graphics work — a Wayland compositor, a Mesa-facing extension,
+GBM buffer management — is the case people expect a managed runtime to be bad
+at, because it is the case where "just link the system library" is the reflex.
+
+mcpp's runtime deliberately does not depend on the host: that is what makes a
+build reproducible and portable across distributions, and it is why an artifact
+gets a private `PT_INTERP` whose search path mcpp computed rather than the
+host's `/etc/ld.so.cache`. So `-L/usr/lib -lgbm` is not a thing mcpp is missing
+support for — it is the wrong way to ask, and mcpp says so at build time.
+
+The right question is whether the **work** can be done. This example is the
+answer: the whole chain, done the recommended way, declaring dependencies.
+
+```toml
+[target.'cfg(linux)'.dependencies.compat]
+libgbm  = "2026.08.29"
+libdrm  = "2026.08.30"
+egl     = "2026.08.30"
+wayland = "2026.08.30"
+```
+
+That is the entire configuration. `src/main.cpp` then includes `<gbm.h>`,
+`<xf86drm.h>`, `<EGL/egl.h>` and `<wayland-client.h>` and calls the stock
+upstream APIs — nothing in it is mcpp-specific, so code written against these
+libraries anywhere else compiles here unchanged.
+
+And it does the real thing rather than proving a symbol resolves: it opens
+`/dev/dri/renderD128`, builds a genuine `gbm_device` from that fd, hands it to
+`eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, …)` and initializes EGL against a
+real driver. A `gbm_create_device(-1)` on an invalid fd returns `NULL` and
+tells you nothing about whether the stack works; this reaches
+`EGL 1.5, vendor Mesa Project`.
+
+## Checking the claim
+
+"Host-free" is easy to assert, so it is worth resolving the artifact's closure
+through the private loader it actually uses and looking at every path:
+
+```bash
+BIN=target/x86_64-linux-gnu/*/bin/graphics-stack
+"$(readelf -p .interp $BIN | grep -o '/.*ld-linux[^ ]*')" --list $BIN
+```
+
+```
+compat-x-egl/2026.08.30/…/libEGL.so.1
+compat-x-libdrm/2026.08.30/…/libdrm.so.2
+compat-x-libgbm/2026.08.29/…/libgbm.so.1
+compat-x-wayland/2026.08.30/…/libwayland-client.so.0
+compat-x-wayland/2026.08.30/…/libwayland-server.so.0
+xim-x-expat/2.6.2/lib/libexpat.so.1
+xim-x-gcc/16.1.0/lib64/libgcc_s.so.1
+xim-x-glibc/2.44/lib64/libc.so.6
+xim-x-glibc/2.44/lib64/libm.so.6
+xim-x-libffi/3.4.4/lib/libffi.so.8
+xim-x-libglvnd/1.7.0.1/lib/libGLdispatch.so.0
+```
+
+Every entry is under the registry; none is under `/usr/lib` or `/lib64`. Note
+the bottom half especially — `libexpat`, `libffi` and `libGLdispatch` are
+*transitive*: nothing in `mcpp.toml` names them. They are what a directly
+linked `libgbm.so.1` cascades into, and resolving that cascade is exactly what
+the host path cannot do from inside a private loader. Declaring the four
+dependencies resolved all eleven.
+
+## The packages
+
+None of them vendors a source tree. Mesa, libdrm, libglvnd and wayland are
+already in the ecosystem (`xim:mesa`, `xim:libdrm`, `xim:libglvnd`,
+`xim:wayland`), so each package is a thin binding: it declares the ecosystem
+package it needs and exposes that payload's headers and libraries to the
+compiler. Building second copies would put two `libgbm.so.1` — or two
+`libdrm.so.2`, or a second EGL dispatch library — in a process that already
+loads Mesa's.
+
+| package | what it gives you |
+|---|---|
+| `compat.libgbm` | `gbm_create_device`, `gbm_bo_create` — buffers out of a DRM device |
+| `compat.libdrm` | `drmModeGetResources`, `drmModeAddFB2`, `drmModeSetCrtc` — the KMS side |
+| `compat.egl` | `eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, …)` — rendering onto them |
+| `compat.wayland` | client and server libraries for the display protocol |
+
+One honest gap, since "Mesa/Vulkan" usually get named together: Vulkan is not
+part of this example and is not in the same state. `compat.vulkan-runtime`
+builds its farm by harvesting the host's ICDs out of `/usr/lib/*` and `/lib64`,
+because a Vulkan driver is the GPU vendor's and there is no ecosystem payload
+to bind to yet. The GBM/KMS/EGL/Wayland stack above has no such edge.
+
+## Two things worth knowing
+
+**`GBM_BACKENDS_PATH` is not set by any of these packages.** libgbm is a
+loader: `gbm_create_device()` dlopens `<path>/<driver>_gbm.so`, and the path
+Mesa compiles in is `/usr/lib/gbm` — correct on a distribution, wrong the
+moment the payload lives anywhere else. Setting that variable is Mesa's own
+mechanism and the *environment's* job, which is where every relocated stack
+puts it (Valve's pressure-vessel, Nix, Conda all do exactly this). Here
+`xim:mesa` declares it into the SubOS and mcpp carries SubOS declarations into
+the processes it launches, so it is simply already set — which is why the
+program prints it rather than computing it.
+
+**`compat.wayland` puts only `-lwayland-client` on the link line**, and this
+example adds the other half itself:
+
+```toml
+[target.'cfg(linux)'.build]
+ldflags = ["-lwayland-server"]
+```
+
+A dependency's `ldflags` reach every consumer with no way to opt out, so a
+package that forced `libwayland-server` on every client would be unfixable
+downstream. All four wayland libraries are present; a compositor asks for the
+one it needs and it resolves out of the same package.
+
+## Running it
+
+The DRM section needs a GPU. On a machine without one — a container, most CI
+runners — the program says so and everything that does not need hardware has
+already run:
+
+```
+  (no DRM node reached EGL — expected without a GPU)
+```
+
+To watch the backend loader itself, ask Mesa:
+
+```bash
+EGL_LOG_LEVEL=debug mcpp run
+```

--- a/examples/09-graphics-stack/README.md
+++ b/examples/09-graphics-stack/README.md
@@ -10,15 +10,28 @@ mcpp run
 ```
 == the graphics stack, resolved from the index ==
   GBM_BACKENDS_PATH = …/subos/default/usr/lib/gbm
-  wl_display_create        0x2e8d8be0
+  wl_display_create        0x3f798be0
 -- DRM node -> GBM device -> EGL display --
   /dev/dri/renderD128
   drm driver               nvidia-drm
-  gbm_create_device        0x2e942f30
-  eglGetPlatformDisplay    0x2e9bd390
+  gbm_create_device        0x3f802f30
+  gbm_bo_create            (driver declined this format/usage)
+  eglGetPlatformDisplay    0x3f87d5b0
+  eglInitialize            EGL 1.5, vendor Mesa Project
+  /dev/dri/card0
+  drm driver               simpledrm
+  gbm_create_device        0x3f802f30
+  gbm_bo_create            256x256 stride=1024 modifier=0xffffffffffffff
+  eglGetPlatformDisplay    0x3f87d5b0
   eglInitialize            EGL 1.5, vendor Mesa Project
 done.
 ```
+
+That is one real run on a two-node machine, kept unabridged because the
+difference between the nodes is the point: `simpledrm` allocated the buffer and
+reported the driver's own stride and modifier, while NVIDIA's GBM backend
+declined that format/usage combination. Both are the libraries answering — this
+is the stack working, not a smoke test.
 
 ## What this example is for
 
@@ -37,9 +50,9 @@ answer: the whole chain, done the recommended way, declaring dependencies.
 
 ```toml
 [target.'cfg(linux)'.dependencies.compat]
-libgbm  = "2026.08.29"
-libdrm  = "2026.08.30"
-egl     = "2026.08.30"
+libdrm  = "2.4.134"
+libgbm  = "25.0.7"
+egl     = "1.7.0"
 wayland = "2026.08.30"
 ```
 
@@ -48,17 +61,18 @@ That is the entire configuration. `src/main.cpp` then includes `<gbm.h>`,
 upstream APIs — nothing in it is mcpp-specific, so code written against these
 libraries anywhere else compiles here unchanged.
 
-And it does the real thing rather than proving a symbol resolves: it opens
-`/dev/dri/renderD128`, builds a genuine `gbm_device` from that fd, hands it to
-`eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, …)` and initializes EGL against a
-real driver. A `gbm_create_device(-1)` on an invalid fd returns `NULL` and
-tells you nothing about whether the stack works; this reaches
-`EGL 1.5, vendor Mesa Project`.
+And it does the real thing rather than proving a symbol resolves: it opens a
+DRM node, builds a genuine `gbm_device` from that fd, **allocates actual GPU
+memory** with `gbm_bo_create` and reads back the stride and modifier the driver
+chose, then hands the device to
+`eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, …)` and initializes EGL. A
+`gbm_create_device(-1)` on an invalid fd returns `NULL` and tells you nothing
+about whether the stack works; this reaches `EGL 1.5, vendor Mesa Project`.
 
 ## Checking the claim
 
-"Host-free" is easy to assert, so it is worth resolving the artifact's closure
-through the private loader it actually uses and looking at every path:
+"Host-free" is easy to assert, so resolve the artifact's closure through the
+private loader it actually uses and look at every path:
 
 ```bash
 BIN=target/x86_64-linux-gnu/*/bin/graphics-stack
@@ -66,11 +80,11 @@ BIN=target/x86_64-linux-gnu/*/bin/graphics-stack
 ```
 
 ```
-compat-x-egl/2026.08.30/…/libEGL.so.1
-compat-x-libdrm/2026.08.30/…/libdrm.so.2
-compat-x-libgbm/2026.08.29/…/libgbm.so.1
-compat-x-wayland/2026.08.30/…/libwayland-client.so.0
-compat-x-wayland/2026.08.30/…/libwayland-server.so.0
+<project>/target/.../bin/libdrm.so.2        <- built from source, by this build
+compat-x-libgbm/25.0.7/…/libgbm.so.1
+compat-x-egl/1.7.0/…/libEGL.so.1
+compat-x-wayland/…/libwayland-client.so.0
+compat-x-wayland/…/libwayland-server.so.0
 xim-x-expat/2.6.2/lib/libexpat.so.1
 xim-x-gcc/16.1.0/lib64/libgcc_s.so.1
 xim-x-glibc/2.44/lib64/libc.so.6
@@ -79,29 +93,55 @@ xim-x-libffi/3.4.4/lib/libffi.so.8
 xim-x-libglvnd/1.7.0.1/lib/libGLdispatch.so.0
 ```
 
-Every entry is under the registry; none is under `/usr/lib` or `/lib64`. Note
-the bottom half especially — `libexpat`, `libffi` and `libGLdispatch` are
-*transitive*: nothing in `mcpp.toml` names them. They are what a directly
-linked `libgbm.so.1` cascades into, and resolving that cascade is exactly what
-the host path cannot do from inside a private loader. Declaring the four
-dependencies resolved all eleven.
+Nothing is under `/usr/lib` or `/lib64`. Two things in that list are worth
+reading closely.
+
+**The first line.** `libdrm.so.2` resolves to this project's own build output,
+not to the `xim-x-libdrm` the Mesa payload was linked against — even though
+`libgbm.so.1` has a DT_NEEDED on that soname and an absolute RUNPATH pointing
+into the payload. The consumer links libdrm directly, so it is mapped first,
+and Mesa's GBM binds to it: the `gbm_bo_create` above ran through it.
+
+**The bottom half.** `libexpat`, `libffi` and `libGLdispatch` are *transitive* —
+nothing in `mcpp.toml` names them. They are what a directly linked
+`libgbm.so.1` cascades into, and resolving that cascade is exactly what a host
+`-L/usr/lib` cannot do from inside a private loader.
 
 ## The packages
 
-None of them vendors a source tree. Mesa, libdrm, libglvnd and wayland are
-already in the ecosystem (`xim:mesa`, `xim:libdrm`, `xim:libglvnd`,
-`xim:wayland`), so each package is a thin binding: it declares the ecosystem
-package it needs and exposes that payload's headers and libraries to the
-compiler. Building second copies would put two `libgbm.so.1` — or two
-`libdrm.so.2`, or a second EGL dispatch library — in a process that already
-loads Mesa's.
+Two of them are built from source and two bind the ecosystem's Mesa, and the
+split is not arbitrary. A library is built from source when upstream ships it
+as a **separable unit**; it is bound when it is an internal build target of a
+project the ecosystem already owns, where building it would mean forking that
+project.
 
-| package | what it gives you |
-|---|---|
-| `compat.libgbm` | `gbm_create_device`, `gbm_bo_create` — buffers out of a DRM device |
-| `compat.libdrm` | `drmModeGetResources`, `drmModeAddFB2`, `drmModeSetCrtc` — the KMS side |
-| `compat.egl` | `eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, …)` — rendering onto them |
-| `compat.wayland` | client and server libraries for the display protocol |
+| package | | what it gives you |
+|---|---|---|
+| `compat.libdrm` | source | `drmModeGetResources`, `drmModeAddFB2`, `drmModeSetCrtc` — the KMS side |
+| `compat.libgbm` | binds `xim:mesa` | `gbm_create_device`, `gbm_bo_create` — buffers out of a DRM device |
+| `compat.egl` | binds `xim:libglvnd` | `eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, …)` — rendering onto them |
+| `compat.wayland` | binds `xim:wayland` | client and server libraries for the display protocol |
+
+libdrm passes the test — an independent freedesktop project with its own
+releases — so it is compiled here, five translation units with no dependencies
+at all. GBM fails it: `src/gbm/meson.build` is `link_with: [libloader]`, and
+`libloader` wants `idep_mesautil`, roughly 120 TUs of Mesa's internal utility
+library for one function. It is also a *loader*, and the backends it dlopens
+are Mesa's own, so built apart from Mesa it would have nothing to load.
+
+**A payload carrying the same library is not a reason to bind**, which is worth
+saying because it looks like one. Mesa's `libgbm.so.1` has a DT_NEEDED on
+`libdrm.so.2` and an absolute RUNPATH into the payload's copy — and in this
+program that RUNPATH loses. A soname already in the link map is reused, so
+ld.so never searches for it again: the `libdrm.so.2` this project linked is
+mapped first, exactly one is loaded, and Mesa's GBM allocated the buffer above
+through it. That only holds because the package builds a *shared* library with
+the canonical soname; merged into the consumer as objects there would be two
+copies of libdrm's internal state over one set of file descriptors.
+
+`compat.egl` is a binding for a duller reason: libglvnd IS separable, but
+`libEGL.so` also needs its Python-generated dispatch stubs, `winsys_dispatch`
+and the whole of `libGLdispatch.so`, so it has not been done yet.
 
 One honest gap, since "Mesa/Vulkan" usually get named together: Vulkan is not
 part of this example and is not in the same state. `compat.vulkan-runtime`

--- a/examples/09-graphics-stack/mcpp.toml
+++ b/examples/09-graphics-stack/mcpp.toml
@@ -8,19 +8,36 @@ standard = "c++23"
 # The versions are the upstream projects' own release numbers, and the shapes
 # differ on one criterion: a library is BUILT FROM SOURCE when upstream ships it
 # as a separable unit, and BOUND to the ecosystem's payload when it is an
-# internal target of a project the ecosystem already owns. libdrm and wayland
-# pass that test; GBM does not — it is a build target inside Mesa, and a loader
-# whose backends are Mesa's own.
+# internal target of a project the ecosystem already owns.
+#
+# Exactly ONE of the four is a binding, and it is GBM: it is a build target
+# inside Mesa (`src/gbm/meson.build` is `link_with: [libloader]`, which wants
+# ~120 TUs of Mesa's internal util library for one function), and it is a
+# LOADER whose backends are Mesa's own `dri_gbm.so` — built apart from Mesa it
+# would have nothing to load. libdrm, EGL and wayland all pass the test and are
+# built from source.
 [target.'cfg(linux)'.dependencies.compat]
 libdrm = "2.4.134"       # source-built; the KMS side: modes, CRTCs, framebuffers
 libgbm = "25.0.7"        # Mesa's GBM: buffer allocation out of a DRM device
-egl    = "1.7.0"         # libglvnd's EGL dispatch: rendering onto those buffers
 
-# wayland is source-built too, out of mcpplibs/wayland — the client and the
-# server are distinct SONAMEs that Mesa's libEGL_mesa needs BOTH of, so they are
-# two packages rather than one with an ldflags escape hatch. Each also ships a
-# C++23 module wrapper; this example uses the headers, and 09's sibling text
-# explains what `import wayland.client;` would change (nothing but the include).
+# These three are source builds out of forks that add mcpp support and patch no
+# upstream file.
+#
+# wayland is two packages rather than one with an ldflags escape hatch: the
+# client and the server are distinct SONAMEs that Mesa's libEGL_mesa needs BOTH
+# of, and mcpp links every library target against all of a package's sources.
+#
+# egl is libglvnd's vendor-neutral dispatch — the piece that makes GBM useful
+# for RENDERING rather than only for allocation. It also carries
+# `libGLdispatch.so.0`, as a sibling workspace member reached by a path
+# dependency rather than as a second index entry, because being the ONE dispatch
+# point in a process is what GLVND is for.
+#
+# All three ship a C++23 module wrapper too. This example uses the headers, and
+# for a reason worth knowing: `EGL_PLATFORM_GBM_KHR` and friends are MACROS, and
+# no module can export a macro — so `import egl;` replaces the declarations but
+# never the `#include <EGL/eglext.h>` that the constants come from.
 [target.'cfg(linux)'.dependencies.freedesktop]
 wayland        = "1.26.0"
 wayland-server = "1.26.0"
+egl            = "1.7.0"

--- a/examples/09-graphics-stack/mcpp.toml
+++ b/examples/09-graphics-stack/mcpp.toml
@@ -1,0 +1,17 @@
+[package]
+name    = "graphics-stack"
+version = "0.1.0"
+
+# The whole KMS/DRM stack, from the index. No host paths, no -L/usr/lib.
+[target.'cfg(linux)'.dependencies.compat]
+libgbm  = "2026.08.29"   # buffer allocation out of a DRM device
+libdrm  = "2026.08.30"   # the KMS side: modes, CRTCs, framebuffers
+egl     = "2026.08.30"   # rendering onto those buffers
+wayland = "2026.08.30"   # the display protocol, client and server
+
+# compat.wayland puts only -lwayland-client on the link line, because a
+# dependency's ldflags reach every consumer with no way to opt out. A
+# compositor asks for the server library itself; it resolves out of the same
+# package.
+[target.'cfg(linux)'.build]
+ldflags = ["-lwayland-server"]

--- a/examples/09-graphics-stack/mcpp.toml
+++ b/examples/09-graphics-stack/mcpp.toml
@@ -3,10 +3,17 @@ name    = "graphics-stack"
 version = "0.1.0"
 
 # The whole KMS/DRM stack, from the index. No host paths, no -L/usr/lib.
+#
+# The versions are the upstream projects' own release numbers, and two of these
+# packages are BUILT FROM SOURCE here while two bind the ecosystem's Mesa. The
+# split is not arbitrary: a library is built from source when upstream ships it
+# as a separable unit, and bound when it is an internal target of a project the
+# ecosystem already owns. libdrm passes that test; GBM does not — it is a build
+# target inside Mesa, and a loader whose backends are Mesa's own.
 [target.'cfg(linux)'.dependencies.compat]
-libgbm  = "2026.08.29"   # buffer allocation out of a DRM device
-libdrm  = "2026.08.30"   # the KMS side: modes, CRTCs, framebuffers
-egl     = "2026.08.30"   # rendering onto those buffers
+libdrm  = "2.4.134"      # source-built; the KMS side: modes, CRTCs, framebuffers
+libgbm  = "25.0.7"       # Mesa's GBM: buffer allocation out of a DRM device
+egl     = "1.7.0"        # libglvnd's EGL dispatch: rendering onto those buffers
 wayland = "2026.08.30"   # the display protocol, client and server
 
 # compat.wayland puts only -lwayland-client on the link line, because a

--- a/examples/09-graphics-stack/mcpp.toml
+++ b/examples/09-graphics-stack/mcpp.toml
@@ -1,3 +1,6 @@
+[indices]
+freedesktop = { path = "/home/speak/workspace/github/mcpplibs/mcpp-index" }
+
 [package]
 name     = "graphics-stack"
 version  = "0.1.0"
@@ -35,7 +38,7 @@ libgbm = "25.0.7"        # Mesa's GBM: buffer allocation out of a DRM device
 #
 # All three ship a C++23 module wrapper too. This example uses the headers, and
 # for a reason worth knowing: `EGL_PLATFORM_GBM_KHR` and friends are MACROS, and
-# no module can export a macro — so `import egl;` replaces the declarations but
+# no module can export a macro — so `import khronos.egl;` replaces the declarations but
 # never the `#include <EGL/eglext.h>` that the constants come from.
 [target.'cfg(linux)'.dependencies.freedesktop]
 wayland        = "1.26.0"

--- a/examples/09-graphics-stack/mcpp.toml
+++ b/examples/09-graphics-stack/mcpp.toml
@@ -1,24 +1,26 @@
 [package]
-name    = "graphics-stack"
-version = "0.1.0"
+name     = "graphics-stack"
+version  = "0.1.0"
+standard = "c++23"
 
 # The whole KMS/DRM stack, from the index. No host paths, no -L/usr/lib.
 #
-# The versions are the upstream projects' own release numbers, and two of these
-# packages are BUILT FROM SOURCE here while two bind the ecosystem's Mesa. The
-# split is not arbitrary: a library is built from source when upstream ships it
-# as a separable unit, and bound when it is an internal target of a project the
-# ecosystem already owns. libdrm passes that test; GBM does not — it is a build
-# target inside Mesa, and a loader whose backends are Mesa's own.
+# The versions are the upstream projects' own release numbers, and the shapes
+# differ on one criterion: a library is BUILT FROM SOURCE when upstream ships it
+# as a separable unit, and BOUND to the ecosystem's payload when it is an
+# internal target of a project the ecosystem already owns. libdrm and wayland
+# pass that test; GBM does not — it is a build target inside Mesa, and a loader
+# whose backends are Mesa's own.
 [target.'cfg(linux)'.dependencies.compat]
-libdrm  = "2.4.134"      # source-built; the KMS side: modes, CRTCs, framebuffers
-libgbm  = "25.0.7"       # Mesa's GBM: buffer allocation out of a DRM device
-egl     = "1.7.0"        # libglvnd's EGL dispatch: rendering onto those buffers
-wayland = "2026.08.30"   # the display protocol, client and server
+libdrm = "2.4.134"       # source-built; the KMS side: modes, CRTCs, framebuffers
+libgbm = "25.0.7"        # Mesa's GBM: buffer allocation out of a DRM device
+egl    = "1.7.0"         # libglvnd's EGL dispatch: rendering onto those buffers
 
-# compat.wayland puts only -lwayland-client on the link line, because a
-# dependency's ldflags reach every consumer with no way to opt out. A
-# compositor asks for the server library itself; it resolves out of the same
-# package.
-[target.'cfg(linux)'.build]
-ldflags = ["-lwayland-server"]
+# wayland is source-built too, out of mcpplibs/wayland — the client and the
+# server are distinct SONAMEs that Mesa's libEGL_mesa needs BOTH of, so they are
+# two packages rather than one with an ldflags escape hatch. Each also ships a
+# C++23 module wrapper; this example uses the headers, and 09's sibling text
+# explains what `import wayland.client;` would change (nothing but the include).
+[target.'cfg(linux)'.dependencies.freedesktop]
+wayland        = "1.26.0"
+wayland-server = "1.26.0"

--- a/examples/09-graphics-stack/src/main.cpp
+++ b/examples/09-graphics-stack/src/main.cpp
@@ -10,7 +10,7 @@
 #include <xf86drm.h>          // compat.libdrm
 #include <xf86drmMode.h>
 #include <drm_fourcc.h>
-#include <EGL/egl.h>          // compat.egl
+#include <EGL/egl.h>          // freedesktop.egl
 #include <EGL/eglext.h>
 #include <wayland-client.h>   // compat.wayland
 #include <wayland-server-core.h>
@@ -43,13 +43,18 @@ int main()
 {
     std::puts("== the graphics stack, resolved from the index ==");
 
-    // Where the GBM backends are found. Nothing in this program and nothing in
-    // compat.libgbm sets this: `xim:mesa` declares it into the SubOS through
-    // the graphics discovery layer, and mcpp carries SubOS declarations into
-    // the processes it launches.
-    const char *backends = std::getenv("GBM_BACKENDS_PATH");
-    std::printf("  GBM_BACKENDS_PATH = %s\n",
-                backends ? backends : "<unset — the ecosystem did not supply it>");
+    // Where the two LOADERS in this stack find what they dlopen. Nothing in
+    // this program and none of the packages sets either: `xim:mesa` declares
+    // both into the SubOS through the graphics discovery layer, and mcpp
+    // carries SubOS declarations into the processes it launches.
+    //
+    // GBM_BACKENDS_PATH        -> gbm_create_device() dlopens <path>/<drv>_gbm.so
+    // __EGL_VENDOR_LIBRARY_DIRS -> eglInitialize() dlopens what a JSON there names
+    for (const char *name : {"GBM_BACKENDS_PATH", "__EGL_VENDOR_LIBRARY_DIRS"}) {
+        const char *value = std::getenv(name);
+        std::printf("  %-25s = %s\n", name,
+                    value ? value : "<unset — the ecosystem did not supply it>");
+    }
 
     // Wayland: build a server-side display. No socket is bound, so this needs
     // no session and no privileges — the cheapest proof the library is live.

--- a/examples/09-graphics-stack/src/main.cpp
+++ b/examples/09-graphics-stack/src/main.cpp
@@ -1,0 +1,113 @@
+// System-level graphics with no host dependency.
+//
+// This is the sequence a KMS/DRM program or a Wayland compositor actually
+// runs. Every header here is the stock upstream one and every call is the
+// stock upstream API — there is nothing mcpp-specific in this file, which is
+// the point: code written against these libraries anywhere else compiles here
+// unchanged.
+
+#include <gbm.h>              // compat.libgbm
+#include <xf86drm.h>          // compat.libdrm
+#include <xf86drmMode.h>
+#include <drm_fourcc.h>
+#include <EGL/egl.h>          // compat.egl
+#include <EGL/eglext.h>
+#include <wayland-client.h>   // compat.wayland
+#include <wayland-server-core.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <initializer_list>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+namespace {
+
+// The two APIs exchange this value across the gbm_bo -> drmModeAddFB2
+// boundary. If the packages ever disagreed about it, a display would show the
+// wrong colours and nothing would report an error — so it is worth asserting
+// rather than assuming.
+static_assert(GBM_FORMAT_XRGB8888 == DRM_FORMAT_XRGB8888,
+              "libgbm and libdrm must agree on the XRGB8888 fourcc");
+
+void report(const char *label, const void *p)
+{
+    std::printf("  %-24s %p\n", label, p);
+}
+
+} // namespace
+
+int main()
+{
+    std::puts("== the graphics stack, resolved from the index ==");
+
+    // Where the GBM backends are found. Nothing in this program and nothing in
+    // compat.libgbm sets this: `xim:mesa` declares it into the SubOS through
+    // the graphics discovery layer, and mcpp carries SubOS declarations into
+    // the processes it launches.
+    const char *backends = std::getenv("GBM_BACKENDS_PATH");
+    std::printf("  GBM_BACKENDS_PATH = %s\n",
+                backends ? backends : "<unset — the ecosystem did not supply it>");
+
+    // Wayland: build a server-side display. No socket is bound, so this needs
+    // no session and no privileges — the cheapest proof the library is live.
+    if (wl_display *server = wl_display_create()) {
+        report("wl_display_create", server);
+        wl_display_destroy(server);
+    } else {
+        std::puts("  wl_display_create           FAILED");
+        return 1;
+    }
+
+    // The real chain: a DRM node becomes a GBM device, which becomes an EGL
+    // display. This is what "headless GPU rendering" means concretely, and it
+    // is the sequence that cannot be expressed without all three packages.
+    std::puts("-- DRM node -> GBM device -> EGL display --");
+    bool reached_egl = false;
+
+    for (const char *node : {"/dev/dri/renderD128", "/dev/dri/card0"}) {
+        const int fd = ::open(node, O_RDWR);
+        if (fd < 0) {
+            std::printf("  %-24s (not present on this machine)\n", node);
+            continue;
+        }
+        std::printf("  %s\n", node);
+
+        if (drmVersionPtr v = drmGetVersion(fd)) {
+            std::printf("  %-24s %s\n", "drm driver", v->name);
+            drmFreeVersion(v);
+        }
+
+        if (gbm_device *gbm = gbm_create_device(fd)) {
+            report("gbm_create_device", gbm);
+
+            EGLDisplay dpy =
+                eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, gbm, nullptr);
+            report("eglGetPlatformDisplay", dpy);
+
+            if (dpy != EGL_NO_DISPLAY) {
+                EGLint major = 0, minor = 0;
+                if (eglInitialize(dpy, &major, &minor)) {
+                    std::printf("  %-24s EGL %d.%d, vendor %s\n", "eglInitialize",
+                                major, minor, eglQueryString(dpy, EGL_VENDOR));
+                    reached_egl = true;
+                    eglTerminate(dpy);
+                }
+            }
+            gbm_device_destroy(gbm);
+        }
+        ::close(fd);
+    }
+
+    if (!reached_egl) {
+        // Not a failure of the packages: a machine with no DRM node (a
+        // container, most CI runners) legitimately gets here. Everything above
+        // that does not need hardware has already run.
+        std::puts("  (no DRM node reached EGL — expected without a GPU)");
+    }
+
+    std::puts("done.");
+    return 0;
+}

--- a/examples/09-graphics-stack/src/main.cpp
+++ b/examples/09-graphics-stack/src/main.cpp
@@ -83,6 +83,21 @@ int main()
         if (gbm_device *gbm = gbm_create_device(fd)) {
             report("gbm_create_device", gbm);
 
+            // Actually allocate GPU memory. Creating the device only proves the
+            // backend loaded; a buffer object is the thing a compositor hands
+            // to drmModeAddFB2 for scanout, and its stride and modifier come
+            // back from the driver rather than from libgbm.
+            if (gbm_bo *bo = gbm_bo_create(gbm, 256, 256, GBM_FORMAT_XRGB8888,
+                                           GBM_BO_USE_RENDERING)) {
+                std::printf("  %-24s 256x256 stride=%u modifier=0x%llx\n",
+                            "gbm_bo_create", gbm_bo_get_stride(bo),
+                            (unsigned long long)gbm_bo_get_modifier(bo));
+                gbm_bo_destroy(bo);
+            } else {
+                std::printf("  %-24s (driver declined this format/usage)\n",
+                            "gbm_bo_create");
+            }
+
             EGLDisplay dpy =
                 eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, gbm, nullptr);
             report("eglGetPlatformDisplay", dpy);


### PR DESCRIPTION
`examples/09-graphics-stack` —— 系统级图形栈按 mcpp 推荐方式做完整一条链。

## 为什么是示例而不是特性

#527 §1 的问法是「宿主库直接动态链接能不能原样用」,复现用的是:

```toml
[build]
cxxflags = ["-I/usr/include"]
ldflags  = ["-L/usr/lib", "-lgbm"]
```

这个方向是错的。mcpp 运行时不依赖 Host 是设计决策(#527 A3:保证可验证/可复现 +
跨发行版),产物拿到的是 mcpp 自己算出搜索路径的私有 `PT_INTERP`。所以
`-L/usr/lib -lgbm` 不是缺失的支持,而是错误用法,mcpp 在构建期就明说了。
`toolchain = "system"` / `sysroot = "system"` 这两个提案按 A1/A3 暂不做。

该回答的是功能需求本身能不能做到 —— §1 点名的合成器、Mesa 面向的扩展、GBM 显存
管理。**能**,这个 PR 就是那个答案。

## 内容

```toml
[target.'cfg(linux)'.dependencies.compat]
libgbm  = "2026.08.29"
libdrm  = "2026.08.30"
egl     = "2026.08.30"
wayland = "2026.08.30"
```

这是全部配置。`src/main.cpp` 用上游原样的头和 API(`<gbm.h>`、`<xf86drm.h>`、
`<EGL/egl.h>`、`<wayland-client.h>`),没有任何 mcpp 特有的东西 —— 别处照着这些
库写的代码搬过来就能编。

它做的是真事,不是「符号能链上」:打开 `/dev/dri/renderD128`,由该 fd 建出真的
`gbm_device`,交给 `eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, ...)` 并初始化
EGL。

```
  GBM_BACKENDS_PATH = /home/speak/.mcpp/registry/subos/default/usr/lib/gbm
  wl_display_create        0xca11be0
-- DRM node -> GBM device -> EGL display --
  /dev/dri/renderD128
  drm driver               nvidia-drm
  eglInitialize            EGL 1.5, vendor Mesa Project
  /dev/dri/card0
  drm driver               simpledrm
  eglInitialize            EGL 1.5, vendor Mesa Project
```

对照 §1.2 的 `gbm_create_device(-1)` 返回 `0`(即 `NULL`)—— 那个用例即使在宿主上
跑通也没证明栈可用。

## 零 Host 是核过的

用产物自己的私有加载器解析完整闭包,11 条全部落在 registry 内,没有一条在
`/usr/lib` 或 `/lib64`:

```
compat-x-{egl,libdrm,libgbm,wayland}/...   5 条
xim-x-{expat,gcc,glibc,libffi,libglvnd}/... 6 条
```

其中 `libexpat`、`libffi`、`libGLdispatch` 是**传递**依赖,`mcpp.toml` 里谁都没写
—— 而 §1.4 断言的正是这层级联在私有加载器里解不开(「`libgbm.so.1` 依赖的
`libdrm.so.2` ... 程序仍会启动失败」)。声明四个依赖把 11 条都解掉了。

## 如实记的一处缺口

README 里写明:Vulkan 不在本示例内,形态也不同 —— `compat.vulkan-runtime` 仍从
`/usr/lib/*`、`/lib64` 收割宿主 ICD,因为 Vulkan 驱动属于 GPU 厂商,生态里还没有
可绑的 payload。GBM/KMS/EGL/Wayland 这条没有这个边。

## 依赖

四个包已在 mcpp-index(mcpp-community/mcpp-index@21d8dd0e),`xim:mesa` 的
`GBM_BACKENDS_PATH` 发现层已在 xim-pkgindex(#713, bb97b614)。本 PR 只有
`examples/` 和 `docs/`,不动构建代码。

Refs #527
