### PR TITLE
docs: 修正 Hook 音频播放器示例

### DIFF
--- a/docs/05-mcpp-toml.md
+++ b/docs/05-mcpp-toml.md
@@ -2154,9 +2154,6 @@ build_start = "echo build started"
 build_failed = "notify-send 'build failed'"
 build_finished = "notify-send 'build finished'"
 
-# Runs alongside the build and is stopped when it ends.
-during_build = { cmd = "mcpp-hooks-audioplayer bgm", loop = true }
-
 # Optional; these are the defaults.
 timeout_seconds = 10
 enabled = true
@@ -2207,8 +2204,8 @@ build_start
     └─ build fails    → during_build closes → build_failed
 ```
 
-`during_build` closes **before** the terminal hook, so a "build finished" sound
-is not competing with the background music it replaces.
+`during_build` closes **before** the terminal hook, so the two commands never
+overlap.
 
 `build_failed` and `build_finished` are mutually exclusive, and both are
 reachable only after `build_start` has run. A project that cannot be *prepared*
@@ -2286,7 +2283,6 @@ than adding media handling to mcpp:
 
 ```toml
 [hooks]
-during_build = { cmd = "mcpp-hooks-audioplayer bgm", loop = true }
 build_finished = "mcpp-hooks-audioplayer niulai-mm"
 build_failed = "mcpp-hooks-audioplayer niulai-niulai"
 side_effect = false
@@ -2295,11 +2291,10 @@ side_effect = false
 deps = ["xim:mcpp-hooks-audioplayer@0.0.1"]
 ```
 
-Background music for the length of the build, and a different sound for how it
-ended. `side_effect = false` is written out rather than left to the default:
-it is the value this manifest wants on its own terms — a missing audio device
-should never fail a build — so it will still say so once the key has more than
-one accepted value.
+A different sound for a successful or failed build. `side_effect = false` is
+written out rather than left to the default: it is the value this manifest
+wants on its own terms — a missing audio device should never fail a build — so
+it will still say so once the key has more than one accepted value.
 
 ## Appendix A. Schema Ownership Principle (admission criteria for new fields)
 

--- a/docs/zh/05-mcpp-toml.md
+++ b/docs/zh/05-mcpp-toml.md
@@ -1845,9 +1845,6 @@ build_start = "echo build started"
 build_failed = "notify-send 'build failed'"
 build_finished = "notify-send 'build finished'"
 
-# 与构建并行,构建结束时被停止。
-during_build = { cmd = "mcpp-hooks-audioplayer bgm", loop = true }
-
 # 可选;以下是默认值。
 timeout_seconds = 10
 enabled = true
@@ -1893,8 +1890,7 @@ build_start
     └─ 构建失败 → during_build 闭合 → build_failed
 ```
 
-`during_build` 在终止 Hook **之前**闭合,这样"构建完成"的提示音不会和它要替换掉的
-背景音乐撞在一起。
+`during_build` 在终止 Hook **之前**闭合,因此两条命令不会重叠执行。
 
 `build_failed` 与 `build_finished` 互斥,而且两者都只在 `build_start` 已经执行之后
 才可达。项目**准备**阶段就失败的情况——manifest 非法、依赖无法解析、没有可用工具链
@@ -1953,7 +1949,6 @@ Hook 程序可以作为普通 xlings 依赖安装。例如,音频通知程序可
 
 ```toml
 [hooks]
-during_build = { cmd = "mcpp-hooks-audioplayer bgm", loop = true }
 build_finished = "mcpp-hooks-audioplayer niulai-mm"
 build_failed = "mcpp-hooks-audioplayer niulai-niulai"
 side_effect = false
@@ -1962,9 +1957,9 @@ side_effect = false
 deps = ["xim:mcpp-hooks-audioplayer@0.0.1"]
 ```
 
-构建全程的背景音乐,加上一段区分结果的提示音。`side_effect = false` 写出来而不是靠
-默认值:它是这份 manifest 自己就想要的值——缺个音频设备不该让构建失败——所以等这个键
-有了不止一个可接受的值之后,它仍然会这么写。
+根据构建成功或失败播放不同提示音。`side_effect = false` 写出来而不是靠默认值:它是
+这份 manifest 自己就想要的值——缺个音频设备不该让构建失败——所以等这个键有了不止
+一个可接受的值之后,它仍然会这么写。
 
 ## 附录 A. Schema 所有权原则(新字段准入标准)
 


### PR DESCRIPTION
## 说明

当前文档使用 `mcpp-hooks-audioplayer bgm` 演示 `during_build`，但已发布的 `mcpp-hooks-audioplayer` 0.0.1 只支持 `niulai-mm` 和 `niulai-niulai`。复制原示例会使 Hook 命令以参数错误退出。

## 修改

- 从中英文配置示例和音频应用示例中删除不存在的 `bgm` 子命令。
- 音频应用示例只保留已实现的构建成功、失败提示音。
- 将 `during_build` 的闭合顺序说明改为通用表述，保留该功能的完整行为说明。

## 验证

- `git diff --check`：通过。
- 两份文档中搜索 `mcpp-hooks-audioplayer bgm`：无匹配。
