### PR TITLE
design: the ecosystem consumer resolves for three targets on the released engine

### DIFF
--- a/.agents/docs/2026-09-02-runner-beyond-baremetal-design.md
+++ b/.agents/docs/2026-09-02-runner-beyond-baremetal-design.md
@@ -908,6 +908,16 @@ fails when something is thrown, so a destructor run during the unwind is what
 separates the two. It answers `yes` under the emulator, which means the runner
 carried a working C++ runtime rather than merely starting the process.
 
+The same consumer was then built for three targets from the same SubOS, to
+establish that the release did not narrow what the ecosystem resolves:
+
+```
+x86_64-linux:        BUILD-OK
+aarch64-linux-musl:  BUILD-OK
+x86_64-windows-gnu:  BUILD-OK
+host run:            RUN-OK
+```
+
 ### 13.4 Release state
 
 | | |


### PR DESCRIPTION
Documentation only, against the 2026.9.2.1 design record.

Section 13.3 recorded the openkal consumer for one target. The release changes what `[xlings]` accepts and when a runner is consulted, and neither is scoped to a target, so the claim that it narrowed nothing has to name more than the one target the runner verification used.

Measured in the same sandbox SubOS, on the published 2026.9.2.1:

```
x86_64-linux:        BUILD-OK
aarch64-linux-musl:  BUILD-OK
x86_64-windows-gnu:  BUILD-OK
host run:            RUN-OK
```