### PR TITLE
test(e2e): 340 只数它自己那个目录里的 ninja

### DIFF
--- a/tests/e2e/340_no_orphan_survives_a_killed_mcpp.sh
+++ b/tests/e2e/340_no_orphan_survives_a_killed_mcpp.sh
@@ -33,12 +33,23 @@ work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
 cd "$work"
 mkdir -p src
 
-# Counting by executable name, not by a `pgrep -f` pattern: this script's own
-# command line contains the word, and a pattern match finds itself.
+# COUNTING BY EXECUTABLE NAME AND BY WORKING DIRECTORY, AND BOTH HALVES MATTER.
+#
+# Not by a `pgrep -f` pattern: this script's own command line contains the word,
+# and a pattern match finds itself.
+#
+# And not every ninja on the machine: a build server, a developer's second
+# checkout, or another test running in parallel can start one inside this
+# check's window, and a baseline taken before the build does not cover a process
+# that appears during it. Measured in an ecosystem sandbox — which shares the
+# host's PID namespace — where an unrelated session's ninja in a different
+# project failed this assertion. The predicate was right and the object was
+# wrong.
 count_ninja() {
   local n=0 p
   for p in /proc/[0-9]*; do
-    [[ "$(cat "$p/comm" 2>/dev/null)" == "ninja" ]] && n=$((n+1))
+    [[ "$(cat "$p/comm" 2>/dev/null)" == "ninja" ]] || continue
+    case "$(readlink "$p/cwd" 2>/dev/null)" in "$work"*) n=$((n+1));; esac
   done
   echo "$n"
 }


### PR DESCRIPTION
谓词对、**对象错**:`count_ninja` 数的是整台机器上的 ninja。事先取的基线只能覆盖「本来就在跑的」,覆盖不了「窗口期间新出现的」。

实测于生态沙箱(它与宿主共享 PID 命名空间):**另一个会话在完全不相干的工程里**跑的 ninja,让一个已经带有修复的构建判成失败。

现在按进程的工作目录限定到测试自己的 `$work` 子树。并已确认限定没有削弱它:对已发布的 2026.9.4.2 仍然变红,并指名孤儿及其目录。