### PR TITLE
fix(doctor): give the nvcc probe a directory this process created

### DIFF
--- a/src/doctor.cppm
+++ b/src/doctor.cppm
@@ -113,12 +113,17 @@ std::optional<std::string> unreachable_device_stage() {
     namespace fs = std::filesystem;
     std::error_code ec;
 
-    const auto probe = fs::temp_directory_path(ec) / "mcpp-nvcc-dryrun";
+    // A fresh directory per run, on the pattern the p1689 scanner already
+    // uses. A fixed name under the shared temporary directory would be a
+    // path another user can create first, and the `remove_all` that a fixed
+    // name needs in order to be reusable is the part that makes that matter.
+    const auto probe = fs::temp_directory_path(ec)
+                     / std::format("mcpp_nvcc_dryrun_{}", std::random_device{}());
     if (ec) return std::nullopt;
-    fs::remove_all(probe, ec);
-    ec.clear();
-    fs::create_directories(probe, ec);
-    if (ec) return std::nullopt;
+    // The return value, not `ec`: create_directory reports an existing
+    // directory by returning false without setting an error, and proceeding
+    // into a directory this process did not create is the case being avoided.
+    if (!fs::create_directory(probe, ec) || ec) return std::nullopt;
     struct Cleanup {
         fs::path dir;
         ~Cleanup() { std::error_code e; fs::remove_all(dir, e); }


### PR DESCRIPTION
Found reviewing #560 after it merged.

`unreachable_device_stage()` wrote its empty `.cu` into a fixed
`mcpp-nvcc-dryrun` under the shared temporary directory, and called
`remove_all` on it first so the name could be reused across runs. On a machine
with more than one user that is a predictable path someone else can create
first — and the `remove_all` a fixed name needs in order to be reusable is the
part that makes that matter, since the probe then writes through whatever it
found.

Two changes:

- A random suffix, `mcpp_nvcc_dryrun_<random_device>`, which is the pattern
  `src/build/prepare.cppm` already uses for the p1689 scanner's scratch
  directory. No `remove_all` of a pre-existing path is needed once the name is
  fresh.
- The gate reads `create_directory`'s **return value**, not its error code.
  `create_directory` reports an already-existing directory by returning false
  *without* setting an error, so the previous `if (ec)` would have accepted
  exactly the case being avoided. Concurrent runs of `mcpp self doctor` are
  also no longer able to delete each other's scratch directory.

Both controls re-run against the rebuilt binary:

| control | occurrences of `cannot reach its own back-end` |
|---|---|
| working nvcc | 0 |
| nvcc copied to a directory holding no profile, first on PATH | 1, naming `cicc` |

`mcpp test`: 100 passed, 0 failed. No temporary directory is left behind after
either run.