### PR TITLE
fix(examples): 09 names the cuRAND payload the clang route needs

### DIFF
--- a/examples/09-cuda-kernel/app/mcpp.toml
+++ b/examples/09-cuda-kernel/app/mcpp.toml
@@ -40,6 +40,11 @@ cuda-runtime = "2026.09.05"
 [xlings.workspace]
 "xim:cuda-nvcc"         = "12.9.86"
 "xim:cuda-cudart"       = "12.9.79"
+# cuRAND's headers. clang's CUDA wrapper includes curand_mtgp32_kernel.h for
+# every device unit, so the clang route needs them even though this kernel
+# never calls cuRAND; on a developer machine the host's /usr/include used to
+# supply the header silently. The 10.3.x line pairs with CUDA 12.x.
+"xim:libcurand"         = "10.3.10.19"
 "xim:libcuda-host-link" = { linux = "0.0.1" }
 
 [build]

--- a/examples/09-cuda-kernel/app/mcpp.toml
+++ b/examples/09-cuda-kernel/app/mcpp.toml
@@ -40,11 +40,13 @@ cuda-runtime = "2026.09.05"
 [xlings.workspace]
 "xim:cuda-nvcc"         = "12.9.86"
 "xim:cuda-cudart"       = "12.9.79"
-# cuRAND's headers. clang's CUDA wrapper includes curand_mtgp32_kernel.h for
-# every device unit, so the clang route needs them even though this kernel
-# never calls cuRAND; on a developer machine the host's /usr/include used to
-# supply the header silently. The 10.3.x line pairs with CUDA 12.x.
+# cuRAND's headers and CCCL. clang's CUDA wrapper includes
+# curand_mtgp32_kernel.h for every device unit, and that header includes
+# <nv/target> from CCCL, so the clang route needs both even though this kernel
+# calls neither; on a developer machine the host's /usr/include used to supply
+# them silently. 10.3.x and 12.9.27 are the 12.9 line.
 "xim:libcurand"         = "10.3.10.19"
+"xim:cuda-cccl"         = "12.9.27"
 "xim:libcuda-host-link" = { linux = "0.0.1" }
 
 [build]


### PR DESCRIPTION
clang's CUDA wrapper includes `curand_mtgp32_kernel.h` unconditionally. The example built on a developer machine only because the host's `/usr/include` supplied the header; the mcpp-plugins CI runner, with no host CUDA, refused it (mcpp-community/mcpp-plugins#1). `mcpp.rules.cuda` now adds `xim:libcurand`'s include directory to the device compile and refuses the clang route without it, naming the `[xlings.workspace]` entry; the example declares it. One-line manifest change, no engine change.