### PR TITLE
fix(examples): 10 declares the lavapipe payload it runs on without a GPU

### DIFF
--- a/examples/10-vulkan-compute/app/mcpp.toml
+++ b/examples/10-vulkan-compute/app/mcpp.toml
@@ -29,6 +29,12 @@ vulkan-runtime = "2026.09.05"
 # which is what every CI runner in this ecosystem is.
 [xlings.workspace]
 "xim:glslang"       = "15.1.0"
+# A Vulkan device that needs no GPU: Mesa's lavapipe as a payload, complete
+# with its own LLVM. On a machine with a vendor ICD the loader lists both and
+# the program picks the discrete GPU; with none -- a CI runner, a sandbox --
+# this is the device the artifact runs on. Selected explicitly with
+# VK_DRIVER_FILES=<payload>/share/vulkan/icd.d/lvp_icd.x86_64.json.
+"xim:mesa-lavapipe" = "26.2.1"
 
 [build]
 # What this build compiles device code FOR. `vulkan1.2` is the SPIR-V target


### PR DESCRIPTION
The README states the artifact runs on the software driver payload when no vendor ICD is present, but the manifest never named `xim:mesa-lavapipe`, so a machine with no GPU (the sandbox verification of 2026.9.5.3) had no Vulkan device at all: `device unavailable`. The example now provisions the payload like its other `[xlings.workspace]` entries. One-line manifest change plus its comment; no engine change.