### PR TITLE
test(e2e 614): ask mcpp where its store is, do not guess

### DIFF
--- a/tests/e2e/614_feature_xlings_reaches_xpkg_dir.sh
+++ b/tests/e2e/614_feature_xlings_reaches_xpkg_dir.sh
@@ -24,8 +24,20 @@
 set -e
 
 MCPP="${MCPP:-mcpp}"
-MH="${MCPP_HOME:-$HOME/.mcpp}"
-store="$MH/registry/data/xpkgs/xim-x-ninja"
+
+# THE STORE IS ASKED FOR, NOT GUESSED. An earlier form derived it from
+# `${MCPP_HOME:-$HOME/.mcpp}` while the BINARY under test resolves its home
+# from its own location -- a released mcpp carries a `registry/` beside itself.
+# Pointed at a released tarball the test then failed about features while
+# really measuring a path mismatch, and the same guess cost a CI job in
+# another repository on the same day.
+#
+# The version is still needed for the manifest, and it comes from the store the
+# binary actually uses. `mcpp index status` is the cheapest command that names
+# a path under that home.
+MH="$("$MCPP" index status 2>/dev/null | grep -oE '/[^ ]*/registry' | head -1)"
+[ -n "$MH" ] || MH="${MCPP_HOME:-$HOME/.mcpp}/registry"
+store="$MH/data/xpkgs/xim-x-ninja"
 
 if [ ! -d "$store" ]; then
     printf 'SKIP: %s is absent, so there is no installed payload to look up\n' "$store"


### PR DESCRIPTION
## What

e2e 614 derived the payload store from `${MCPP_HOME:-$HOME/.mcpp}` while the
**binary under test** resolves its home from its own location — a released mcpp
carries a `registry/` beside itself.

Pointed at the released 2026.9.6.2 tarball the test therefore **failed about
features while really measuring a path mismatch**.

## Why it is worth a commit rather than a note

The same guess cost a CI job in `llama.cpp-m` on the same day: its Vulkan job
searched `${HOME}/.mcpp` for the lavapipe ICD while the payloads sat under
`$RUNNER_TEMP`. One fact, two readers, both guessing.

## The fix

`mcpp index status` names a path under the home the binary actually uses. The
environment default remains the fallback for a build that has no index yet.

## Measured

| binary | before | after |
|---|---|---|
| locally built 2026.9.6.2 | pass | pass |
| **released 2026.9.6.2 tarball** | **fail** | pass |
| the binary predating the engine fix 614 exists for | fail | **fail** |

The last row is the one that matters: the test still says no to what it was
written to catch.