### PR TITLE
fix(refusal): name the std-module-precompile refusal, and enforce that the matrix has no unnamed one

### DIFF
--- a/.github/tools/check_matrix_reasons.sh
+++ b/.github/tools/check_matrix_reasons.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# The target matrix declares no `other`, and no `mismatch`.
+#
+# `expected.tsv` argues this for `mismatch` in its own header -- writing one
+# down declares a defect to be the expectation, and the matrix then goes green
+# on it. `other` is the same move one level up: `src/build/refusal.cppm` defines
+# it as "a refusal that has not been given a code yet", so a row spelling
+# `other` freezes an unnamed branch into the expected table.
+#
+# It was not hypothetical. Until 2026-09-06 the table carried exactly one such
+# row -- `x86_64-windows-msvc x llvm@22.1.8` -- while `Code::StdModulePrecompile`
+# already existed with a name and had NO WRITER anywhere in the tree. The gap
+# was between the declaration and the call, and nothing pointed at it except a
+# line of scan output nobody had to read.
+#
+# Both directions are checked, because a vocabulary that lists a reason no row
+# uses is the same defect seen from the other side: a name with no fact under it.
+set -uo pipefail
+cd "$(dirname "$0")/../.."
+table=tests/matrix/expected.tsv
+fail=0
+
+for banned in other mismatch; do
+    if rows=$(awk -F'\t' -v b="$banned" '!/^#/ && NF>1 && $NF==b {print NR": "$0}' "$table") \
+       && [ -n "$rows" ]; then
+        echo "::error::$table declares '$banned':"
+        echo "$rows" | sed 's/^/    /'
+        case "$banned" in
+          other) echo "    Give that refusal branch a code in src/build/refusal.cppm and record it"
+                 echo "    at the site that returns, then put the code here." ;;
+          mismatch) echo "    A mismatch is a defect, not an expectation. Fix mcpp, or make it refuse"
+                 echo "    at the decision with a named reason." ;;
+        esac
+        fail=1
+    fi
+done
+
+# Every reason the table uses must be a name `refusal.cppm` actually defines.
+# A typo here is silent otherwise: the comparison would demand a string the
+# engine can never produce, and the cell would read as a permanent mismatch.
+known=$(grep -oE 'return "[a-z-]+";' src/build/refusal.cppm | sed 's/return "//; s/";//' | sort -u)
+used=$(awk -F'\t' '!/^#/ && NF>1 {print $NF}' "$table" | sort -u)
+for r in $used; do
+    grep -Fxq "$r" <<<"$known" || {
+        echo "::error::$table uses reason '$r', which src/build/refusal.cppm does not define"
+        fail=1
+    }
+done
+
+[ "$fail" -eq 0 ] && echo "OK: the target matrix names every refusal, and names them from the taxonomy"
+exit "$fail"

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -88,6 +88,13 @@ jobs:
       - name: Where the CI assertions live
         run: bash tools/lint-ci-assertions.sh
 
+      # Text-only, like the two steps around it, and it belongs here rather
+      # than in the target-matrix workflow: that workflow runs the matrix, and
+      # this asserts a property of the TABLE, which is readable without a
+      # single toolchain.
+      - name: The target matrix names every refusal
+        run: bash .github/tools/check_matrix_reasons.sh
+
       # Same placement and the same reason: pure text, no toolchain, and the
       # drift it catches — a 简体中文 page that has silently fallen behind its
       # English original — is invisible to every other job.

--- a/src/build/build_program.cppm
+++ b/src/build/build_program.cppm
@@ -20,6 +20,7 @@ import mcpp.toolchain.cppfly;        // std_flag (dialect- and c++fly-aware -std
 import mcpp.toolchain.dialect;       // CommandDialect — gnu vs cl.exe spellings
 import mcpp.toolchain.fingerprint;   // hash_file / hash_string (FNV-1a, 16 hex)
 import mcpp.build.directives;        // the directive definition table (own module: see its header)
+import mcpp.build.refusal;           // the machine-readable identity of a refusal
 import mcpp.build.hostprogram;       // bundled `mcpp` module compile (own module: see its header)
 import mcpp.toolchain.hostflags;     // the shared host-compile flag producer
 import mcpp.toolchain.linkmodel;     // shared C-library / clang-cfg-bypass model
@@ -946,6 +947,13 @@ std::expected<void, std::string> run_build_program(
         auto sm = mcpp::toolchain::ensure_built(
             tc, cppStandard.canonical, std_flag, macosDeploymentTarget);
         if (!sm) {
+            // The second branch of the same refusal, and it is named for the
+            // same reason: both `run_build_program` call sites in prepare.cppm
+            // return `std::unexpected` unconditionally, so this error always
+            // reaches the layer that reads the code. An unnamed one here would
+            // reproduce, for the host std module, exactly the gap the target
+            // std module had.
+            refusal::record(refusal::Code::StdModulePrecompile);
             return std::unexpected(std::format(
                 "build.mcpp uses `import std;` but the std module could not be "
                 "built for the host toolchain: {}", sm.error().message));

--- a/src/build/prepare.cppm
+++ b/src/build/prepare.cppm
@@ -9179,7 +9179,24 @@ prepare_build(bool print_fingerprint,
             mcpp::platform::macos::deployment_target(
                 m->buildConfig.macosDeploymentTarget),
             mcpp::toolchain::default_cache_root(), stdCrt);
-        if (!sm) return std::unexpected(sm.error().message);
+        if (!sm) {
+            // THE ONE CODE IN THE TAXONOMY THAT NOTHING WROTE.
+            //
+            // `Code::StdModulePrecompile` has existed, with a name and a
+            // comment, since the taxonomy was written; `grep` for it found the
+            // declaration and the `name()` arm and no third site. So every
+            // std-module refusal reported `other`, which is the bucket
+            // refusal.cppm defines as "a refusal that has not been given a code
+            // yet" -- a visible admission, and one nobody had cashed.
+            //
+            // Measured: `tests/matrix/expected.tsv` carried exactly ONE `other`
+            // row out of 176, `x86_64-windows-msvc x llvm@22.1.8` in graph mode,
+            // and `scan.sh` printed it under "无名拒绝" on every Windows run.
+            // The sentence was right and the classification was missing --
+            // the same shape `Code::HostToolToolchain` was added for.
+            refusal::record(refusal::Code::StdModulePrecompile);
+            return std::unexpected(sm.error().message);
+        }
         stdBmiPath = sm->bmiPath;
         stdObjectPath = sm->objectPath;
         stdCompatBmiPath = sm->compatBmiPath;

--- a/tests/matrix/expected.tsv
+++ b/tests/matrix/expected.tsv
@@ -12,6 +12,16 @@
 #   unsupported  / convention-unreplaced    约定被推翻了,而没有任何东西接替它
 #   unsupported  / host-cannot-serve        本机没有载荷,图也没有供给这个系统
 #   unsupported  / layer-requirement        某个包要求的层,解析没有给出
+#   unsupported  / host-tool-toolchain      交叉目标下的 build.mcpp 没有可解析的宿主工具链
+#   unsupported  / lld-required-absent      这一行直接经 lld 链接,而本机没有
+#   unsupported  / std-module-precompile    std 模块预编译不过
+#
+# 这张表里**没有 `other`**,而这是一条不变量而不是巧合。`other` 在
+# `src/build/refusal.cppm` 里的定义是「拒绝了而这一处分支还没有名字」,所以一行
+# `other` 就是一处待命名的分支。2026-09-06 之前这里恰好有一行:
+# `x86_64-windows-msvc x llvm@22.1.8`,而 `Code::StdModulePrecompile` 那时已经
+# 存在、有名字、且**没有任何写入者** —— 声明与调用之间的缺口,不是分类学的缺口。
+# 再出现一行 `other`,要做的是给那个分支一个名字,不是把 `other` 写进这张表。
 #
 # 这里**没有** `mismatch`,而这是刻意的。写下 `mismatch` 就是把一个缺陷
 #      声明成期望,矩阵会在它上面变绿。一格测出 `mismatch`,要么修 mcpp,要么
@@ -82,7 +92,7 @@ graph	windows-x86_64	x86_64-macos	llvm@22.1.8	-	-	-	-	-	unsupported	tier-planned
 graph	windows-x86_64	x86_64-macos	msvc@system	-	-	-	-	-	unsupported	tier-planned
 graph	windows-x86_64	x86_64-windows-gnu	llvm@22.1.8	x86_64-w64-windows-gnu	none	musl(graph)	libc++(graph)	openkal-llvm-runtime@0.1.3	ok	none
 graph	windows-x86_64	x86_64-windows-gnu	msvc@system	-	-	-	-	-	unsupported	host-tool-toolchain
-graph	windows-x86_64	x86_64-windows-msvc	llvm@22.1.8	-	-	-	-	-	unsupported	other
+graph	windows-x86_64	x86_64-windows-msvc	llvm@22.1.8	-	-	-	-	-	unsupported	std-module-precompile
 graph	windows-x86_64	x86_64-windows-msvc	msvc@system	-	-	-	-	-	unsupported	host-tool-toolchain
 graph	windows-x86_64	x86_64-windows-musl	llvm@22.1.8	x86_64-w64-windows-gnu	none	musl(graph)	libc++(graph)	openkal-llvm-runtime@0.1.3	ok	none
 graph	windows-x86_64	x86_64-windows-musl	msvc@system	-	-	-	-	-	unsupported	capability-pin


### PR DESCRIPTION
`Code::StdModulePrecompile` existed in `src/build/refusal.cppm` with a name and
a comment, and NOTHING WROTE IT. `grep` over the tree found the enumerator and
the `name()` arm and no third site, so every std-module refusal reported
`other` -- the bucket that file defines as "a refusal that has not been given a
code yet". Fifteen of the sixteen other codes had a writer; this one had zero.

It was visible the whole time and nobody had to look. `tests/matrix/scan.sh`
prints unnamed refusals under a heading for exactly this purpose, and
`tests/matrix/expected.tsv` carried one `other` row out of 176 --
`x86_64-windows-msvc x llvm@22.1.8` in graph mode, where the openkal LLVM
runtime supplies no Windows C library and libc++'s `std` cannot precompile.

Both branches that turn a std-module failure into a refusal now record the
code: the target module in `prepare.cppm`, and build.mcpp's host module in
`build_program.cppm`. The second is safe to record because both
`run_build_program` call sites return `std::unexpected` unconditionally, so the
error always reaches the layer that reads the code.

The expected table names that row, and `.github/tools/check_matrix_reasons.sh`
now enforces two things about it:

  * no row says `other` or `mismatch`. The file already argues this for
    `mismatch` -- writing one down declares a defect to be the expectation --
    and `other` is the same move one level up.
  * every reason a row uses is one `refusal.cppm` actually defines. A typo
    would otherwise be silent: the comparison would demand a string the engine
    cannot produce, and the cell would read as a permanent mismatch.

Both directions were checked by breaking them: restoring the `other` row fails
the first, misspelling the reason fails the second.