### PR TITLE
fix(examples, record): follow the farms that answer for their own members

### DIFF
--- a/.agents/docs/2026-09-09-dlopen-surface-and-two-unwinders.md
+++ b/.agents/docs/2026-09-09-dlopen-surface-and-two-unwinders.md
@@ -603,11 +603,28 @@ already filed as mcpp-index#376, reached this time through
   | `libnvidia-pkcs11.so.550.144.03` | `libcrypto.so.1.1` | same |
 
   All four are real and all four are the same shape as mcpp#596 -- a farm that
-  mirrors a driver family and stops one library short. They are NOT repaired
-  here: a check whose first catch is its author's own package should report it,
-  not quietly absorb it, and the repair belongs to `compat:vulkan-runtime` with
-  its own criterion, filed as mcpplibs/mcpp-index#376. On a runner with no NVIDIA driver the farm is nearly empty
-  and the check is silent, so this does not appear in CI.
+  mirrors a driver family and stops one library short. They were filed rather
+  than absorbed, as mcpplibs/mcpp-index#376, and repaired there in
+  mcpplibs/mcpp-index#380. On a runner with no NVIDIA driver the farm is nearly
+  empty and the check is silent, so this never appeared in CI.
+
+  WHAT THE REPAIR FOUND THAT THE FILING DID NOT. The defect is in three farms,
+  not one, and the issue names the wrong one: the four findings above were
+  published by `compat:opencl-runtime`, while `compat:vulkan-runtime` had five
+  and `compat:glx-runtime` -- which had no closure pass at all -- had thirty.
+  The cause is one rule: membership is decided by a filename pattern while
+  completeness was decided against the ICD manifests, so the half of each farm
+  the pattern exists for is the half nothing verified. The reason recorded
+  against seeding the closure from the farm turned out to have measured the
+  set BEFORE `never_farm_patterns` removed the driver's settings GUI; measured
+  after, it adds five libraries and no GUI stack.
+
+  The repair also holds the host surface down rather than widening it. Every
+  soname a member needs now has a written answer -- an ecosystem package
+  declared in `deps`, a `*-host-link` sentinel for what cannot be
+  redistributed (openxlings/xim-pkgindex#801 adds one for the codec
+  user-space), a named entry in `UNSERVED` with its reason, or a warning at
+  install time. No branch harvests a new file from `/usr/lib`.
 
 ## 8. Order
 

--- a/examples/09-heterogeneous/multi-backend/mcpp.toml
+++ b/examples/09-heterogeneous/multi-backend/mcpp.toml
@@ -104,7 +104,7 @@ cuda-driver = "2026.09.05"
 # is a payload and the hardware ones are the host's.
 [target.'cfg(accelerator = "vulkan")'.dependencies.compat]
 vulkan         = "1.4.357.0"
-vulkan-runtime = "2026.09.07"
+vulkan-runtime = "2026.09.10"
 
 [build]
 # The device sources carry the accel they are for. A CONSTRAINED glob gates

--- a/examples/09-heterogeneous/vulkan/app/mcpp.toml
+++ b/examples/09-heterogeneous/vulkan/app/mcpp.toml
@@ -22,7 +22,7 @@ plugins = { version = "0.5.2", features = ["rules-spirv"], host-module = true }
 # below is a payload and the hardware ones are the host's.
 [dependencies.compat]
 vulkan         = "1.4.357.0"
-vulkan-runtime = "2026.09.07"
+vulkan-runtime = "2026.09.10"
 
 # ONE payload here, and the shader compiler is not it: `mcpp.rules.spirv`
 # declares `xim:glslang` for itself. What stays is a DEVICE, and the boundary is

--- a/examples/10-graphics/offscreen/mcpp.toml
+++ b/examples/10-graphics/offscreen/mcpp.toml
@@ -28,7 +28,7 @@ plugins = { version = "0.5.2", features = ["rules-spirv"], host-module = true }
 # seam work: the CPU leg below is selected by the accelerator, and only the
 # packages are unconditional.
 [dependencies.compat]
-vulkan = "1.4.357.0"
+vulkan = "1.4.357.1"
 
 # The adapter that makes the host's own ICDs reachable from a binary running
 # under mcpp's private loader. An OS predicate, which IS allowed, and a Linux

--- a/examples/10-graphics/offscreen/mcpp.toml
+++ b/examples/10-graphics/offscreen/mcpp.toml
@@ -35,7 +35,7 @@ vulkan = "1.4.357.0"
 # concern by construction: macOS resolves through dyld and Windows through the
 # PE loader, and neither has a private loader to work around.
 [target.'cfg(linux)'.dependencies.compat]
-vulkan-runtime = "2026.09.07"
+vulkan-runtime = "2026.09.10"
 
 # A Vulkan device that needs no GPU, so this example runs on a machine that has
 # none. It is a DEVICE and therefore a payload; the drivers a real GPU needs are


### PR DESCRIPTION
`compat:vulkan-runtime` published a farm whose members needed four sonames that nothing on the artifact's search path carried. The three examples that pin it move to `2026.09.10`, where the farm closes over its own members and reaches the host only through a named `*-host-link` package.

## Measured, on this host, from the example's own record

| | members | walked | missing | dangling |
|---|---|---|---|---|
| before | 55 | 55 | **4** | 0 |
| after | 60 | 59 | **0** | 1 |

The one remaining finding is `libcrypto.so.1.1`, and it is *dangling* rather than *missing* because the publishing package now says so: OpenSSL 1.1 is end-of-life upstream, the ecosystem publishes 3.x, and only NVIDIA's PKCS#11 provider asks for it.

`libcrypto.so.3` comes from `xim:openssl`, `libnvcuvid.so.1` from `xim:nvidia-video-host-link`. No branch harvests a new file from `/usr/lib`.

The example still runs on the device:

```
12 24 36 48
device: NVIDIA GeForce RTX 4080
```

## The record

Section 7 no longer files those four findings as open. It records what repairing them found instead:

- the defect was in **three** farms, not one — `glx-runtime` 30 unmet edges, `vulkan-runtime` 5, `opencl-runtime` 4
- mcpplibs/mcpp-index#376 names the wrong package: the four observed findings came from `compat:opencl-runtime`
- the reason written against seeding the closure from the farm had measured the set **before** the driver's settings GUI was excluded; measured after, it adds five libraries and no GUI stack

Follows mcpplibs/mcpp-index#380 and openxlings/xim-pkgindex#801, both merged.