### PR TITLE
fix(examples): follow the farms to 2026.09.11

### DIFF
--- a/examples/09-heterogeneous/multi-backend/mcpp.toml
+++ b/examples/09-heterogeneous/multi-backend/mcpp.toml
@@ -104,7 +104,7 @@ cuda-driver = "2026.09.05"
 # is a payload and the hardware ones are the host's.
 [target.'cfg(accelerator = "vulkan")'.dependencies.compat]
 vulkan         = "1.4.357.0"
-vulkan-runtime = "2026.09.10"
+vulkan-runtime = "2026.09.11"
 
 [build]
 # The device sources carry the accel they are for. A CONSTRAINED glob gates

--- a/examples/09-heterogeneous/sycl/app/mcpp.toml
+++ b/examples/09-heterogeneous/sycl/app/mcpp.toml
@@ -37,7 +37,7 @@ plugins = { version = "0.5.2", features = ["rules-sycl", "tools-island"], host-m
 # message (#596). The farm now mirrors what the driver sentinel publishes
 # rather than naming a file.
 [dependencies.compat]
-sycl-runtime = "2026.09.10"
+sycl-runtime = "2026.09.11"
 
 # NO [xlings.workspace]. `mcpp.rules.sycl` declares all five payloads this lane
 # needs, each closing one hole the host would otherwise fill: `dpcpp` (the

--- a/examples/09-heterogeneous/vulkan/app/mcpp.toml
+++ b/examples/09-heterogeneous/vulkan/app/mcpp.toml
@@ -22,7 +22,7 @@ plugins = { version = "0.5.2", features = ["rules-spirv"], host-module = true }
 # below is a payload and the hardware ones are the host's.
 [dependencies.compat]
 vulkan         = "1.4.357.0"
-vulkan-runtime = "2026.09.10"
+vulkan-runtime = "2026.09.11"
 
 # ONE payload here, and the shader compiler is not it: `mcpp.rules.spirv`
 # declares `xim:glslang` for itself. What stays is a DEVICE, and the boundary is

--- a/examples/10-graphics/offscreen/mcpp.toml
+++ b/examples/10-graphics/offscreen/mcpp.toml
@@ -28,14 +28,14 @@ plugins = { version = "0.5.2", features = ["rules-spirv"], host-module = true }
 # seam work: the CPU leg below is selected by the accelerator, and only the
 # packages are unconditional.
 [dependencies.compat]
-vulkan = "1.4.357.1"
+vulkan = "1.4.357.2"
 
 # The adapter that makes the host's own ICDs reachable from a binary running
 # under mcpp's private loader. An OS predicate, which IS allowed, and a Linux
 # concern by construction: macOS resolves through dyld and Windows through the
 # PE loader, and neither has a private loader to work around.
 [target.'cfg(linux)'.dependencies.compat]
-vulkan-runtime = "2026.09.10"
+vulkan-runtime = "2026.09.11"
 
 # A Vulkan device that needs no GPU, so this example runs on a machine that has
 # none. It is a DEVICE and therefore a payload; the drivers a real GPU needs are

--- a/examples/10-graphics/offscreen/mcpp.toml
+++ b/examples/10-graphics/offscreen/mcpp.toml
@@ -30,12 +30,21 @@ plugins = { version = "0.5.2", features = ["rules-spirv"], host-module = true }
 [dependencies.compat]
 vulkan = "1.4.357.2"
 
-# The adapter that makes the host's own ICDs reachable from a binary running
-# under mcpp's private loader. An OS predicate, which IS allowed, and a Linux
-# concern by construction: macOS resolves through dyld and Windows through the
-# PE loader, and neither has a private loader to work around.
-[target.'cfg(linux)'.dependencies.compat]
-vulkan-runtime = "2026.09.11"
+# THE ADAPTER IS NOT NAMED HERE, AND THAT IS THE POINT.
+#
+# `compat.vulkan` declares `compat.vulkan-runtime` itself on Linux -- the
+# adapter that makes the host's own ICDs reachable from a binary running under
+# mcpp's private loader, which macOS and Windows do not need because dyld and
+# the PE loader have no private-loader problem to work around.
+#
+# Naming it here as well pinned one version in two places, in two repositories,
+# with nothing enforcing that they agree. They drifted three times in one day:
+# the loader package moved its pin, this file moved its own, and an installed
+# copy of `compat.vulkan` still recorded the previous one -- each time the build
+# stopped with `irreconcilable versions`, and each time the fix was to edit the
+# other place. A dependency that another dependency already declares is a
+# second copy of a decision; the version it needs is the one that package says
+# it needs.
 
 # A Vulkan device that needs no GPU, so this example runs on a machine that has
 # none. It is a DEVICE and therefore a payload; the drivers a real GPU needs are


### PR DESCRIPTION
`compat:vulkan-runtime` and `compat:opencl-runtime` no longer carry `libnvidia-pkcs11*` — a PKCS#11 token module the vendor name pattern swept in and that no GPU driver's dispatch reaches — and the chain that delivers them (`sycl-runtime → opencl → opencl-runtime`, `vulkan → vulkan-runtime`) took new versions so an installed copy stops recording the old pin.

## Measured on this host with the driver

Both examples rebuilt from an empty target directory:

| example | members | walked | findings |
|---|---|---|---|
| `09-heterogeneous/sycl` | 49 | 49 | **none** |
| `09-heterogeneous/vulkan` | 56 | 56 | **none** |

Both compute `12 24 36 48` and print `device: NVIDIA GeForce RTX 4080`.

Follows mcpplibs/mcpp-index#383.