### PR TITLE
A verified Web run that asked the host for node (2026.9.12.1)

### DIFF
--- a/.agents/docs/2026-09-12-a-verified-web-run-that-asked-the-host-for-node.md
+++ b/.agents/docs/2026-09-12-a-verified-web-run-that-asked-the-host-for-node.md
@@ -1,0 +1,123 @@
+---
+subject: targets
+status: landed
+---
+
+# A verified Web run that asked the host for node
+
+**Status:** implemented in mcpp 2026.9.12.1 and openxlings/xim-pkgindex#823.
+
+## What was measured
+
+The sandbox verification of the published mcpp 2026.9.11.4 ran 27 checks in an
+`xlings subos use <name> --sandbox` environment: a fresh `$HOME`, a fresh
+`/tmp`, and no `mcpp` or `node` on PATH. Twenty-six held. The one that did not
+was the Web run:
+
+```
+mcpp run --target wasm32-emscripten
+  Compiling w v0.1.0 (.)
+  Finished dev [unoptimized + debuginfo] in 0.84s
+  Running `target/wasm32-emscripten/.../bin/w`
+/usr/bin/env: 'node': No such file or directory
+```
+
+The build was correct. The run depended on the host.
+
+## Why the development host could not see it
+
+An Emscripten link produces a JavaScript launcher whose first line is
+`#!/usr/bin/env node`. When neither the project nor its dependency graph
+declares a runner, `mcpp run` executes the artefact, and the kernel resolves the
+interpreter from the PATH mcpp inherited. `choose_device_action` consults the
+manifest and the graph and nothing else, and the spawned artefact receives no
+toolchain directory on its PATH.
+
+The ecosystem had already installed the right program. `xim:emsdk` declares
+`xim:node` as a runtime dependency and writes that payload's `bin/node` into its
+own `.emscripten`, deliberately so that linking does not depend on PATH. Running
+the result was the one step that still did.
+
+The row's `verified` record states how it was measured: `node bin/<name>`, with
+a `node` the measuring machine had. The development host has one on PATH through
+its default xlings environment. So every measurement on that host, including the
+dry run of the verification script itself, read the host's `node` and passed.
+Only an environment without one could distinguish "the ecosystem runs this" from
+"this machine runs this".
+
+## Where the answer belongs
+
+Three placements were considered and rejected.
+
+- **The engine reads `NODE_JS` from emsdk's `.emscripten`.** This would put an
+  emsdk layout fact into the engine, which is the coupling the payload
+  descriptor was introduced to remove (2026-09-11 record, item C).
+- **The recipe places a `node` link inside the emsdk payload's `bin/`.** Recipe
+  hooks in this ecosystem have no reliable symlink or permission primitive, and
+  a link would restate a fact the recipe already records as a path.
+- **Projects declare `[target.wasm32-emscripten] runner` and `xim:node`.** A
+  `verified` row that needs two lines of vocabulary to run is not the row the
+  2026.9.11.3 release described, where changing a flag was the whole cost.
+
+The payload knows which program runs what its compiler produces, so the payload
+states it. `.mcpp-toolchain.json` gains a fourth key.
+
+## The contract
+
+```json
+{
+  "schema": 1,
+  "frontend": "emscripten/em++",
+  "runner": "<store>/xim-x-node/26.7.0/bin/node"
+}
+```
+
+- **One program, no arguments.** The artefact path is appended. The key cannot
+  carry flags, which keeps the descriptor what it was: a set of answers to
+  questions the engine already asks, and not a flag channel.
+- **Relative or absolute.** A relative runner obeys the rules `frontend` obeys
+  and resolves against the directory the descriptor was read from. An absolute
+  runner exists because the program is usually a dependency's, and it is
+  honoured only inside the package store that holds the payload
+  (`<store>/<package>/<version>`), compared on canonical paths so that a store
+  reached through a symbolic link is still that store.
+- **Outside the store is ignored, malformed is refused.** Where a store lives is
+  a property of the machine, so a runner outside it is not honoured and the run
+  proceeds as it did before the key existed. A structurally wrong value (not a
+  string, empty, a backslash, a `.` or `..` component) is refused by name at
+  read time, like every other key.
+- **Last in precedence, run slot only.** A project's `[target.<triple>] runner`
+  and a dependency's `mcpp::runner(...)` are statements about this program and
+  outrank a statement about everything a compiler produces. `--no-runner` still
+  executes the artefact directly. `flash`, `monitor` and `debug` name actions a
+  board package owns, and a compiler has no opinion about them.
+
+## Compatibility
+
+Both directions hold without coordination. An mcpp that predates the key ignores
+it, so the recipe ships first. A payload installed before the recipe wrote the
+descriptor has none, and its artefact runs through its own shebang exactly as
+before; reinstalling the payload adds the descriptor.
+
+## Criteria
+
+| claim | criterion | measured |
+|---|---|---|
+| a runner in the payload's store is the default for its compiler | unit test with the emsdk shape: compiler at `emscripten/em++`, runner a sibling payload's `bin/node` | yes |
+| a runner outside the store is not honoured | unit test with `/usr/bin/node`; and the same test with the store rule removed | yes, and the probe turned it red |
+| malformed runners are refused by name and by key | seven shapes, each refusal naming the file and `"runner"` | yes |
+| the wiring reaches `mcpp run` | in the sandbox, no `node` on PATH, with a descriptor in the sandbox's own emsdk payload | `1-2-3` |
+| the runner came from the descriptor and not from somewhere else | the same run with the descriptor removed | fails at `/usr/bin/env: 'node'` again |
+| CI holds the claim against the published recipe | `scan (linux-x86_64)` runs a Web program with a fresh `MCPP_HOME`, so the emsdk payload is the one the index publishes rather than one restored from cache, and with a decoy `node` first on PATH that exits 97 with a marker; the step fails if the payload has no descriptor, if the decoy ran, or if `1-2-3` is not a line of the output | on this PR, after openxlings/xim-pkgindex#823 was published |
+
+The first attempt at the sandbox reading measured nothing. The development binary
+was dynamically linked, and its loader lives in the host's `~/.mcpp`, which the
+sandbox replaces with its own; both readings were "cannot execute: required file
+not found" and said nothing about runners. The reading above used a
+`x86_64-linux-musl` static build, the form a release ships.
+
+## What remains
+
+An emsdk payload already installed on a machine keeps running through PATH until
+it is reinstalled. The published-artefact check is the sandbox verification
+script's Web section, run again after this release.

--- a/.agents/docs/README.md
+++ b/.agents/docs/README.md
@@ -18,7 +18,7 @@ superseded_by: 2026-09-07-....md  # when status is superseded
 ---
 ```
 
-278 records.
+279 records.
 
 ## By subject
 
@@ -46,6 +46,7 @@ Records that declare one. Everything else is listed by date below.
 
 ### targets
 
+- [A verified Web run that asked the host for node](2026-09-12-a-verified-web-run-that-asked-the-host-for-node.md) — landed
 - [SDK toolchains, the payload/engine seam, and openkal across iOS, Android and Web](2026-09-11-sdk-toolchains-and-ios-local-verification.md) — landed
 - [Where a platform's knowledge belongs: iOS, Android and Web across the engine, the index and the plugins](2026-09-11-platform-targets-design-review.md) — active
 
@@ -57,6 +58,7 @@ Records that declare one. Everything else is listed by date below.
 
 ### 2026-09
 
+- [A verified Web run that asked the host for node](2026-09-12-a-verified-web-run-that-asked-the-host-for-node.md) — landed
 - [Six open issues: what each one actually is, and what would answer it](2026-09-11-six-open-issues-analysis.md) — active
 - [SDK toolchains, the payload/engine seam, and openkal across iOS, Android and Web](2026-09-11-sdk-toolchains-and-ios-local-verification.md) — landed
 - [Where a platform's knowledge belongs: iOS, Android and Web across the engine, the index and the plugins](2026-09-11-platform-targets-design-review.md) — active

--- a/.github/workflows/ci-target-matrix.yml
+++ b/.github/workflows/ci-target-matrix.yml
@@ -348,6 +348,64 @@ jobs:
                tests/matrix/expected.tsv ${{ matrix.host }} graph || fail=1
           [ "$fail" = 0 ] || exit 1
 
+      # A WEB ARTEFACT RUNS THROUGH THE INTERPRETER ITS PAYLOAD NAMES, NOT
+      # THROUGH PATH. That is what `wasm32-emscripten`'s `verified` tier
+      # claims, and no step measured it until a sandbox with no `node` on PATH
+      # showed that the run depended on the host:
+      #
+      #   /usr/bin/env: 'node': No such file or directory
+      #
+      # A FRESH MCPP_HOME, BECAUSE THE CACHE IS NOT THE PUBLISHED FORM.
+      # `~/.mcpp` is restored by key prefix, so the emsdk payload in it may
+      # predate the recipe that writes `.mcpp-toolchain.json`, and that older
+      # payload would be the object measured. A fresh home installs what the
+      # index publishes today.
+      #
+      # AND A DECOY `node` FIRST ON PATH, rather than `node` removed from PATH.
+      # Removing it would also remove whatever else those directories hold,
+      # and an image that ships a real `node` would pass for the wrong reason.
+      # A decoy that exits 97 with a marker separates the two outcomes on any
+      # image: the payload's runner never reaches it.
+      - name: "wasm32-emscripten runs through its payload's runner, not PATH"
+        if: ${{ !cancelled() && matrix.host == 'linux-x86_64' }}
+        run: |
+          set -uo pipefail
+          home=$(mktemp -d); work=$(mktemp -d); decoy=$(mktemp -d)
+          printf '#!/bin/sh\necho "DECOY-NODE-WAS-RUN" >&2\nexit 97\n' > "$decoy/node"
+          chmod +x "$decoy/node"
+          export MCPP_HOME="$home" MCPP_VENDORED_XLINGS="$XLINGS_BIN"
+          "$MCPP_UNDER_TEST" self config --mirror GLOBAL >/dev/null 2>&1 || true
+          mkdir -p "$work/src"
+          printf '[package]\nname = "w"\nversion = "0.1.0"\n' > "$work/mcpp.toml"
+          cat > "$work/src/main.cpp" <<'CPP'
+          import std;
+          int main() {
+            std::vector<int> v{3, 1, 2};
+            std::ranges::sort(v);
+            std::print("{}-{}-{}\n", v[0], v[1], v[2]);
+          }
+          CPP
+          out=$(cd "$work" && PATH="$decoy:$PATH" "$MCPP_UNDER_TEST" run --target wasm32-emscripten 2>&1) && rc=0 || rc=$?
+          printf '%s\n' "$out" | tail -12
+          desc="$home/registry/data/xpkgs/xim-x-emsdk/6.0.9/.mcpp-toolchain.json"
+          if [ ! -f "$desc" ]; then
+            echo "::error::the freshly installed emsdk payload has no .mcpp-toolchain.json; the published recipe does not name its runner"
+            exit 1
+          fi
+          if grep -q 'DECOY-NODE-WAS-RUN' <<<"$out"; then
+            echo "::error::the artefact ran through the node on PATH, not through the payload's runner"
+            exit 1
+          fi
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::mcpp run --target wasm32-emscripten exited $rc"
+            exit 1
+          fi
+          if ! grep -qx '1-2-3' <<<"$out"; then
+            echo "::error::the program's output line 1-2-3 is absent"
+            exit 1
+          fi
+          echo "ok: wasm32-emscripten ran through the payload's runner; the decoy node was never run"
+
   coverage:
     # THE DENOMINATOR. Every check above is per host, and no per-host check
     # can notice a host that never ran.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@
 
 ## [Unreleased]
 
+## [2026.9.12.1] - 2026-09-12
+
+### Web 产物的运行不再依赖宿主的 `node`
+
+2026.9.11.4 发布后在 xlings 沙箱里核验发布物:`mcpp build --target wasm32-emscripten`
+成功,而 `mcpp run` 停在
+
+```
+/usr/bin/env: 'node': No such file or directory
+```
+
+Emscripten 链接产出的是首行为 `#!/usr/bin/env node` 的 JavaScript 启动器。项目什么都不
+声明时 mcpp 直接执行它,于是解释器取自机器的 PATH。而生态早已装好了它:`xim:emsdk` 声明
+依赖 `xim:node`,并把那份载荷的 `bin/node` 写进自己的 `.emscripten`。开发机的 PATH 上恰好
+有 `node`,所以此前那次 `verified` 测量看不出这条宿主依赖;沙箱没有,于是看出来了。
+
+- 载荷描述文件 `.mcpp-toolchain.json` 增加第四个键 `runner`:运行这个工具链产物的程序,
+  一个程序、不带参数,产物路径追加在后,因此不构成 flag 通道。它可以是载荷内的相对路径
+  (与 `frontend` 同一套规则),也可以是绝对路径;绝对路径只在持有该载荷的包存储
+  (`<store>/<package>/<version>`)之内才被采用,按规范化路径比较,存储之外的一律忽略
+  —— 载荷不能选择宿主解释器。
+- 优先级:项目的 `[target.<triple>] runner` 与依赖图提供的 runner 在前,载荷的 runner
+  在后;`--no-runner` 仍然直接执行产物。只作用于 run 槽位,即 `mcpp run` 与 `mcpp test`。
+- 结构错误的 `runner`(非字符串、为空、含反斜杠、含 `.` 或 `..` 分量)按描述文件的既有
+  规则拒绝,并点名该文件。
+- `xim:emsdk` 的配方写出 `runner`(openxlings/xim-pkgindex#823)。早于这个键的 mcpp
+  忽略它,所以配方可以先发;在此之前安装的 emsdk 载荷没有描述文件,行为与之前相同,重新
+  安装后获得。
+
 ## [2026.9.11.4] - 2026-09-11
 
 ### iOS 三行:生态编译器与定位到的 SDK

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ list` reports for this machine):
 | `aarch64-none-elf` · `x86_64-none-elf` | llvm 22 — bare metal, no C library by default ² | preview |
 | `thumbv7em-none-eabi` · `thumbv8m.base-none-eabi` · `thumbv8m.main-none-eabihf` | llvm 22 — Cortex-M4/M7 soft float, M23, M33F/M55F ² | preview |
 | `riscv64-linux-musl` · `aarch64-linux-gnu` · `x86_64-macos` | — | planned |
-| `wasm32-emscripten` | `emsdk@6.0.9` — Emscripten ships its own sysroot and its own libc++ module surface; `mcpp run` executes the module with `node` | verified |
+| `wasm32-emscripten` | `emsdk@6.0.9` — Emscripten ships its own sysroot and its own libc++ module surface; `mcpp run` executes the module with the `node` the payload declares (`xim:node`), not one found on PATH | verified |
 | `x86_64-linux-android` | `android-ndk@30.0.16248370` — bionic from the NDK, one payload for both ABIs; ran on an API 24 x86_64 emulator image | verified |
 | `aarch64-linux-android` | the same payload and the same build; ran under qemu-user over the system image's own bionic, which the platform emulator cannot do from an x86_64 host | verified |
 | `aarch64-ios-sim` | llvm 22 plus the machine's iPhoneSimulator SDK, which mcpp locates rather than installs; ran on a simulator through `simctl-run` ³ | verified |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -406,7 +406,7 @@ mcpp 的身份模型是两条正交轴:**工具链** = `family@version`(family �
 | `aarch64-none-elf` · `x86_64-none-elf` | llvm 22——裸机,默认不带 C 库 ² | preview |
 | `thumbv7em-none-eabi` · `thumbv8m.base-none-eabi` · `thumbv8m.main-none-eabihf` | llvm 22——Cortex-M4/M7 软浮点、M23、M33F/M55F ² | preview |
 | `riscv64-linux-musl` · `aarch64-linux-gnu` · `x86_64-macos` | — | planned |
-| `wasm32-emscripten` | `emsdk@6.0.9` —— Emscripten 自带 sysroot 和它自己的 libc++ 模块面;`mcpp run` 用 `node` 把模块跑起来 | verified |
+| `wasm32-emscripten` | `emsdk@6.0.9` —— Emscripten 自带 sysroot 和它自己的 libc++ 模块面;`mcpp run` 用载荷声明的 `node`(`xim:node`)把模块跑起来,不取 PATH 上的 | verified |
 | `x86_64-linux-android` | `android-ndk@30.0.16248370` —— bionic 来自 NDK,一个载荷服务两个 ABI;在 API 24 的 x86_64 模拟器镜像上跑过 | verified |
 | `aarch64-linux-android` | 同一个载荷、同样的构建;在 qemu-user 上、配系统镜像自带的 bionic 跑过 —— 这是平台模拟器从 x86_64 宿主做不到的 | verified |
 | `aarch64-ios-sim` | llvm 22 加上机器自己的 iPhoneSimulator SDK,mcpp 定位而不安装它;经 `simctl-run` 在模拟器上跑过 ³ | verified |

--- a/docs/20-toolchains.md
+++ b/docs/20-toolchains.md
@@ -587,10 +587,19 @@ the NDK itself declares in `meta/platforms.json`.
 
 ### Running what they produce
 
-Neither the emulator nor a device is part of the toolchain axis. `mcpp run`
-executes a wasm module directly, because Emscripten's output is a program
-`node` can run. For a target whose artifact runs elsewhere, the `runner` key is
-an argv prefix and the session belongs to a package rather than to the engine:
+Neither the emulator nor a device is part of the toolchain axis. A wasm module
+needs an interpreter rather than an emulator, and the payload names it:
+`xim:emsdk` writes `.mcpp-toolchain.json` beside itself, and its `runner` key is
+the `node` of the `xim:node` payload it depends on. `mcpp run` and `mcpp test`
+use that program when neither the project nor a dependency declares a runner,
+so no `node` on PATH is involved. A payload's runner is one program with the
+artefact path appended; it is either relative to the payload or absolute inside
+the package store that holds the payload, and a path outside that store is
+ignored. A payload installed before its recipe wrote the key has no descriptor,
+and its artefact runs through its own `#!/usr/bin/env node` line as before.
+
+For a target whose artifact runs elsewhere, the `runner` key is an argv prefix
+and the session belongs to a package rather than to the engine:
 
 ```toml
 [target.x86_64-linux-android]

--- a/docs/zh/20-toolchains.md
+++ b/docs/zh/20-toolchains.md
@@ -535,9 +535,15 @@ macos_deployment_target = "14.0" # Apple
 
 ### 产物的运行方式
 
-模拟器和真机都不属于工具链这根轴。`mcpp run` 直接执行一个 wasm 模块,因为
-Emscripten 的产物就是一个 `node` 能跑的程序。对于产物在别处运行的目标,`runner`
-键是一个 argv 前缀,而那个会话属于一个**包**而不属于引擎:
+模拟器和真机都不属于工具链这根轴。wasm 模块需要的是解释器而不是模拟器,由载荷说出它:
+`xim:emsdk` 在自身旁边写出 `.mcpp-toolchain.json`,其中的 `runner` 键就是它所依赖的
+`xim:node` 载荷里的 `node`。项目与依赖都没有声明 runner 时,`mcpp run` 与 `mcpp test`
+使用这个程序,因此不涉及 PATH 上的 `node`。载荷的 runner 是一个程序,产物路径追加在后;
+它或是载荷内的相对路径,或是持有该载荷的包存储之内的绝对路径,存储之外的路径一律忽略。
+在配方写出这个键之前安装的载荷没有描述文件,其产物仍按自身的 `#!/usr/bin/env node`
+一行运行,与之前相同。
+
+对于产物在别处运行的目标,`runner` 键是一个 argv 前缀,而那个会话属于一个**包**而不属于引擎:
 
 ```toml
 [target.x86_64-linux-android]

--- a/examples/13-platform-targets/README.md
+++ b/examples/13-platform-targets/README.md
@@ -23,6 +23,11 @@ bin/platform-targets.wasm  447183 bytes   the module
 node bin/platform-targets   ->  1-2-3
 ```
 
+运行用的 `node` 取自 `xim:emsdk` 声明的依赖 `xim:node`,而不是 PATH 上的某一个。载荷在
+`.mcpp-toolchain.json` 里用 `runner` 写出它,项目与依赖图都没有声明 runner 时 mcpp 使用
+它。这需要 mcpp 2026.9.12.1,以及在配方更新之后安装的 emsdk 载荷;更早安装的载荷没有
+描述文件,仍按产物首行的 `#!/usr/bin/env node` 取 PATH 上的 `node`。
+
 `mcpp run` 会用 `node` 跑它，所以不需要额外的一步。工程侧**一个新词汇都不需要**：
 `wasm32-emscripten` 这一行自己命名了它的载荷（`emsdk@6.0.9`），载荷自带 sysroot，
 而 Emscripten 自己就发布一份 libc++ 的模块面。
@@ -175,7 +180,7 @@ error: target aarch64-ios needs the iphoneos SDK, which this machine does not pr
 
 | target | tier | pin | 运行过？ |
 |---|---|---|---|
-| `wasm32-emscripten` | verified | `emsdk@6.0.9` | 是，`node` |
+| `wasm32-emscripten` | verified | `emsdk@6.0.9` | 是，载荷声明的 `node` |
 | `x86_64-linux-android` | verified | `android-ndk@30.0.16248370` | 是，平台模拟器 |
 | `aarch64-linux-android` | verified | `android-ndk@30.0.16248370` | 是，`qemu-aarch64-static` + 从镜像取出的 bionic |
 | `aarch64-ios` | preview | `llvm@22.1.8` | 否 —— 真机需要开发者自己的签名 |

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mcpp"
-version = "2026.9.11.4"
+version = "2026.9.12.1"
 description = "Modern C++ build & package management tool"
 license     = "Apache-2.0"
 authors     = ["mcpp-community"]

--- a/modules/versioning/src/version.cppm
+++ b/modules/versioning/src/version.cppm
@@ -31,6 +31,6 @@ import std;
 
 export namespace mcpp {
 
-inline constexpr std::string_view MCPP_VERSION = "2026.9.11.4";
+inline constexpr std::string_view MCPP_VERSION = "2026.9.12.1";
 
 } // namespace mcpp

--- a/src/build/execute.cppm
+++ b/src/build/execute.cppm
@@ -18,6 +18,7 @@ import mcpp.build.plan;
 import mcpp.toolchain.triple;
 import mcpp.freestanding.runner;
 import mcpp.build.runner_lookup;    // #544: where the runner's program is
+import mcpp.toolchain.registry;     // a payload's own runner (PayloadDescriptor::runner)
 import mcpp.build.directives;      // the device-slot table: run / flash / monitor / debug
 import mcpp.freestanding.linkline;
 import mcpp.build.graph_shape;    // #407: which mode wrote this build.ninja
@@ -565,6 +566,7 @@ struct RunnerChoice {
     bool fromManifest = false;          // the consumer overrode a dependency's
     bool ignored = false;               // --no-runner dropped a declared template
     bool longLived = false;             // declared by the package; no natural end
+    bool fromPayload = false;           // the toolchain payload's runner, nothing declared
     // The spelling that names this target in the manifest: the canonical form,
     // which is also the output directory's name and the key every
     // `[target.<triple>]` reader resolves. Every diagnostic below prints this
@@ -632,6 +634,22 @@ RunnerChoice choose_device_action(const BuildContext& ctx,
                 std::string(which));
             c.tmpl = entry->namedRunners.at(std::string(which));
         }
+    }
+    // AND THE TOOLCHAIN'S OWN ANSWER, WHEN THE PROJECT AND ITS GRAPH GAVE NONE.
+    //
+    // The third source and the last. A project's `[target.<triple>] runner`
+    // and a package's `mcpp::runner(...)` both outrank it, because they are
+    // statements about THIS program; the payload's is a statement about
+    // everything its compiler produces. Measured 2026-09-12 in a sandbox with
+    // no `node` on PATH: an Emscripten artefact built correctly and then
+    // stopped at `#!/usr/bin/env node`, while the node the payload had
+    // declared sat in its store. See `PayloadDescriptor::runner`.
+    //
+    // The run slot only. `flash`, `monitor` and `debug` name actions a board
+    // package owns, and a compiler has no opinion about them.
+    if (isDefault && c.tmpl.empty()) {
+        c.tmpl = mcpp::toolchain::payload_default_runner(ctx.tc.binaryPath);
+        c.fromPayload = !c.tmpl.empty();
     }
     // `--no-runner` is the operator on THIS host stating a host fact the
     // manifest cannot carry: the triple is native here. On a freestanding

--- a/src/toolchain/registry.cppm
+++ b/src/toolchain/registry.cppm
@@ -216,10 +216,24 @@ payload_frontend(const std::filesystem::path& payloadRoot,
 //       "std_module_defines": ["__BIONIC_CTYPE_INLINE="]
 //     }
 //
-// It is NOT a general flag channel. Three keys, each answering a question this
+// It is NOT a general flag channel. Four keys, each answering a question this
 // engine already asks; a payload that could inject arbitrary flags would be a
 // package changing a build it does not own, and `[build]` in a manifest is the
 // project's to write.
+//
+// THE FOURTH, `runner`, ARRIVED WITH THE FIRST PAYLOAD WHOSE ARTEFACTS NEED AN
+// INTERPRETER. An Emscripten link produces a JavaScript launcher whose first
+// line is `#!/usr/bin/env node`, so an artefact run with nothing declared asked
+// the machine's PATH for a program the ecosystem had already installed:
+// `xim:emsdk` declares `xim:node` and writes that payload's `bin/node` into its
+// own `.emscripten`. Measured 2026-09-12 in a sandbox with no `node` on PATH:
+//
+//     mcpp run --target wasm32-emscripten
+//       Finished dev [unoptimized + debuginfo] in 0.84s
+//       /usr/bin/env: 'node': No such file or directory
+//
+// The build was correct and the run depended on the host. The payload knows
+// which program runs what its compiler produces, so it says so.
 struct PayloadDescriptor {
     int                      schema = 0;
     // Relative to the payload root, already host-resolved by the recipe. The
@@ -233,6 +247,24 @@ struct PayloadDescriptor {
     // channel from the compile flags, and they enter the build fingerprint
     // because they change what the module compiles to.
     std::vector<std::string> stdModuleDefines;
+    // The program that runs what this toolchain produces, used when neither
+    // the project nor the dependency graph declares a runner. ONE PROGRAM AND
+    // NO ARGUMENTS -- the artefact path is appended -- so it cannot carry
+    // flags.
+    //
+    // Either relative to the payload root, under the rules `frontend` obeys,
+    // or absolute. The absolute form exists because the program is usually a
+    // DEPENDENCY's: emsdk's runner is `xim:node`'s `bin/node`, the path its
+    // recipe already writes into `.emscripten`. An absolute runner is honoured
+    // only inside the package store that holds this payload, which is decided
+    // where it is used (`payload_default_runner`), because where a store lives
+    // is a property of the machine and not of this file.
+    std::string              runner;
+    // The directory the descriptor was read from. Not a key: filled by the
+    // reader, so that a relative `runner` resolves against the payload it was
+    // written for, including when the descriptor was found by walking up from
+    // a compiler.
+    std::filesystem::path    root;
 };
 
 // The descriptor's file name, so a message and a test name the same string.
@@ -266,6 +298,18 @@ read_payload_descriptor(const std::filesystem::path& payloadRoot);
 // reach a descriptor belonging to a directory that is not its payload.
 std::expected<std::optional<PayloadDescriptor>, std::string>
 payload_descriptor_for_compiler(const std::filesystem::path& compilerPath);
+
+// The runner a toolchain payload supplies for its own artefacts, as an argv
+// prefix ready for `runner_lookup::locate`: empty when the payload ships no
+// descriptor, names no runner, names one outside its store, or describes
+// itself malformedly.
+//
+// MALFORMED IS READ AS ABSENCE HERE ONLY, for the reason
+// `min_platform_version` gives: a payload-provided compiler reached the build
+// through `payload_frontend`, which refuses a malformed descriptor by name
+// before anything is run.
+std::vector<std::string>
+payload_default_runner(const std::filesystem::path& compilerPath);
 
 // The DIRECTORY `payload_frontend` searched, for a message that has to name it.
 //
@@ -838,6 +882,51 @@ std::filesystem::path toolchain_frontend(const std::filesystem::path& binDir,
     return {};
 }
 
+namespace {
+// ONE RULE FOR A PATH A DESCRIPTOR NAMES, shared by every key that names one,
+// so that the second key cannot be the one that forgot a case. Checked on the
+// string, for the reason `frontend`'s comment below gives.
+//
+// `rootedOk` admits the absolute spellings `/...` and `X:/...`, which only
+// `runner` accepts. Every other rule applies to what follows the root.
+std::optional<std::string> descriptor_path_problem(std::string_view key,
+                                                   std::string_view v,
+                                                   bool rootedOk) {
+    if (v.find('\\') != std::string_view::npos)
+        return std::format("\"{}\" contains a backslash; the separator "
+                           "is `/` on every host", key);
+    std::string_view rest = v;
+    if (rootedOk) {
+        if (v.front() == '/')
+            rest = v.substr(1);
+        else if (v.size() > 2 && v[1] == ':' && v[2] == '/')
+            rest = v.substr(3);
+    } else if (v.front() == '/') {
+        return std::format("\"{}\" is absolute; it is relative to the "
+                           "payload root", key);
+    }
+    const bool rooted = rest.data() != v.data();
+    if (rest.find(':') != std::string_view::npos)
+        return rooted
+            ? std::format("\"{}\" names a drive or a scheme after its root", key)
+            : std::format("\"{}\" names a drive or a scheme; it is a "
+                          "path relative to the payload root", key);
+    for (std::size_t i = 0, n = 0; i <= rest.size(); ++i) {
+        if (i != rest.size() && rest[i] != '/') { ++n; continue; }
+        const auto part = rest.substr(i - n, n);
+        n = 0;
+        if (part.empty())
+            return std::format("\"{}\" has an empty path component", key);
+        if (part == "." || part == "..")
+            return rooted
+                ? std::format("\"{}\" has a `.` or `..` component; an "
+                              "absolute path is written in its normal form", key)
+                : std::format("\"{}\" leaves the payload root", key);
+    }
+    return std::nullopt;
+}
+} // namespace
+
 std::expected<std::optional<PayloadDescriptor>, std::string>
 read_payload_descriptor(const std::filesystem::path& payloadRoot) {
     std::error_code ec;
@@ -901,24 +990,9 @@ read_payload_descriptor(const std::filesystem::path& payloadRoot) {
         // `/`-separated, plain components. Asserting that positively is
         // host-independent by construction; asking a path type whether it is
         // absolute is asking a question whose meaning the host supplies.
-        if (d.frontend.find('\\') != std::string::npos)
-            return refuse("\"frontend\" contains a backslash; the separator "
-                          "is `/` on every host");
-        if (d.frontend.front() == '/')
-            return refuse("\"frontend\" is absolute; it is relative to the "
-                          "payload root");
-        if (d.frontend.find(':') != std::string::npos)
-            return refuse("\"frontend\" names a drive or a scheme; it is a "
-                          "path relative to the payload root");
-        for (std::size_t i = 0, n = 0; i <= d.frontend.size(); ++i) {
-            if (i != d.frontend.size() && d.frontend[i] != '/') { ++n; continue; }
-            const auto part = d.frontend.substr(i - n, n);
-            n = 0;
-            if (part.empty())
-                return refuse("\"frontend\" has an empty path component");
-            if (part == "." || part == "..")
-                return refuse("\"frontend\" leaves the payload root");
-        }
+        if (auto problem = descriptor_path_problem("frontend", d.frontend,
+                                                   /*rootedOk=*/false))
+            return refuse(*problem);
     }
 
     if (j.contains("platform_floor")) {
@@ -964,6 +1038,17 @@ read_payload_descriptor(const std::filesystem::path& payloadRoot) {
             d.stdModuleDefines.push_back(std::move(def));
         }
     }
+    if (j.contains("runner")) {
+        if (!j["runner"].is_string())
+            return refuse("\"runner\" is not a string; it names one program, "
+                          "and the artefact path is appended to it");
+        d.runner = j["runner"].get<std::string>();
+        if (d.runner.empty()) return refuse("\"runner\" is empty");
+        if (auto problem = descriptor_path_problem("runner", d.runner,
+                                                   /*rootedOk=*/true))
+            return refuse(*problem);
+    }
+    d.root = payloadRoot;
     return d;
 }
 
@@ -982,6 +1067,36 @@ payload_descriptor_for_compiler(const std::filesystem::path& compilerPath) {
             return read_payload_descriptor(dir);
     }
     return std::nullopt;
+}
+
+std::vector<std::string>
+payload_default_runner(const std::filesystem::path& compilerPath) {
+    auto desc = payload_descriptor_for_compiler(compilerPath);
+    if (!desc || !*desc || (*desc)->runner.empty()) return {};
+    const auto& d = **desc;
+    const std::string_view r = d.runner;
+    const bool absolute = r.front() == '/'
+                       || (r.size() > 2 && r[1] == ':' && r[2] == '/');
+    if (!absolute) return { (d.root / d.runner).string() };
+
+    // AN ABSOLUTE RUNNER IS HONOURED ONLY INSIDE THE STORE THAT HOLDS THIS
+    // PAYLOAD. The layout is `<store>/<package>/<version>`, so the store is
+    // the root's grandparent, and a dependency's program lives beside it.
+    //
+    // Compared on canonical paths, because a store reached through a symbolic
+    // link is still that store; and IGNORED rather than refused when it is
+    // outside, because where a store lives is a property of this machine and
+    // not a defect in the file. What the rule removes is the one case that
+    // matters: a payload choosing a host interpreter.
+    std::error_code rootEc, runnerEc;
+    const auto store = std::filesystem::weakly_canonical(d.root, rootEc)
+                           .parent_path().parent_path();
+    const auto program = std::filesystem::weakly_canonical(
+        std::filesystem::path(d.runner), runnerEc);
+    if (rootEc || runnerEc || store.empty()) return {};
+    const auto rel = program.lexically_relative(store);
+    if (rel.empty() || rel == "." || *rel.begin() == "..") return {};
+    return { program.string() };
 }
 
 std::filesystem::path payload_frontend_dir(const std::filesystem::path& payloadRoot,

--- a/tests/unit/test_toolchain_descriptor.cpp
+++ b/tests/unit/test_toolchain_descriptor.cpp
@@ -262,3 +262,126 @@ TEST(PayloadDescriptor, FoundFromTheCompilerAndTheWalkIsBounded) {
         << "an unbounded walk adopts a descriptor from a directory that is "
            "not this payload";
 }
+
+// ─── The fourth key: the program that runs what the payload produces ────────
+//
+// An Emscripten artefact is a JavaScript launcher that begins
+// `#!/usr/bin/env node`. With no runner of the payload's own, an artefact run
+// with nothing declared asked the machine's PATH for node, and a sandbox with
+// none on PATH stopped there while the build was correct.
+namespace {
+// `<store>/<package>/<version>`, which is the layout the store rule reads.
+struct FakeStore {
+    std::filesystem::path store;
+    explicit FakeStore(std::string_view name) {
+        store = std::filesystem::temp_directory_path()
+              / std::format("mcpp-store-{}-{}", name,
+                            std::chrono::steady_clock::now()
+                                .time_since_epoch().count());
+        std::filesystem::create_directories(store);
+    }
+    ~FakeStore() { std::error_code ec; std::filesystem::remove_all(store, ec); }
+    FakeStore(const FakeStore&) = delete;
+    FakeStore& operator=(const FakeStore&) = delete;
+
+    std::filesystem::path payload(std::string_view pkg, std::string_view ver) const {
+        auto p = store / pkg / ver;
+        std::filesystem::create_directories(p);
+        return p;
+    }
+    static std::filesystem::path file(const std::filesystem::path& p) {
+        std::filesystem::create_directories(p.parent_path());
+        std::ofstream(p) << "#!/bin/sh\n";
+        return p;
+    }
+    static void describe(const std::filesystem::path& root, std::string_view json) {
+        std::ofstream(root / ".mcpp-toolchain.json") << json;
+    }
+};
+} // namespace
+
+TEST(PayloadDescriptor, TheRunnerIsCarriedThroughWithTheRootItWasReadFrom) {
+    FakePayload fp{"runner"};
+    fp.write_descriptor(R"({"schema": 1, "runner": "bin/node"})");
+    auto d = read_payload_descriptor(fp.root);
+    ASSERT_TRUE(d.has_value()) << d.error();
+    ASSERT_TRUE(d->has_value());
+    EXPECT_EQ((*d)->runner, "bin/node");
+    EXPECT_EQ((*d)->root, fp.root);
+
+    // Optional like the other three: a payload whose artefacts run natively
+    // has no runner to name.
+    fp.write_descriptor(R"({"schema": 1})");
+    auto bare = read_payload_descriptor(fp.root);
+    ASSERT_TRUE(bare.has_value()) << bare.error();
+    ASSERT_TRUE(bare->has_value());
+    EXPECT_TRUE((*bare)->runner.empty());
+}
+
+// THE SHAPE emsdk HAS: the compiler two levels below the root, and the runner
+// a DEPENDENCY's program named by its absolute path in the same store.
+TEST(PayloadDescriptor, ARunnerInTheSameStoreIsTheDefaultForItsCompiler) {
+    FakeStore fs{"same"};
+    auto emsdk = fs.payload("xim-x-emsdk", "6.0.9");
+    auto compiler = FakeStore::file(emsdk / "emscripten" / "em++");
+    auto node = FakeStore::file(fs.payload("xim-x-node", "26.7.0") / "bin" / "node");
+    FakeStore::describe(emsdk, std::format(
+        R"({{"schema": 1, "frontend": "emscripten/em++", "runner": "{}"}})",
+        node.generic_string()));
+
+    auto argv = payload_default_runner(compiler);
+    ASSERT_EQ(argv.size(), 1u);
+    EXPECT_EQ(std::filesystem::path(argv[0]), std::filesystem::weakly_canonical(node));
+
+    // The relative form resolves against the root the descriptor came from.
+    FakeStore::describe(emsdk, R"({"schema": 1, "runner": "bin/node"})");
+    auto rel = payload_default_runner(compiler);
+    ASSERT_EQ(rel.size(), 1u);
+    EXPECT_EQ(std::filesystem::path(rel[0]), emsdk / "bin/node");
+}
+
+// WHAT THE STORE RULE REMOVES: a payload choosing a host interpreter. Ignored
+// rather than refused, so a machine whose store is elsewhere does not lose its
+// build over a run-time default.
+TEST(PayloadDescriptor, ARunnerOutsideTheStoreIsNotHonoured) {
+    FakeStore fs{"outside"};
+    auto emsdk = fs.payload("xim-x-emsdk", "6.0.9");
+    auto compiler = FakeStore::file(emsdk / "emscripten" / "em++");
+    FakeStore::describe(emsdk, R"({"schema": 1, "runner": "/usr/bin/node"})");
+
+    auto d = read_payload_descriptor(emsdk);
+    ASSERT_TRUE(d.has_value()) << "an absolute runner is well formed: " << d.error();
+    EXPECT_TRUE(payload_default_runner(compiler).empty())
+        << "a runner outside the payload's store was honoured";
+}
+
+TEST(PayloadDescriptor, NoDescriptorOrNoRunnerMeansNoDefault) {
+    FakeStore fs{"none"};
+    auto llvm = fs.payload("xim-x-llvm", "22.1.8");
+    auto compiler = FakeStore::file(llvm / "bin" / "clang++");
+    EXPECT_TRUE(payload_default_runner(compiler).empty());
+    FakeStore::describe(llvm, R"({"schema": 1, "platform_floor": "21"})");
+    EXPECT_TRUE(payload_default_runner(compiler).empty());
+    // And a malformed descriptor is absence here; the build refused it first.
+    FakeStore::describe(llvm, R"({"schema": 1, "runner": 7})");
+    EXPECT_TRUE(payload_default_runner(compiler).empty());
+}
+
+TEST(PayloadDescriptor, AMalformedRunnerIsRefusedByNameAndByKey) {
+    FakePayload fp{"badrunner"};
+    for (std::string_view json : {
+             std::string_view(R"({"schema": 1, "runner": 7})"),
+             std::string_view(R"({"schema": 1, "runner": ["node", "--flag"]})"),
+             std::string_view(R"({"schema": 1, "runner": ""})"),
+             std::string_view(R"({"schema": 1, "runner": "../node"})"),
+             std::string_view(R"({"schema": 1, "runner": "/store/../node"})"),
+             std::string_view(R"({"schema": 1, "runner": "bin\\node"})"),
+             std::string_view(R"({"schema": 1, "runner": "bin//node"})"),
+         }) {
+        fp.write_descriptor(json);
+        auto d = read_payload_descriptor(fp.root);
+        ASSERT_FALSE(d.has_value()) << "accepted: " << json;
+        EXPECT_NE(d.error().find("\"runner\""), std::string::npos) << d.error();
+        EXPECT_NE(d.error().find(".mcpp-toolchain.json"), std::string::npos) << d.error();
+    }
+}


### PR DESCRIPTION
Carries version **2026.9.12.1**. Design record: `.agents/docs/2026-09-12-a-verified-web-run-that-asked-the-host-for-node.md`.

## What was measured

The sandbox verification of the published 2026.9.11.4 held on 26 of 27 checks in an `xlings subos use <name> --sandbox` environment, which has no `node` on PATH. The one that did not was the Web run: `mcpp build --target wasm32-emscripten` succeeded, and `mcpp run` stopped at

```
/usr/bin/env: 'node': No such file or directory
```

An Emscripten link produces a JavaScript launcher whose first line is `#!/usr/bin/env node`. With nothing declared, mcpp executes the artefact, so the interpreter came from the PATH mcpp inherited. Meanwhile the `node` that `xim:emsdk` declares, and writes into its own `.emscripten`, sat in the store. The development host has `node` on PATH, which is why no earlier measurement could see the dependency.

## The change

The payload names the program that runs what it produces: `.mcpp-toolchain.json` gains a fourth key, `runner`.

- **One program, no arguments.** The artefact path is appended, so the key cannot carry flags.
- **Relative or absolute.** A relative runner obeys the `frontend` rules. An absolute runner is honoured only inside the package store that holds the payload, compared on canonical paths, and a runner outside the store is ignored, so a payload cannot choose a host interpreter.
- **Malformed values are refused by name.** The path rules are now one helper shared by `frontend` and `runner`, and the `frontend` messages are unchanged.
- **Last in precedence, run slot only.** `[target.<triple>] runner` and a dependency's `mcpp::runner(...)` outrank it, and `--no-runner` still executes the artefact directly.

`xim:emsdk` writes the key: openxlings/xim-pkgindex#823, merged and published (index artifact `971571a`). An engine that predates the key ignores it. A payload installed before the recipe change has no descriptor and runs as before.

## Verification

- **Unit:** five new descriptor tests. With the store rule removed, `ARunnerOutsideTheStoreIsNotHonoured` fails.
- **Sandbox, no `node` on PATH, a musl-static build of this tree:**
  - with a descriptor in the sandbox's emsdk payload, the run prints `1-2-3`;
  - with the descriptor removed, it fails at `/usr/bin/env: 'node'` again.
- **CI:** `scan (linux-x86_64)` runs a Web program with a fresh `MCPP_HOME`, so the payload is the one the index publishes rather than a cached one. A decoy `node` sits first on PATH and exits 97 with a marker. The step fails if the payload has no descriptor, if the decoy ran, or if `1-2-3` is not a line of the output.

## Docs

`docs/20-toolchains.md` and its Chinese copy state where the interpreter comes from. Both READMEs and `examples/13-platform-targets` no longer imply a `node` from PATH. The CHANGELOG has the 2026.9.12.1 entry.
